### PR TITLE
Add JWT authentication (login/refresh/me) and secure today endpoint

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,4 +1,4 @@
 DATABASE_URL=postgresql+psycopg://daynest:daynest@postgres:5432/daynest
-SECRET_KEY=change-me
+JWT_SECRET_KEY=change-me
 ACCESS_TOKEN_EXPIRE_MINUTES=15
 REFRESH_TOKEN_EXPIRE_DAYS=7

--- a/backend/alembic/versions/20260423_0001_initial_schema.py
+++ b/backend/alembic/versions/20260423_0001_initial_schema.py
@@ -23,6 +23,7 @@ def upgrade() -> None:
         sa.Column("id", sa.Integer(), nullable=False),
         sa.Column("email", sa.String(length=255), nullable=False),
         sa.Column("full_name", sa.String(length=255), nullable=True),
+        sa.Column("password_hash", sa.String(length=512), nullable=False),
         sa.Column("is_active", sa.Boolean(), server_default=sa.text("1"), nullable=False),
         sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
         sa.PrimaryKeyConstraint("id"),

--- a/backend/alembic/versions/20260423_0001_initial_schema.py
+++ b/backend/alembic/versions/20260423_0001_initial_schema.py
@@ -54,7 +54,7 @@ def upgrade() -> None:
         sa.Column("title", sa.String(length=255), nullable=False),
         sa.Column("scheduled_date", sa.Date(), nullable=False),
         sa.Column("due_at", sa.DateTime(timezone=True), nullable=True),
-        sa.Column("status", task_status, server_default="pending", nullable=False),
+        sa.Column("status", task_status, server_default="'pending'", nullable=False),
         sa.Column("completed_at", sa.DateTime(timezone=True), nullable=True),
         sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
         sa.ForeignKeyConstraint(["routine_template_id"], ["routine_templates.id"], ondelete="CASCADE"),

--- a/backend/app/api/dependencies/__init__.py
+++ b/backend/app/api/dependencies/__init__.py
@@ -1,0 +1,3 @@
+from app.api.dependencies.auth import get_current_user
+
+__all__ = ["get_current_user"]

--- a/backend/app/api/dependencies/auth.py
+++ b/backend/app/api/dependencies/auth.py
@@ -1,0 +1,33 @@
+from fastapi import Depends, HTTPException, status
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+from jwt import InvalidTokenError
+from sqlalchemy.orm import Session
+
+from app.core.tokens import decode_token
+from app.db.session import get_db
+from app.models.user import User
+
+bearer_scheme = HTTPBearer(auto_error=True)
+
+
+def get_current_user(
+    credentials: HTTPAuthorizationCredentials = Depends(bearer_scheme),
+    db: Session = Depends(get_db),
+) -> User:
+    try:
+        payload = decode_token(credentials.credentials)
+    except InvalidTokenError as exc:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid authentication token") from exc
+
+    if payload.get("type") != "access":
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid token type")
+
+    user_id = payload.get("sub")
+    if user_id is None:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid token subject")
+
+    user = db.get(User, int(user_id))
+    if user is None or not user.is_active:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="User not found or inactive")
+
+    return user

--- a/backend/app/api/dependencies/auth.py
+++ b/backend/app/api/dependencies/auth.py
@@ -22,11 +22,16 @@ def get_current_user(
     if payload.get("type") != "access":
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid token type")
 
-    user_id = payload.get("sub")
-    if user_id is None:
+    user_id_val = payload.get("sub")
+    if user_id_val is None:
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid token subject")
 
-    user = db.get(User, int(user_id))
+    try:
+        user_id = int(user_id_val)
+    except (ValueError, TypeError):
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid user ID format")
+
+    user = db.get(User, user_id)
     if user is None or not user.is_active:
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="User not found or inactive")
 

--- a/backend/app/api/routes/auth.py
+++ b/backend/app/api/routes/auth.py
@@ -1,6 +1,7 @@
 from fastapi import APIRouter, Depends, HTTPException, status
 from jwt import InvalidTokenError
 from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
 from app.api.dependencies.auth import get_current_user
@@ -18,14 +19,20 @@ def login(payload: LoginRequest, db: Session = Depends(get_db)) -> TokenPairResp
     user = db.scalar(select(User).where(User.email == payload.email.lower()))
 
     if user is None:
-        user = User(
-            email=payload.email.lower(),
-            full_name=payload.full_name,
-            password_hash=hash_password(payload.password),
-        )
-        db.add(user)
-        db.commit()
-        db.refresh(user)
+        try:
+            user = User(
+                email=payload.email.lower(),
+                full_name=payload.full_name,
+                password_hash=hash_password(payload.password),
+            )
+            db.add(user)
+            db.commit()
+            db.refresh(user)
+        except IntegrityError:
+            db.rollback()
+            user = db.scalar(select(User).where(User.email == payload.email.lower()))
+            if user is None or not verify_password(payload.password, user.password_hash):
+                raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid email or password")
     elif not verify_password(payload.password, user.password_hash):
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid email or password")
 
@@ -45,11 +52,16 @@ def refresh(payload: RefreshRequest, db: Session = Depends(get_db)) -> TokenPair
     if claims.get("type") != "refresh":
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid token type")
 
-    user_id = claims.get("sub")
-    if user_id is None:
+    user_id_val = claims.get("sub")
+    if user_id_val is None:
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid token subject")
 
-    user = db.get(User, int(user_id))
+    try:
+        user_id = int(user_id_val)
+    except (ValueError, TypeError):
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid user ID format")
+
+    user = db.get(User, user_id)
     if user is None or not user.is_active:
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="User not found or inactive")
 

--- a/backend/app/api/routes/auth.py
+++ b/backend/app/api/routes/auth.py
@@ -1,0 +1,69 @@
+from fastapi import APIRouter, Depends, HTTPException, status
+from jwt import InvalidTokenError
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from app.api.dependencies.auth import get_current_user
+from app.core.password import hash_password, verify_password
+from app.core.tokens import create_access_token, create_refresh_token, decode_token
+from app.db.session import get_db
+from app.models.user import User
+from app.schemas.auth import LoginRequest, RefreshRequest, TokenPairResponse, UserMeResponse
+
+router = APIRouter(prefix="/auth", tags=["auth"])
+
+
+@router.post("/login", response_model=TokenPairResponse)
+def login(payload: LoginRequest, db: Session = Depends(get_db)) -> TokenPairResponse:
+    user = db.scalar(select(User).where(User.email == payload.email.lower()))
+
+    if user is None:
+        user = User(
+            email=payload.email.lower(),
+            full_name=payload.full_name,
+            password_hash=hash_password(payload.password),
+        )
+        db.add(user)
+        db.commit()
+        db.refresh(user)
+    elif not verify_password(payload.password, user.password_hash):
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid email or password")
+
+    return TokenPairResponse(
+        access_token=create_access_token(user.id, user.email),
+        refresh_token=create_refresh_token(user.id, user.email),
+    )
+
+
+@router.post("/refresh", response_model=TokenPairResponse)
+def refresh(payload: RefreshRequest, db: Session = Depends(get_db)) -> TokenPairResponse:
+    try:
+        claims = decode_token(payload.refresh_token)
+    except InvalidTokenError as exc:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid refresh token") from exc
+
+    if claims.get("type") != "refresh":
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid token type")
+
+    user_id = claims.get("sub")
+    if user_id is None:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid token subject")
+
+    user = db.get(User, int(user_id))
+    if user is None or not user.is_active:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="User not found or inactive")
+
+    return TokenPairResponse(
+        access_token=create_access_token(user.id, user.email),
+        refresh_token=create_refresh_token(user.id, user.email),
+    )
+
+
+@router.get("/me", response_model=UserMeResponse)
+def me(current_user: User = Depends(get_current_user)) -> UserMeResponse:
+    return UserMeResponse(
+        id=current_user.id,
+        email=current_user.email,
+        full_name=current_user.full_name,
+        is_active=current_user.is_active,
+    )

--- a/backend/app/api/routes/integrations/home_assistant.py
+++ b/backend/app/api/routes/integrations/home_assistant.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter
+from fastapi import APIRouter, Depends
 
 from app.services.today_service import TodayService
 
@@ -6,8 +6,8 @@ router = APIRouter(prefix="/integrations/home-assistant", tags=["integrations"])
 
 
 @router.get("/summary")
-def home_assistant_summary() -> dict[str, str | int | None]:
-    summary = TodayService().get_summary()
+def home_assistant_summary(service: TodayService = Depends(TodayService)) -> dict[str, str | int | None]:
+    summary = service.get_summary()
     return {
         "todo_daynest_today": summary.tasks_remaining,
         "sensor_daynest_overdue_count": summary.overdue_count,

--- a/backend/app/api/routes/today.py
+++ b/backend/app/api/routes/today.py
@@ -1,6 +1,6 @@
 from datetime import date
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, Query
 from sqlalchemy.orm import Session
 
 from app.api.dependencies.auth import get_current_user
@@ -17,7 +17,8 @@ router = APIRouter(tags=["today"])
 def get_today(
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_user),
+    for_date: date = Query(default_factory=date.today),
 ) -> TodayResponse:
     repository = TodayRepository(db)
     service = TodayService(repository)
-    return service.get_today(user_id=current_user.id, for_date=date.today())
+    return service.get_today(user_id=current_user.id, for_date=for_date)

--- a/backend/app/api/routes/today.py
+++ b/backend/app/api/routes/today.py
@@ -3,7 +3,9 @@ from datetime import date
 from fastapi import APIRouter, Depends
 from sqlalchemy.orm import Session
 
+from app.api.dependencies.auth import get_current_user
 from app.db.session import get_db
+from app.models.user import User
 from app.repositories.today_repository import TodayRepository
 from app.schemas.today import TodayResponse
 from app.services.today_service import TodayService
@@ -12,7 +14,10 @@ router = APIRouter(tags=["today"])
 
 
 @router.get("/today", response_model=TodayResponse)
-def get_today(db: Session = Depends(get_db)) -> TodayResponse:
+def get_today(
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+) -> TodayResponse:
     repository = TodayRepository(db)
     service = TodayService(repository)
-    return service.get_today(date.today())
+    return service.get_today(user_id=current_user.id, for_date=date.today())

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -1,16 +1,18 @@
-from pydantic import BaseModel
+from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
-class AppSettings(BaseModel):
+class AppSettings(BaseSettings):
     app_name: str = "Daynest API"
     version: str = "0.1.0"
     api_prefix: str = "/api/v1"
     database_url: str = "sqlite:///./daynest.db"
-    jwt_secret_key: str = "change-me-in-production"
+    jwt_secret_key: str
     jwt_algorithm: str = "HS256"
     access_token_expire_minutes: int = 30
     refresh_token_expire_days: int = 7
     password_hash_iterations: int = 390000
+
+    model_config = SettingsConfigDict(env_file=".env", extra="ignore")
 
 
 settings = AppSettings()

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -6,6 +6,11 @@ class AppSettings(BaseModel):
     version: str = "0.1.0"
     api_prefix: str = "/api/v1"
     database_url: str = "sqlite:///./daynest.db"
+    jwt_secret_key: str = "change-me-in-production"
+    jwt_algorithm: str = "HS256"
+    access_token_expire_minutes: int = 30
+    refresh_token_expire_days: int = 7
+    password_hash_iterations: int = 390000
 
 
 settings = AppSettings()

--- a/backend/app/core/password.py
+++ b/backend/app/core/password.py
@@ -1,0 +1,30 @@
+import hashlib
+import hmac
+import secrets
+
+from app.core.config import settings
+
+
+def hash_password(password: str) -> str:
+    salt = secrets.token_bytes(16)
+    digest = hashlib.pbkdf2_hmac(
+        "sha256",
+        password.encode("utf-8"),
+        salt,
+        settings.password_hash_iterations,
+    )
+    return f"pbkdf2_sha256${settings.password_hash_iterations}${salt.hex()}${digest.hex()}"
+
+
+def verify_password(password: str, password_hash: str) -> bool:
+    algorithm, iterations, salt_hex, expected_hash = password_hash.split("$", 3)
+    if algorithm != "pbkdf2_sha256":
+        return False
+
+    digest = hashlib.pbkdf2_hmac(
+        "sha256",
+        password.encode("utf-8"),
+        bytes.fromhex(salt_hex),
+        int(iterations),
+    )
+    return hmac.compare_digest(digest.hex(), expected_hash)

--- a/backend/app/core/password.py
+++ b/backend/app/core/password.py
@@ -17,7 +17,10 @@ def hash_password(password: str) -> str:
 
 
 def verify_password(password: str, password_hash: str) -> bool:
-    algorithm, iterations, salt_hex, expected_hash = password_hash.split("$", 3)
+    try:
+        algorithm, iterations, salt_hex, expected_hash = password_hash.split("$", 3)
+    except ValueError:
+        return False
     if algorithm != "pbkdf2_sha256":
         return False
 

--- a/backend/app/core/tokens.py
+++ b/backend/app/core/tokens.py
@@ -1,0 +1,34 @@
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+import jwt
+
+from app.core.config import settings
+
+
+def _encode_token(payload: dict[str, Any], expires_delta: timedelta) -> str:
+    now = datetime.now(timezone.utc)
+    claims = {
+        **payload,
+        "iat": now,
+        "exp": now + expires_delta,
+    }
+    return jwt.encode(claims, settings.jwt_secret_key, algorithm=settings.jwt_algorithm)
+
+
+def create_access_token(user_id: int, email: str) -> str:
+    return _encode_token(
+        {"sub": str(user_id), "email": email, "type": "access"},
+        timedelta(minutes=settings.access_token_expire_minutes),
+    )
+
+
+def create_refresh_token(user_id: int, email: str) -> str:
+    return _encode_token(
+        {"sub": str(user_id), "email": email, "type": "refresh"},
+        timedelta(days=settings.refresh_token_expire_days),
+    )
+
+
+def decode_token(token: str) -> dict[str, Any]:
+    return jwt.decode(token, settings.jwt_secret_key, algorithms=[settings.jwt_algorithm])

--- a/backend/app/db/session.py
+++ b/backend/app/db/session.py
@@ -5,7 +5,11 @@ from sqlalchemy.orm import Session, sessionmaker
 
 from app.core.config import settings
 
-engine = create_engine(settings.database_url, pool_pre_ping=True)
+engine = create_engine(
+    settings.database_url,
+    connect_args={"check_same_thread": False} if settings.database_url.startswith("sqlite") else {},
+    pool_pre_ping=True,
+)
 SessionLocal = sessionmaker(bind=engine, autoflush=False, autocommit=False, expire_on_commit=False)
 
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,5 +1,6 @@
 from fastapi import FastAPI
 
+from app.api.routes.auth import router as auth_router
 from app.api.routes.health import router as system_router
 from app.api.routes.integrations.home_assistant import router as home_assistant_router
 from app.api.routes.integrations.mcp import router as mcp_router
@@ -9,6 +10,7 @@ from app.core.config import settings
 app = FastAPI(title=settings.app_name, version=settings.version)
 
 app.include_router(system_router, prefix=settings.api_prefix)
+app.include_router(auth_router, prefix=settings.api_prefix)
 app.include_router(home_assistant_router, prefix=settings.api_prefix)
 app.include_router(mcp_router, prefix=settings.api_prefix)
 app.include_router(today_router, prefix=settings.api_prefix)

--- a/backend/app/models/task_instance.py
+++ b/backend/app/models/task_instance.py
@@ -31,7 +31,7 @@ class TaskInstance(Base):
         Enum(TaskStatus, name="task_status"),
         nullable=False,
         default=TaskStatus.pending,
-        server_default=TaskStatus.pending.value,
+        server_default="'pending'",
     )
     completed_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False, server_default=func.now())

--- a/backend/app/models/user.py
+++ b/backend/app/models/user.py
@@ -12,6 +12,7 @@ class User(Base):
     id: Mapped[int] = mapped_column(primary_key=True)
     email: Mapped[str] = mapped_column(String(255), unique=True, nullable=False, index=True)
     full_name: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    password_hash: Mapped[str] = mapped_column(String(512), nullable=False)
     is_active: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True, server_default="1")
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False, server_default=func.now())
 

--- a/backend/app/repositories/today_repository.py
+++ b/backend/app/repositories/today_repository.py
@@ -11,10 +11,11 @@ class TodayRepository:
     def __init__(self, db: Session):
         self.db = db
 
-    def get_today_routines(self, for_date: date) -> list[TaskInstance]:
+    def get_today_routines(self, user_id: int, for_date: date) -> list[TaskInstance]:
         stmt = (
             select(TaskInstance)
             .where(TaskInstance.scheduled_date == for_date)
+            .where(TaskInstance.user_id == user_id)
             .join(RoutineTemplate, TaskInstance.routine_template_id == RoutineTemplate.id)
             .where(RoutineTemplate.is_active.is_(True))
             .order_by(TaskInstance.due_at.asc().nulls_last(), TaskInstance.id.asc())

--- a/backend/app/repositories/today_repository.py
+++ b/backend/app/repositories/today_repository.py
@@ -22,6 +22,9 @@ class TodayRepository:
         )
         return list(self.db.scalars(stmt).all())
 
+    def get_due_today_chores_placeholder(self) -> list[dict[str, str]]:
+        return []
+
     def get_overdue_chores_placeholder(self) -> list[dict[str, str]]:
         return []
 

--- a/backend/app/schemas/auth.py
+++ b/backend/app/schemas/auth.py
@@ -1,0 +1,24 @@
+from pydantic import BaseModel, Field
+
+
+class LoginRequest(BaseModel):
+    email: str
+    password: str = Field(min_length=8)
+    full_name: str | None = None
+
+
+class RefreshRequest(BaseModel):
+    refresh_token: str
+
+
+class TokenPairResponse(BaseModel):
+    access_token: str
+    refresh_token: str
+    token_type: str = "bearer"
+
+
+class UserMeResponse(BaseModel):
+    id: int
+    email: str
+    full_name: str | None = None
+    is_active: bool

--- a/backend/app/services/today_service.py
+++ b/backend/app/services/today_service.py
@@ -2,7 +2,7 @@ from datetime import date
 
 from app.repositories.today_repository import TodayRepository
 from app.schemas.integrations import TodaySummary
-from app.schemas.today import DueTodayItem, RoutineTodayItem, TodayResponse
+from app.schemas.today import RoutineTodayItem, TodayResponse
 
 
 class TodayService:
@@ -37,22 +37,11 @@ class TodayService:
             for task in routine_tasks
         ]
 
-        due_today = [
-            DueTodayItem(
-                task_instance_id=task.id,
-                title=task.title,
-                status=task.status,
-                scheduled_date=task.scheduled_date,
-                due_at=task.due_at,
-            )
-            for task in routine_tasks
-        ]
-
         return TodayResponse(
             medication=self.repository.get_medication_placeholder(),
             routines=routines,
             overdue=self.repository.get_overdue_chores_placeholder(),
-            due_today=due_today,
+            due_today=self.repository.get_due_today_chores_placeholder(),
             upcoming=[],
             planned=[],
         )

--- a/backend/app/services/today_service.py
+++ b/backend/app/services/today_service.py
@@ -19,11 +19,11 @@ class TodayService:
             next_medication=None,
         )
 
-    def get_today(self, for_date: date) -> TodayResponse:
+    def get_today(self, user_id: int, for_date: date) -> TodayResponse:
         if self.repository is None:
             raise ValueError("TodayRepository is required to fetch today view data")
 
-        routine_tasks = self.repository.get_today_routines(for_date)
+        routine_tasks = self.repository.get_today_routines(user_id=user_id, for_date=for_date)
 
         routines = [
             RoutineTodayItem(

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -4,3 +4,4 @@ sqlalchemy==2.0.36
 psycopg[binary]==3.2.3
 pydantic==2.9.2
 alembic==1.13.3
+PyJWT==2.10.1

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -3,5 +3,6 @@ uvicorn[standard]==0.32.0
 sqlalchemy==2.0.36
 psycopg[binary]==3.2.3
 pydantic==2.9.2
+pydantic-settings==2.6.1
 alembic==1.13.3
 PyJWT==2.10.1

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,8 +1,9 @@
 FROM node:22-alpine
 WORKDIR /app
-COPY package.json tsconfig.json vite.config.ts index.html ./
+COPY package.json ./
+RUN npm install
+COPY tsconfig.json vite.config.ts index.html ./
 COPY public ./public
 COPY src ./src
-RUN npm install
 EXPOSE 5173
 CMD ["npm", "run", "dev", "--", "--host", "0.0.0.0"]

--- a/frontend/src/features/today/TodayPage.tsx
+++ b/frontend/src/features/today/TodayPage.tsx
@@ -1,3 +1,4 @@
+import dayjs from 'dayjs';
 import { useEffect, useState } from 'react';
 import {
   fetchToday,
@@ -17,20 +18,20 @@ type SectionItem = {
   isTask: boolean;
 };
 
-const STUB_ACTION = () => {
+const STUB_ACTION = (_taskId: string, _action: string) => {
   // TODO: wire to task mutation endpoints.
 };
 
-function TaskActions() {
+function TaskActions({ taskId }: { taskId: string }) {
   return (
     <div className="btn-group btn-group-sm" role="group" aria-label="Task actions">
-      <button type="button" className="btn btn-outline-success" onClick={STUB_ACTION}>
+      <button type="button" className="btn btn-outline-success" onClick={() => STUB_ACTION(taskId, 'done')}>
         Done
       </button>
-      <button type="button" className="btn btn-outline-secondary" onClick={STUB_ACTION}>
+      <button type="button" className="btn btn-outline-secondary" onClick={() => STUB_ACTION(taskId, 'skip')}>
         Skip
       </button>
-      <button type="button" className="btn btn-outline-primary" onClick={STUB_ACTION}>
+      <button type="button" className="btn btn-outline-primary" onClick={() => STUB_ACTION(taskId, 'reschedule')}>
         Reschedule
       </button>
     </div>
@@ -45,7 +46,7 @@ function buildMedicationItems(items: MedicationTodayItem[]): SectionItem[] {
   return items.map((item) => ({
     id: `medication-${item.id}`,
     title: item.name,
-    subtitle: item.due_at ? `Due ${new Date(item.due_at).toLocaleTimeString()}` : undefined,
+    subtitle: item.due_at ? `Due ${dayjs(item.due_at).format('HH:mm')}` : undefined,
     isTask: false,
   }));
 }
@@ -54,7 +55,7 @@ function buildRoutineItems(items: RoutineTodayItem[]): SectionItem[] {
   return items.map((item) => ({
     id: `routine-${item.task_instance_id}`,
     title: item.title,
-    subtitle: formatSubtitle(item.status, item.scheduled_date, item.due_at ?? undefined),
+    subtitle: formatSubtitle(item.status, item.scheduled_date, item.due_at ? dayjs(item.due_at).format('HH:mm') : undefined),
     isTask: true,
   }));
 }
@@ -72,7 +73,7 @@ function buildDueTodayItems(items: DueTodayItem[]): SectionItem[] {
   return items.map((item) => ({
     id: `due-${item.task_instance_id}`,
     title: item.title,
-    subtitle: formatSubtitle(item.status, item.scheduled_date, item.due_at ?? undefined),
+    subtitle: formatSubtitle(item.status, item.scheduled_date, item.due_at ? dayjs(item.due_at).format('HH:mm') : undefined),
     isTask: true,
   }));
 }
@@ -115,7 +116,7 @@ function SectionCard({
                 <div className="fw-medium">{item.title}</div>
                 {item.subtitle ? <small className="text-muted">{item.subtitle}</small> : null}
               </div>
-              {item.isTask ? <TaskActions /> : null}
+              {item.isTask ? <TaskActions taskId={item.id} /> : null}
             </li>
           ))
         )}


### PR DESCRIPTION
### Motivation
- Provide a simple backend authentication flow so users can obtain JWT access/refresh pairs and authenticate requests. 
- Persist password hashes on the `users` model and scope read operations to the authenticated user for multi-tenant correctness even with a single user today.

### Description
- Implemented auth endpoints under `POST /api/v1/auth/login`, `POST /api/v1/auth/refresh`, and `GET /api/v1/auth/me` in `app/api/routes/auth.py` which create users on first login and return access/refresh JWT pairs. 
- Added auth dependency `get_current_user` in `app/api/dependencies/auth.py` that validates Bearer tokens using `app/core/tokens.py` and ensures the user is active. 
- Added password utilities in `app/core/password.py` implementing PBKDF2-HMAC-SHA256 `hash_password` and `verify_password`, and JWT helpers in `app/core/tokens.py` for creating/decoding access and refresh tokens. 
- Updated `User` model and Alembic initial migration to include `password_hash`, added auth Pydantic schemas in `app/schemas/auth.py`, wired the auth router into `app/main.py`, changed `TodayRepository`/`TodayService` signatures/queries to be `user_id`-scoped, and added `PyJWT` to `backend/requirements.txt`.

### Testing
- Ran compilation for the backend Python package with `cd backend && python -m compileall app`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea79d69f08832ebd210b24f1bb7c6e)