### PR TITLE
Add authentication flow, secure token storage, and network auth interceptor

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -111,6 +111,7 @@ dependencies {
     implementation("com.squareup.retrofit2:converter-kotlinx-serialization:3.0.0")
     implementation("com.squareup.okhttp3:okhttp:5.3.2")
     implementation("com.squareup.okhttp3:logging-interceptor:5.3.2")
+    implementation("androidx.security:security-crypto:1.1.0")
 
     debugImplementation("androidx.compose.ui:ui-tooling")
     debugImplementation("androidx.compose.ui:ui-test-manifest")

--- a/android/app/src/main/java/com/daynest/android/app/DaynestApp.kt
+++ b/android/app/src/main/java/com/daynest/android/app/DaynestApp.kt
@@ -1,9 +1,13 @@
 package com.daynest.android.app
 
 import androidx.compose.runtime.Composable
+import androidx.navigation.NavGraph.Companion.findStartDestination
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
+import com.daynest.android.app.navigation.DaynestDestination
+import com.daynest.android.app.session.SessionGateRoute
+import com.daynest.android.feature.auth.AuthRoute
 import com.daynest.android.feature.home.HomeRoute
 import com.daynest.android.ui.theme.DaynestTheme
 
@@ -14,9 +18,35 @@ fun DaynestApp() {
 
         NavHost(
             navController = navController,
-            startDestination = "home",
+            startDestination = DaynestDestination.SessionGate,
         ) {
-            composable(route = "home") {
+            composable(route = DaynestDestination.SessionGate) {
+                SessionGateRoute(
+                    onGoAuth = {
+                        navController.navigate(DaynestDestination.Auth) {
+                            popUpTo(DaynestDestination.SessionGate) { inclusive = true }
+                        }
+                    },
+                    onGoHome = {
+                        navController.navigate(DaynestDestination.Home) {
+                            popUpTo(DaynestDestination.SessionGate) { inclusive = true }
+                        }
+                    },
+                )
+            }
+
+            composable(route = DaynestDestination.Auth) {
+                AuthRoute(
+                    onSignedIn = {
+                        navController.navigate(DaynestDestination.Home) {
+                            popUpTo(navController.graph.findStartDestination().id) { inclusive = true }
+                            launchSingleTop = true
+                        }
+                    },
+                )
+            }
+
+            composable(route = DaynestDestination.Home) {
                 HomeRoute()
             }
         }

--- a/android/app/src/main/java/com/daynest/android/app/navigation/DaynestDestination.kt
+++ b/android/app/src/main/java/com/daynest/android/app/navigation/DaynestDestination.kt
@@ -1,0 +1,7 @@
+package com.daynest.android.app.navigation
+
+object DaynestDestination {
+    const val SessionGate = "session_gate"
+    const val Auth = "auth"
+    const val Home = "home"
+}

--- a/android/app/src/main/java/com/daynest/android/app/session/SessionGateRoute.kt
+++ b/android/app/src/main/java/com/daynest/android/app/session/SessionGateRoute.kt
@@ -1,0 +1,39 @@
+package com.daynest.android.app.session
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+
+@Composable
+fun SessionGateRoute(
+    onGoAuth: () -> Unit,
+    onGoHome: () -> Unit,
+    viewModel: SessionGateViewModel = hiltViewModel(),
+) {
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+
+    LaunchedEffect(uiState) {
+        when (uiState) {
+            SessionGateUiState.GoAuth -> onGoAuth()
+            SessionGateUiState.GoHome -> onGoHome()
+            SessionGateUiState.Loading -> Unit
+        }
+    }
+
+    Box(
+        modifier = Modifier.fillMaxSize(),
+        contentAlignment = Alignment.Center,
+    ) {
+        if (uiState == SessionGateUiState.Loading) {
+            CircularProgressIndicator()
+        }
+    }
+}

--- a/android/app/src/main/java/com/daynest/android/app/session/SessionGateViewModel.kt
+++ b/android/app/src/main/java/com/daynest/android/app/session/SessionGateViewModel.kt
@@ -1,0 +1,40 @@
+package com.daynest.android.app.session
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.daynest.android.data.auth.AuthRepository
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+
+@HiltViewModel
+class SessionGateViewModel @Inject constructor(
+    private val authRepository: AuthRepository,
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow<SessionGateUiState>(SessionGateUiState.Loading)
+    val uiState: StateFlow<SessionGateUiState> = _uiState.asStateFlow()
+
+    init {
+        decideRoute()
+    }
+
+    private fun decideRoute() {
+        viewModelScope.launch {
+            _uiState.value = if (authRepository.hasValidSession()) {
+                SessionGateUiState.GoHome
+            } else {
+                SessionGateUiState.GoAuth
+            }
+        }
+    }
+}
+
+sealed interface SessionGateUiState {
+    data object Loading : SessionGateUiState
+    data object GoHome : SessionGateUiState
+    data object GoAuth : SessionGateUiState
+}

--- a/android/app/src/main/java/com/daynest/android/core/di/NetworkDiModule.kt
+++ b/android/app/src/main/java/com/daynest/android/core/di/NetworkDiModule.kt
@@ -3,6 +3,8 @@ package com.daynest.android.core.di
 import com.daynest.android.BuildConfig
 import com.daynest.android.core.network.ApiConfig
 import com.daynest.android.core.network.JsonSerializer
+import com.daynest.android.core.storage.SecureTokenStorage
+import com.daynest.android.data.auth.AuthApi
 import com.daynest.android.data.today.TodayApi
 import dagger.Module
 import dagger.Provides
@@ -14,6 +16,7 @@ import okhttp3.OkHttpClient
 import okhttp3.logging.HttpLoggingInterceptor
 import retrofit2.Retrofit
 import retrofit2.converter.kotlinx.serialization.asConverterFactory
+import kotlinx.coroutines.runBlocking
 import javax.inject.Singleton
 
 @Module
@@ -26,7 +29,17 @@ object NetworkDiModule {
 
     @Provides
     @Singleton
-    fun provideOkHttpClient(): OkHttpClient = OkHttpClient.Builder()
+    fun provideOkHttpClient(
+        secureTokenStorage: SecureTokenStorage,
+    ): OkHttpClient = OkHttpClient.Builder()
+        .addInterceptor { chain ->
+            val requestBuilder = chain.request().newBuilder()
+            val token = runBlocking { secureTokenStorage.getToken() }
+            if (!token.isNullOrBlank()) {
+                requestBuilder.addHeader("Authorization", "Bearer $token")
+            }
+            chain.proceed(requestBuilder.build())
+        }
         .apply {
             if (BuildConfig.DEBUG) {
                 addInterceptor(HttpLoggingInterceptor().apply { level = HttpLoggingInterceptor.Level.BODY })
@@ -48,4 +61,8 @@ object NetworkDiModule {
     @Provides
     @Singleton
     fun provideTodayApi(retrofit: Retrofit): TodayApi = retrofit.create(TodayApi::class.java)
+
+    @Provides
+    @Singleton
+    fun provideAuthApi(retrofit: Retrofit): AuthApi = retrofit.create(AuthApi::class.java)
 }

--- a/android/app/src/main/java/com/daynest/android/core/di/StorageDiModule.kt
+++ b/android/app/src/main/java/com/daynest/android/core/di/StorageDiModule.kt
@@ -1,0 +1,46 @@
+package com.daynest.android.core.di
+
+import android.content.Context
+import android.content.SharedPreferences
+import androidx.security.crypto.EncryptedSharedPreferences
+import androidx.security.crypto.MasterKey
+import com.daynest.android.core.storage.EncryptedTokenStorage
+import com.daynest.android.core.storage.SecureTokenStorage
+import dagger.Binds
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+abstract class StorageDiModule {
+
+    @Binds
+    @Singleton
+    abstract fun bindSecureTokenStorage(
+        encryptedTokenStorage: EncryptedTokenStorage,
+    ): SecureTokenStorage
+
+    companion object {
+        @Provides
+        @Singleton
+        fun provideSecurePreferences(
+            @ApplicationContext context: Context,
+        ): SharedPreferences {
+            val masterKey = MasterKey.Builder(context)
+                .setKeyScheme(MasterKey.KeyScheme.AES256_GCM)
+                .build()
+
+            return EncryptedSharedPreferences.create(
+                context,
+                "daynest_secure_store",
+                masterKey,
+                EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
+                EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM,
+            )
+        }
+    }
+}

--- a/android/app/src/main/java/com/daynest/android/core/storage/EncryptedTokenStorage.kt
+++ b/android/app/src/main/java/com/daynest/android/core/storage/EncryptedTokenStorage.kt
@@ -1,0 +1,33 @@
+package com.daynest.android.core.storage
+
+import android.content.SharedPreferences
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+@Singleton
+class EncryptedTokenStorage @Inject constructor(
+    private val sharedPreferences: SharedPreferences,
+) : SecureTokenStorage {
+
+    override suspend fun getToken(): String? = withContext(Dispatchers.IO) {
+        sharedPreferences.getString(KEY_TOKEN, null)
+    }
+
+    override suspend fun saveToken(token: String) {
+        withContext(Dispatchers.IO) {
+            sharedPreferences.edit().putString(KEY_TOKEN, token).apply()
+        }
+    }
+
+    override suspend fun clearToken() {
+        withContext(Dispatchers.IO) {
+            sharedPreferences.edit().remove(KEY_TOKEN).apply()
+        }
+    }
+
+    private companion object {
+        const val KEY_TOKEN = "auth_token"
+    }
+}

--- a/android/app/src/main/java/com/daynest/android/core/storage/SecureTokenStorage.kt
+++ b/android/app/src/main/java/com/daynest/android/core/storage/SecureTokenStorage.kt
@@ -1,0 +1,7 @@
+package com.daynest.android.core.storage
+
+interface SecureTokenStorage {
+    suspend fun getToken(): String?
+    suspend fun saveToken(token: String)
+    suspend fun clearToken()
+}

--- a/android/app/src/main/java/com/daynest/android/data/auth/AuthApi.kt
+++ b/android/app/src/main/java/com/daynest/android/data/auth/AuthApi.kt
@@ -1,0 +1,27 @@
+package com.daynest.android.data.auth
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import retrofit2.http.Body
+import retrofit2.http.GET
+import retrofit2.http.POST
+
+interface AuthApi {
+    @POST("api/v1/auth/sign-in")
+    suspend fun signIn(@Body request: SignInRequestDto): AuthSessionDto
+
+    @GET("api/v1/auth/session")
+    suspend fun restoreSession(): AuthSessionDto
+}
+
+@Serializable
+data class SignInRequestDto(
+    val email: String,
+    val password: String,
+)
+
+@Serializable
+data class AuthSessionDto(
+    @SerialName("access_token")
+    val accessToken: String,
+)

--- a/android/app/src/main/java/com/daynest/android/data/auth/AuthRepository.kt
+++ b/android/app/src/main/java/com/daynest/android/data/auth/AuthRepository.kt
@@ -1,0 +1,41 @@
+package com.daynest.android.data.auth
+
+import com.daynest.android.core.storage.SecureTokenStorage
+import javax.inject.Inject
+import javax.inject.Singleton
+import retrofit2.HttpException
+
+@Singleton
+class AuthRepository @Inject constructor(
+    private val authApi: AuthApi,
+    private val secureTokenStorage: SecureTokenStorage,
+) {
+    suspend fun signIn(email: String, password: String): Boolean {
+        val session = authApi.signIn(
+            request = SignInRequestDto(
+                email = email,
+                password = password,
+            ),
+        )
+        secureTokenStorage.saveToken(session.accessToken)
+        return true
+    }
+
+    suspend fun hasValidSession(): Boolean {
+        val persistedToken = secureTokenStorage.getToken().orEmpty()
+        if (persistedToken.isBlank()) {
+            return false
+        }
+
+        return try {
+            val refreshed = authApi.restoreSession()
+            secureTokenStorage.saveToken(refreshed.accessToken)
+            true
+        } catch (exception: Exception) {
+            if (exception is HttpException && exception.code() == 401) {
+                secureTokenStorage.clearToken()
+            }
+            false
+        }
+    }
+}

--- a/android/app/src/main/java/com/daynest/android/feature/auth/AuthRoute.kt
+++ b/android/app/src/main/java/com/daynest/android/feature/auth/AuthRoute.kt
@@ -1,0 +1,107 @@
+package com.daynest.android.feature.auth
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.Button
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.input.PasswordVisualTransformation
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.daynest.android.R
+
+@Composable
+fun AuthRoute(
+    onSignedIn: () -> Unit,
+    viewModel: AuthViewModel = hiltViewModel(),
+) {
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+
+    LaunchedEffect(uiState.isSignedIn) {
+        if (uiState.isSignedIn) {
+            onSignedIn()
+        }
+    }
+
+    AuthScreen(
+        uiState = uiState,
+        onEvent = viewModel::onEvent,
+    )
+}
+
+@Composable
+internal fun AuthScreen(
+    uiState: AuthUiState,
+    onEvent: (AuthUiEvent) -> Unit,
+) {
+    Scaffold(modifier = Modifier.fillMaxSize()) { innerPadding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(innerPadding)
+                .padding(24.dp),
+            verticalArrangement = Arrangement.Center,
+            horizontalAlignment = Alignment.CenterHorizontally,
+        ) {
+            Text(
+                text = stringResource(R.string.auth_title),
+                style = MaterialTheme.typography.headlineMedium,
+            )
+            OutlinedTextField(
+                value = uiState.email,
+                onValueChange = { onEvent(AuthUiEvent.EmailChanged(it)) },
+                modifier = Modifier.padding(top = 16.dp),
+                label = { Text(stringResource(id = R.string.auth_email_label)) },
+                enabled = !uiState.isSubmitting,
+                singleLine = true,
+            )
+            OutlinedTextField(
+                value = uiState.password,
+                onValueChange = { onEvent(AuthUiEvent.PasswordChanged(it)) },
+                modifier = Modifier.padding(top = 12.dp),
+                label = { Text(stringResource(id = R.string.auth_password_label)) },
+                visualTransformation = PasswordVisualTransformation(),
+                enabled = !uiState.isSubmitting,
+                singleLine = true,
+            )
+            if (uiState.error != null) {
+                Text(
+                    text = when (uiState.error) {
+                        AuthError.MissingCredentials -> stringResource(R.string.auth_error_missing_credentials)
+                        AuthError.SignInFailed -> stringResource(R.string.auth_error_sign_in_failed)
+                    },
+                    color = MaterialTheme.colorScheme.error,
+                    modifier = Modifier.padding(top = 12.dp),
+                )
+            }
+
+            Button(
+                onClick = { onEvent(AuthUiEvent.SignInClicked) },
+                enabled = !uiState.isSubmitting,
+                modifier = Modifier.padding(top = 20.dp),
+            ) {
+                if (uiState.isSubmitting) {
+                    CircularProgressIndicator(
+                        modifier = Modifier.size(24.dp),
+                        strokeWidth = 2.dp,
+                    )
+                } else {
+                    Text(text = stringResource(id = R.string.auth_sign_in_button))
+                }
+            }
+        }
+    }
+}

--- a/android/app/src/main/java/com/daynest/android/feature/auth/AuthViewModel.kt
+++ b/android/app/src/main/java/com/daynest/android/feature/auth/AuthViewModel.kt
@@ -1,0 +1,74 @@
+package com.daynest.android.feature.auth
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.daynest.android.data.auth.AuthRepository
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+
+@HiltViewModel
+class AuthViewModel @Inject constructor(
+    private val authRepository: AuthRepository,
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow(AuthUiState())
+    val uiState: StateFlow<AuthUiState> = _uiState.asStateFlow()
+
+    fun onEvent(event: AuthUiEvent) {
+        when (event) {
+            is AuthUiEvent.EmailChanged -> _uiState.update { it.copy(email = event.value, error = null) }
+            is AuthUiEvent.PasswordChanged -> _uiState.update { it.copy(password = event.value, error = null) }
+            AuthUiEvent.SignInClicked -> signIn()
+        }
+    }
+
+    private fun signIn() {
+        val current = _uiState.value
+        if (current.email.isBlank() || current.password.isBlank()) {
+            _uiState.update { it.copy(error = AuthError.MissingCredentials) }
+            return
+        }
+
+        viewModelScope.launch {
+            _uiState.update { it.copy(isSubmitting = true, error = null) }
+
+            val succeeded = try {
+                authRepository.signIn(current.email.trim(), current.password)
+            } catch (_: Exception) {
+                false
+            }
+
+            _uiState.update {
+                it.copy(
+                    isSubmitting = false,
+                    isSignedIn = succeeded,
+                    error = if (succeeded) null else AuthError.SignInFailed,
+                )
+            }
+        }
+    }
+}
+
+data class AuthUiState(
+    val email: String = "",
+    val password: String = "",
+    val isSubmitting: Boolean = false,
+    val isSignedIn: Boolean = false,
+    val error: AuthError? = null,
+)
+
+sealed interface AuthUiEvent {
+    data class EmailChanged(val value: String) : AuthUiEvent
+    data class PasswordChanged(val value: String) : AuthUiEvent
+    data object SignInClicked : AuthUiEvent
+}
+
+enum class AuthError {
+    MissingCredentials,
+    SignInFailed,
+}

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -6,6 +6,14 @@
     <string name="home_retry">Retry</string>
     <string name="home_error_generic">Unable to load today data.</string>
 
+    <string name="auth_title">Sign in to Daynest</string>
+    <string name="auth_email_label">Email</string>
+    <string name="auth_password_label">Password</string>
+    <string name="auth_sign_in_button">Sign in</string>
+    <string name="auth_error_missing_credentials">Enter both email and password.</string>
+    <string name="auth_error_sign_in_failed">Unable to sign in. Please try again.</string>
+
+
     <plurals name="home_items_remaining">
         <item quantity="one">You have %1$d item to handle today.</item>
         <item quantity="other">You have %1$d items to handle today.</item>


### PR DESCRIPTION
### Motivation
- Introduce a sign-in and session restoration flow so the app can gate users before showing the home screen.  
- Persist authentication tokens securely and attach them to outgoing API requests to support authenticated endpoints.  
- Centralize navigation destinations to make routing explicit and easier to manage.  
- Provide DI bindings for network and storage components so auth and other APIs can be injected via Hilt.  

### Description
- Added a new `DaynestDestination` object and updated `DaynestApp` to route via a new `SessionGate` destination that decides whether to go to `Auth` or `Home`.  
- Implemented `SessionGateRoute` and `SessionGateViewModel` which use `AuthRepository.hasValidSession()` to determine navigation.  
- Added authentication feature: `AuthRoute`, `AuthViewModel`, `AuthApi` DTOs, and `AuthRepository` to handle sign-in and session restore.  
- Added secure token storage via `SecureTokenStorage` interface, `EncryptedTokenStorage` implementation, and `StorageDiModule` using `EncryptedSharedPreferences`, and registered `security-crypto` in `build.gradle.kts`.  
- Updated `NetworkDiModule` to provide an OkHttp interceptor that reads the token from `SecureTokenStorage` and adds an `Authorization` header, and added `provideAuthApi` to the Retrofit bindings.  
- Added localized strings for the auth UI.  

### Testing
- Built the Android app with `./gradlew assembleDebug`, which completed successfully.  
- Ran unit tests with `./gradlew test`; no failing tests were reported (no new unit tests were added).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ecbe5935c0832ebb9d607814bc84e7)