### PR TITLE
feat(api): add typed HTTP client for integration endpoints with contract support

### DIFF
--- a/backend/tests/test_integration_adapters.py
+++ b/backend/tests/test_integration_adapters.py
@@ -1,16 +1,37 @@
 from datetime import date, time
 
 from fastapi.testclient import TestClient
+from pytest import MonkeyPatch
 from sqlalchemy.orm import Session
 
 from app.api.dependencies.integration_auth import hash_integration_key
 from app.core.tokens import create_access_token
+from app.schemas.integration_contracts import (
+    HOME_ASSISTANT_ADAPTER,
+    HOME_ASSISTANT_CONTRACT_VERSION,
+    INTEGRATION_CONTRACT_HEADER,
+    integration_contract_header,
+)
 from app.models.chore_instance import ChoreInstance, ChoreStatus
 from app.models.chore_template import ChoreTemplate
 from app.models.integration_client import IntegrationClient
 from app.models.medication_plan import MedicationPlan
 from app.models.planned_item import PlannedItem
 from app.models.user import User
+
+
+HOME_ASSISTANT_ENDPOINTS = ("summary", "entities", "dashboard")
+FIXED_TODAY = date(2026, 1, 15)
+
+
+class FrozenDate(date):
+    @classmethod
+    def today(cls) -> date:
+        return FIXED_TODAY
+
+
+def _freeze_route_today(monkeypatch: MonkeyPatch, route_module: str) -> None:
+    monkeypatch.setattr(f"{route_module}.date", FrozenDate)
 
 
 def _create_user(db_session: Session, email: str) -> User:
@@ -41,6 +62,43 @@ def _create_integration_key(
     return raw_key
 
 
+def _create_home_assistant_fixture(db_session: Session, email: str) -> User:
+    user = _create_user(db_session, email)
+    template = ChoreTemplate(
+        user_id=user.id,
+        name="Home Assistant Template",
+        description=None,
+        start_date=FIXED_TODAY,
+        every_n_days=1,
+        is_active=True,
+    )
+    db_session.add(template)
+    db_session.commit()
+    db_session.refresh(template)
+    db_session.add(
+        ChoreInstance(
+            user_id=user.id,
+            chore_template_id=template.id,
+            title="Home Assistant Chore",
+            scheduled_date=FIXED_TODAY,
+            status=ChoreStatus.pending,
+        )
+    )
+    db_session.add(
+        MedicationPlan(
+            user_id=user.id,
+            name="Omega-3",
+            instructions="With lunch",
+            start_date=FIXED_TODAY,
+            schedule_time=time(12, 0),
+            every_n_days=1,
+            is_active=True,
+        )
+    )
+    db_session.commit()
+    return user
+
+
 def test_create_integration_client_and_list(client: TestClient, db_session: Session) -> None:
     user = _create_user(db_session, "client-create@example.com")
     token = create_access_token(user_id=user.id, email=user.email)
@@ -60,53 +118,115 @@ def test_create_integration_client_and_list(client: TestClient, db_session: Sess
     assert list_response.json()[0]["name"] == "Home Assistant"
 
 
-def test_home_assistant_requires_scope_and_returns_entities(client: TestClient, db_session: Session) -> None:
-    user = _create_user(db_session, "ha-scope@example.com")
-    template = ChoreTemplate(
-        user_id=user.id,
-        name="Trash Template",
-        description=None,
-        start_date=date.today(),
-        every_n_days=1,
-        is_active=True,
-    )
-    db_session.add(template)
-    db_session.commit()
-    db_session.refresh(template)
-    db_session.add(
-        ChoreInstance(
-            user_id=user.id,
-            chore_template_id=template.id,
-            title="Trash",
-            scheduled_date=date.today(),
-            status=ChoreStatus.pending,
-        )
-    )
-    db_session.add(
-        MedicationPlan(
-            user_id=user.id,
-            name="Vitamin D",
-            instructions="With breakfast",
-            start_date=date.today(),
-            schedule_time=time(8, 0),
-            every_n_days=1,
-            is_active=True,
-        )
-    )
-    db_session.commit()
-
+def test_home_assistant_routes_enforce_ha_read_scope(
+    client: TestClient,
+    db_session: Session,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    _freeze_route_today(monkeypatch, "app.api.routes.integrations.home_assistant")
+    user = _create_home_assistant_fixture(db_session, "ha-scope@example.com")
     wrong_key = _create_integration_key(db_session, user.id, scopes="mcp:read")
-    denied = client.get("/api/v1/integrations/home-assistant/entities", headers={"X-Integration-Key": wrong_key})
-    assert denied.status_code == 403
 
-    key = _create_integration_key(db_session, user.id, scopes="ha:read")
-    response = client.get("/api/v1/integrations/home-assistant/entities", headers={"X-Integration-Key": key})
-    assert response.status_code == 200
-    assert response.json()[0]["entity_id"] == "todo.daynest_tasks"
+    for endpoint in HOME_ASSISTANT_ENDPOINTS:
+        denied = client.get(
+            f"/api/v1/integrations/home-assistant/{endpoint}",
+            headers={"X-Integration-Key": wrong_key},
+        )
+        assert denied.status_code == 403
 
 
-def test_mcp_adapter_and_rate_limit(client: TestClient, db_session: Session) -> None:
+def test_home_assistant_summary_contract_is_stable(
+    client: TestClient,
+    db_session: Session,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    _freeze_route_today(monkeypatch, "app.api.routes.integrations.home_assistant")
+    user = _create_home_assistant_fixture(db_session, "ha-summary-contract@example.com")
+    ha_key = _create_integration_key(db_session, user.id, scopes="ha:read")
+    expected_contract = integration_contract_header(HOME_ASSISTANT_ADAPTER, HOME_ASSISTANT_CONTRACT_VERSION)
+
+    summary = client.get("/api/v1/integrations/home-assistant/summary", headers={"X-Integration-Key": ha_key})
+    assert summary.status_code == 200
+    assert summary.headers[INTEGRATION_CONTRACT_HEADER] == expected_contract
+    summary_payload = summary.json()
+    assert set(summary_payload.keys()) == {
+        "todo_daynest_today",
+        "sensor_daynest_overdue_count",
+        "sensor_daynest_next_medication",
+    }
+    assert isinstance(summary_payload["todo_daynest_today"], int)
+    assert isinstance(summary_payload["sensor_daynest_overdue_count"], int)
+    assert summary_payload["sensor_daynest_next_medication"] is None or isinstance(
+        summary_payload["sensor_daynest_next_medication"],
+        str,
+    )
+
+
+def test_home_assistant_entities_contract_is_stable(
+    client: TestClient,
+    db_session: Session,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    _freeze_route_today(monkeypatch, "app.api.routes.integrations.home_assistant")
+    user = _create_home_assistant_fixture(db_session, "ha-entities-contract@example.com")
+    ha_key = _create_integration_key(db_session, user.id, scopes="ha:read")
+    expected_contract = integration_contract_header(HOME_ASSISTANT_ADAPTER, HOME_ASSISTANT_CONTRACT_VERSION)
+
+    entities = client.get("/api/v1/integrations/home-assistant/entities", headers={"X-Integration-Key": ha_key})
+    assert entities.status_code == 200
+    assert entities.headers[INTEGRATION_CONTRACT_HEADER] == expected_contract
+    entities_payload = entities.json()
+    assert isinstance(entities_payload, list)
+    assert len(entities_payload) == 4
+    expected_entity_ids = {
+        "todo.daynest_tasks",
+        "sensor.daynest_overdue_count",
+        "sensor.daynest_completion_ratio",
+        "sensor.daynest_next_medication",
+    }
+    assert {item["entity_id"] for item in entities_payload} == expected_entity_ids
+    for item in entities_payload:
+        assert set(item.keys()) == {"entity_id", "state", "attributes"}
+        assert isinstance(item["state"], str)
+        assert isinstance(item["attributes"], dict)
+
+
+def test_home_assistant_dashboard_contract_is_stable(
+    client: TestClient,
+    db_session: Session,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    _freeze_route_today(monkeypatch, "app.api.routes.integrations.home_assistant")
+    user = _create_home_assistant_fixture(db_session, "ha-dashboard-contract@example.com")
+    ha_key = _create_integration_key(db_session, user.id, scopes="ha:read")
+    expected_contract = integration_contract_header(HOME_ASSISTANT_ADAPTER, HOME_ASSISTANT_CONTRACT_VERSION)
+
+    dashboard = client.get("/api/v1/integrations/home-assistant/dashboard", headers={"X-Integration-Key": ha_key})
+    assert dashboard.status_code == 200
+    assert dashboard.headers[INTEGRATION_CONTRACT_HEADER] == expected_contract
+    dashboard_payload = dashboard.json()
+    assert set(dashboard_payload.keys()) == {
+        "for_date",
+        "overdue_count",
+        "due_today_count",
+        "planned_count",
+        "medication_due_count",
+        "completion_ratio",
+        "next_medication",
+    }
+    assert isinstance(dashboard_payload["for_date"], str)
+    assert isinstance(dashboard_payload["overdue_count"], int)
+    assert isinstance(dashboard_payload["due_today_count"], int)
+    assert isinstance(dashboard_payload["planned_count"], int)
+    assert isinstance(dashboard_payload["medication_due_count"], int)
+    assert isinstance(dashboard_payload["completion_ratio"], float)
+    assert dashboard_payload["next_medication"] is None or isinstance(dashboard_payload["next_medication"], str)
+
+
+def test_mcp_adapter_and_rate_limit(client: TestClient, db_session: Session, monkeypatch: MonkeyPatch) -> None:
     import app.api.dependencies.integration_auth as auth_dep
+
+    _freeze_route_today(monkeypatch, "app.api.routes.integrations.mcp")
     auth_dep._request_log.clear()
 
     user = _create_user(db_session, "mcp-rate@example.com")
@@ -114,7 +234,7 @@ def test_mcp_adapter_and_rate_limit(client: TestClient, db_session: Session) -> 
         PlannedItem(
             user_id=user.id,
             title="Weekly planning",
-            planned_for=date.today(),
+            planned_for=FIXED_TODAY,
             notes="sync",
             is_done=False,
         )

--- a/daynest-home-assistant/CHANGELOG.md
+++ b/daynest-home-assistant/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+
+All notable changes to this project are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project uses release-please to generate release entries.
+
+## [0.1.0] - 2026-04-25
+
+### Added
+
+- Initial release of the Daynest Home Assistant custom integration.

--- a/daynest-home-assistant/README.md
+++ b/daynest-home-assistant/README.md
@@ -26,7 +26,7 @@ Uncomment and customize these badges if you want to use them:
 - **Smart Control**: Adjust fan speed, target humidity, and operating modes
 - **Child Lock**: Safety feature to prevent accidental changes
 - **Diagnostic Info**: View filter life, runtime hours, and device statistics
-- **Reconfigurable**: Change credentials anytime without removing the integration
+- **Reconfigurable**: Change the configured URL and API key anytime without removing the integration
 - **Options Flow**: Adjust settings like update interval after setup
 - **Custom Services**: Advanced control with built-in service calls
 
@@ -88,11 +88,11 @@ Click the button below to open the configuration dialog:
 
 Follow the setup wizard:
 
-1. Enter your username
-2. Enter your password
-3. Click Submit
+1. Enter your Daynest base URL (`CONF_URL`)
+2. Paste your integration API key (`CONF_API_KEY`)
+3. Click **Submit**
 
-That's it! The integration will start loading your data.
+That's it. The integration will use that URL and API key to start loading your data.
 
 #### Option 2: Manual Configuration
 
@@ -111,7 +111,7 @@ After setup, you can adjust options:
    - Update interval (how often to refresh data)
    - Enable debug logging
 
-You can also **Reconfigure** your credentials anytime without removing the integration.
+You can also **Reconfigure** the stored URL and API key anytime without removing the integration.
 
 ### Step 4: Start Using!
 
@@ -149,7 +149,7 @@ The integration includes the backend contract expectation using the `X-Integrati
 
 | Integration version | Expected `X-Integration-Contract` | Backend expectation |
 | --- | --- | --- |
-| `0.1.x` | `1` | Supports `GET /api/v1/integrations/home-assistant/summary` and `GET /api/v1/integrations/home-assistant/dashboard` contract documented in [the backend integration guide](docs/user/BACKEND_INTEGRATION_HOME_ASSISTANT.md). |
+| `0.1.x` | `home-assistant; version=ha.v1` | Supports `GET /api/v1/integrations/home-assistant/summary` and `GET /api/v1/integrations/home-assistant/dashboard` contract documented in [the backend integration guide](docs/user/BACKEND_INTEGRATION_HOME_ASSISTANT.md). |
 
 > [!NOTE]
 > When introducing a new backend contract (`2`, etc.), add a new row before release and document compatibility or migration notes in `CHANGELOG.md`.
@@ -274,8 +274,8 @@ Use these services in automations or scripts for more control.
 
 | Name     | Required | Description           |
 | -------- | -------- | --------------------- |
-| Username | Yes      | Your account username |
-| Password | Yes      | Your account password |
+| URL (`CONF_URL`) | Yes | Base URL of the Daynest backend |
+| API Key (`CONF_API_KEY`) | Yes | Integration API key with `ha:read` scope |
 
 ### After Setup (Options)
 
@@ -292,25 +292,25 @@ You can change these anytime by clicking **Configure**:
 
 #### Reauthentication
 
-If your credentials expire or change, Home Assistant will automatically prompt you to reauthenticate:
+If the configured URL or API key becomes invalid, Home Assistant will prompt you to reconfigure the integration:
 
 1. Go to **Settings** → **Devices & Services**
 2. Look for **"Action Required"** or **"Configuration Required"** message on the integration
 3. Click **"Reconfigure"** or follow the prompt
-4. Enter your updated credentials
-5. Click Submit
+4. Enter the updated `CONF_URL` and `CONF_API_KEY`
+5. Click **Submit**
 
-The integration will automatically resume normal operation with the new credentials.
+The integration will automatically resume normal operation with the new URL and API key.
 
 #### Manual Credential Update
 
-You can also update credentials at any time without waiting for an error:
+You can also update `CONF_URL` and `CONF_API_KEY` at any time without waiting for an error:
 
 1. Go to **Settings** → **Devices & Services**
 2. Find **Daynest**
 3. Click the **3 dots menu** → **Reconfigure**
-4. Enter new username/password
-5. Click Submit
+4. Enter the new URL and API key
+5. Click **Submit**
 
 #### Connection Status
 
@@ -319,7 +319,7 @@ Monitor your connection status with the **API Connection** binary sensor:
 - **On** (Connected): Integration is receiving data normally
 - **Off** (Disconnected): Connection lost or authentication failed
   - Check the binary sensor attributes for diagnostic information
-  - Verify credentials if authentication failed
+  - Verify `CONF_URL` and `CONF_API_KEY` if authentication failed
   - Check network connectivity
 
 ### Enable Debug Logging
@@ -339,9 +339,9 @@ logger:
 
 If you receive authentication errors:
 
-1. Verify your username and password are correct
-2. Check that your account has the necessary permissions
-3. Wait for the automatic reauthentication prompt, or manually reconfigure
+1. Verify `CONF_URL` points at the Daynest backend origin
+2. Verify `CONF_API_KEY` is correct and has the necessary permissions
+3. Wait for the automatic reconfiguration prompt, or manually reconfigure
 4. Check the API Connection binary sensor for status
 
 #### Device Not Responding

--- a/daynest-home-assistant/README.md
+++ b/daynest-home-assistant/README.md
@@ -55,7 +55,7 @@ Uncomment and customize these badges if you want to use them:
 
 Click the button below to open the integration directly in HACS:
 
-[![Open your Home Assistant instance and open a repository inside the Home Assistant Community Store.](https://my.home-assistant.io/badges/hacs_repository.svg)](https://my.home-assistant.io/redirect/hacs_repository/?owner=jpawlowski&repository=daynest-home-assistant&category=integration)
+[![Open your Home Assistant instance and open a repository inside the Home Assistant Community Store.](https://my.home-assistant.io/badges/hacs_repository.svg)](https://my.home-assistant.io/redirect/hacs_repository/?owner=daynest&repository=daynest-home-assistant&category=integration)
 
 Then:
 
@@ -126,6 +126,65 @@ The integration creates several entities for your air purifier:
 - **Fan**: Air purifier fan control
 
 Find all entities in **Settings** → **Devices & Services** → **Daynest** → click on the device.
+
+## Integration Docs
+
+- [Getting Started](docs/user/GETTING_STARTED.md) - Installation and initial setup
+- [Configuration](docs/user/CONFIGURATION.md) - Detailed configuration options
+- [Examples](docs/user/EXAMPLES.md) - Automation and dashboard examples
+- [Backend Integration: Home Assistant Custom Integration](docs/user/BACKEND_INTEGRATION_HOME_ASSISTANT.md) - API scope, base URL, endpoints, and error handling guidance
+
+## HACS Repository Structure
+
+This repository is structured for direct HACS installation:
+
+- `hacs.json` exists in the repository root and defines HACS metadata
+- Integration code is located at `custom_components/daynest/`
+- `custom_components/daynest/manifest.json` includes the integration `version`
+- `README.md` is rendered in HACS for install/setup guidance
+
+## Compatibility Matrix (Integration ↔ Backend Contract)
+
+The integration includes the backend contract expectation using the `X-Integration-Contract` header. Keep backend behavior aligned with the matrix below during upgrades.
+
+| Integration version | Expected `X-Integration-Contract` | Backend expectation |
+| --- | --- | --- |
+| `0.1.x` | `1` | Supports `GET /api/v1/integrations/home-assistant/summary` and `GET /api/v1/integrations/home-assistant/dashboard` contract documented in [the backend integration guide](docs/user/BACKEND_INTEGRATION_HOME_ASSISTANT.md). |
+
+> [!NOTE]
+> When introducing a new backend contract (`2`, etc.), add a new row before release and document compatibility or migration notes in `CHANGELOG.md`.
+
+## Release Checklist
+
+Use this checklist before and after publishing each integration release.
+
+### 1) Version tagging
+
+- [ ] Confirm `custom_components/daynest/manifest.json` version is correct (`./script/version`)
+- [ ] Confirm release tag format is `vX.Y.Z` and matches `manifest.json`
+- [ ] Verify `.release-please-manifest.json` is aligned (`./script/version --check`)
+
+### 2) Changelog updates
+
+- [ ] Verify `CHANGELOG.md` includes all user-facing changes for the release
+- [ ] Ensure compatibility or migration notes are present for contract changes
+- [ ] Ensure non-user-facing internal changes remain excluded (per release-please config)
+
+### 3) Daynest backend contract compatibility notes
+
+- [ ] Confirm the compatibility matrix in this README is updated for the new version
+- [ ] Confirm backend expectation still matches integration requests and payload parsing
+- [ ] If contract changed, include explicit upgrade notes and rollback guidance
+
+### 4) Post-release validation in a real Home Assistant instance
+
+- [ ] Install from HACS in a non-dev Home Assistant instance and restart HA
+- [ ] Add or reconfigure the Daynest integration through UI config flow
+- [ ] Validate entities load and update (`sensor`, `binary_sensor`, `fan`, `select`, `number`, `button`, `switch`)
+- [ ] Execute `daynest.reload_data` and verify coordinator refresh succeeds
+- [ ] Check Home Assistant logs for auth, schema, and availability errors
+- [ ] Validate diagnostics redaction and confirm no secrets are exposed
+- [ ] Verify upgrade path from previous release (no orphaned entities or broken config entries)
 
 ## Available Entities
 

--- a/daynest-home-assistant/custom_components/daynest/__init__.py
+++ b/daynest-home-assistant/custom_components/daynest/__init__.py
@@ -18,16 +18,15 @@ https://developers.home-assistant.io/docs/creating_integration_manifest
 
 from __future__ import annotations
 
-from datetime import timedelta
 from typing import TYPE_CHECKING
 
-from homeassistant.const import CONF_PASSWORD, CONF_USERNAME, Platform
+from homeassistant.const import CONF_API_KEY, CONF_URL, Platform
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 import homeassistant.helpers.config_validation as cv
 from homeassistant.loader import async_get_loaded_integration
 
 from .api import DaynestApiClient
-from .const import DOMAIN, LOGGER
+from .const import DOMAIN
 from .coordinator import DaynestDataUpdateCoordinator
 from .data import DaynestData
 from .service_actions import async_setup_services
@@ -93,8 +92,8 @@ async def async_setup_entry(
     6. Sets up reload listener for config changes
 
     Data flow in this integration:
-    1. User enters username/password in config flow (config_flow.py)
-    2. Credentials stored in entry.data[CONF_USERNAME/CONF_PASSWORD]
+    1. User enters base URL / API key in config flow (config_flow.py)
+    2. Credentials stored in entry.data[CONF_URL/CONF_API_KEY]
     3. API Client initialized with credentials (api/client.py)
     4. Coordinator fetches data using authenticated client (coordinator/base.py)
     5. Entities access data via self.coordinator.data (sensor/, binary_sensor/, etc.)
@@ -114,19 +113,16 @@ async def async_setup_entry(
     """
     # Initialize client first
     client = DaynestApiClient(
-        username=entry.data[CONF_USERNAME],  # From config flow setup
-        password=entry.data[CONF_PASSWORD],  # From config flow setup
+        base_url=entry.data[CONF_URL],  # From config flow setup
+        integration_key=entry.data[CONF_API_KEY],  # From config flow setup
         session=async_get_clientsession(hass),
     )
 
     # Initialize coordinator with config_entry
     coordinator = DaynestDataUpdateCoordinator(
         hass=hass,
-        logger=LOGGER,
-        name=DOMAIN,
         config_entry=entry,
-        update_interval=timedelta(hours=1),
-        always_update=False,  # Only update entities when data actually changes
+        client=client,
     )
 
     # Store runtime data

--- a/daynest-home-assistant/custom_components/daynest/api/__init__.py
+++ b/daynest-home-assistant/custom_components/daynest/api/__init__.py
@@ -8,13 +8,21 @@ Architecture:
 
 Exception hierarchy:
     DaynestApiClientError (base)
-    ├── DaynestApiClientCommunicationError (network/timeout)
-    └── DaynestApiClientAuthenticationError (401/403)
+    ├── DaynestApiClientCommunicationError
+    │   ├── DaynestApiClientTimeoutError
+    │   └── DaynestApiClientServerUnavailableError
+    ├── DaynestApiClientMalformedResponseError
+    └── DaynestApiClientAuthenticationError
 
 Coordinator exception mapping:
-    ApiClientAuthenticationError → ConfigEntryAuthFailed (triggers reauth)
-    ApiClientCommunicationError → UpdateFailed (auto-retry)
-    ApiClientError             → UpdateFailed (auto-retry)
+    DaynestApiClientAuthenticationError → ConfigEntryAuthFailed
+    DaynestApiClientCommunicationError → UpdateFailed
+    DaynestApiClientTimeoutError → UpdateFailed
+    DaynestApiClientServerUnavailableError → UpdateFailed
+    DaynestApiClientMalformedResponseError → UpdateFailed
+    DaynestApiClientError → UpdateFailed
+
+These mappings reflect the handling in coordinator._async_update_data.
 """
 
 from .client import (

--- a/daynest-home-assistant/custom_components/daynest/api/__init__.py
+++ b/daynest-home-assistant/custom_components/daynest/api/__init__.py
@@ -18,15 +18,27 @@ Coordinator exception mapping:
 """
 
 from .client import (
+    DaynestApiResponse,
     DaynestApiClient,
     DaynestApiClientAuthenticationError,
     DaynestApiClientCommunicationError,
     DaynestApiClientError,
+    DaynestApiClientMalformedResponseError,
+    DaynestApiClientServerUnavailableError,
+    DaynestApiClientTimeoutError,
+    DaynestDashboard,
+    DaynestSummary,
 )
 
 __all__ = [
+    "DaynestApiResponse",
     "DaynestApiClient",
     "DaynestApiClientAuthenticationError",
     "DaynestApiClientCommunicationError",
     "DaynestApiClientError",
+    "DaynestApiClientMalformedResponseError",
+    "DaynestApiClientServerUnavailableError",
+    "DaynestApiClientTimeoutError",
+    "DaynestDashboard",
+    "DaynestSummary",
 ]

--- a/daynest-home-assistant/custom_components/daynest/api/client.py
+++ b/daynest-home-assistant/custom_components/daynest/api/client.py
@@ -1,237 +1,183 @@
-"""
-API Client for daynest.
-
-This module provides the API client for communicating with external services.
-It demonstrates proper error handling, authentication patterns, and async operations.
-
-For more information on creating API clients:
-https://developers.home-assistant.io/docs/api_lib_index
-"""
+"""HTTP API client for Daynest backend integration endpoints."""
 
 from __future__ import annotations
 
 import asyncio
-import socket
-from typing import Any
+from dataclasses import dataclass
+from collections.abc import Callable
+from typing import Any, Generic, TypeVar
+from urllib.parse import urljoin
 
 import aiohttp
 
 
 class DaynestApiClientError(Exception):
-    """Base exception to indicate a general API error."""
+    """Base exception for API client failures."""
 
 
-class DaynestApiClientCommunicationError(
-    DaynestApiClientError,
-):
-    """Exception to indicate a communication error with the API."""
+class DaynestApiClientCommunicationError(DaynestApiClientError):
+    """Generic transport-level failure."""
 
 
-class DaynestApiClientAuthenticationError(
-    DaynestApiClientError,
-):
-    """Exception to indicate an authentication error with the API."""
+class DaynestApiClientAuthenticationError(DaynestApiClientError):
+    """Authentication/authorization failure reported by backend."""
 
 
-def _verify_response_or_raise(response: aiohttp.ClientResponse) -> None:
-    """
-    Verify that the API response is valid.
+class DaynestApiClientTimeoutError(DaynestApiClientCommunicationError):
+    """Request timed out before receiving a response."""
 
-    Raises appropriate exceptions for authentication and HTTP errors.
 
-    Args:
-        response: The aiohttp ClientResponse to verify.
+class DaynestApiClientServerUnavailableError(DaynestApiClientCommunicationError):
+    """Backend is unavailable or returned an upstream/server error."""
 
-    Raises:
-        DaynestApiClientAuthenticationError: For 401/403 errors.
-        aiohttp.ClientResponseError: For other HTTP errors.
 
-    """
-    if response.status in (401, 403):
-        msg = "Invalid credentials"
-        raise DaynestApiClientAuthenticationError(
-            msg,
-        )
-    response.raise_for_status()
+class DaynestApiClientMalformedResponseError(DaynestApiClientError):
+    """Response payload could not be parsed into expected model."""
+
+
+@dataclass(slots=True, frozen=True)
+class DaynestSummary:
+    """Typed model for `/summary` payload."""
+
+    user_id: int
+    record_id: int
+    title: str
+    body: str
+
+    @classmethod
+    def from_dict(cls, payload: dict[str, Any]) -> DaynestSummary:
+        """Build a typed summary model from raw JSON payload."""
+        try:
+            user_id = int(payload["userId"])
+            record_id = int(payload["id"])
+            title = str(payload["title"])
+            body = str(payload["body"])
+        except (KeyError, TypeError, ValueError) as err:
+            msg = f"Malformed summary payload: {err}"
+            raise DaynestApiClientMalformedResponseError(msg) from err
+
+        return cls(user_id=user_id, record_id=record_id, title=title, body=body)
+
+
+@dataclass(slots=True, frozen=True)
+class DaynestDashboard:
+    """Typed model for `/dashboard` payload."""
+
+    payload: dict[str, Any]
+
+    @classmethod
+    def from_dict(cls, payload: dict[str, Any]) -> DaynestDashboard:
+        """Build a typed dashboard model from raw JSON payload."""
+        if not isinstance(payload, dict):
+            msg = "Malformed dashboard payload: expected JSON object"
+            raise DaynestApiClientMalformedResponseError(msg)
+        return cls(payload=payload)
+
+
+ModelT = TypeVar("ModelT")
+
+
+@dataclass(slots=True, frozen=True)
+class DaynestApiResponse(Generic[ModelT]):
+    """Typed response wrapper carrying contract metadata."""
+
+    data: ModelT
+    integration_contract: str | None
 
 
 class DaynestApiClient:
-    """
-    API Client for Smart Air Purifier integration.
-
-    This client demonstrates authentication and API communication patterns
-    for Home Assistant integrations. It handles HTTP requests, error handling,
-    and credential management.
-
-    The username and password are stored and would be used for:
-    - HTTP Basic Auth headers
-    - OAuth token exchange
-    - API key generation
-    - Session token management
-
-    Note: JSONPlaceholder is used as a demo endpoint and doesn't require auth.
-    In production, replace with your actual API endpoint that validates credentials.
-
-    For more information on API clients:
-    https://developers.home-assistant.io/docs/api_lib_index
-
-    Attributes:
-        _username: The username for API authentication.
-        _password: The password for API authentication.
-        _session: The aiohttp ClientSession for making requests.
-
-    """
+    """Thin HTTP client for Daynest Home Assistant integration backend."""
 
     def __init__(
         self,
-        username: str,
-        password: str,
         session: aiohttp.ClientSession,
+        base_url: str | None = None,
+        integration_key: str | None = None,
+        *,
+        username: str | None = None,
+        password: str | None = None,
     ) -> None:
-        """
-        Initialize the API Client with credentials.
+        """Initialize client with optional backward-compatible parameter aliases."""
+        resolved_base_url = (base_url or username or "").strip().rstrip("/")
+        if not resolved_base_url:
+            msg = "A base URL is required to initialize DaynestApiClient"
+            raise ValueError(msg)
 
-        Args:
-            username: The username for authentication from config flow.
-            password: The password for authentication from config flow.
-            session: The aiohttp ClientSession to use for requests.
-
-        """
-        self._username = username
-        self._password = password
         self._session = session
+        self._base_url = resolved_base_url
+        self._integration_key = integration_key or password
 
-    async def async_get_data(self) -> Any:
-        """
-        Get data from the API.
+        # Backwards-compatibility for existing diagnostics code.
+        self._username = resolved_base_url
+        self._password = self._integration_key
 
-        This method fetches the current state and sensor data from the device.
-        It demonstrates where credentials would be used in production:
-        - Authorization headers (Basic Auth, Bearer Token)
-        - Query parameters (username, api_key)
-        - Session cookies (after login)
+        self.last_integration_contract: str | None = None
 
-        Returns:
-            A dictionary containing the device data.
+    async def async_get_data(self) -> dict[str, Any]:
+        """Fetch summary data as the coordinator's primary payload."""
+        response = await self.async_get_summary()
+        return {
+            "userId": response.data.user_id,
+            "id": response.data.record_id,
+            "title": response.data.title,
+            "body": response.data.body,
+        }
 
-        Raises:
-            DaynestApiClientAuthenticationError: If authentication fails.
-            DaynestApiClientCommunicationError: If communication fails.
-            DaynestApiClientError: For other API errors.
-
-        """
-        # In production: Use username/password for authentication
-        # Example patterns:
-        # 1. Basic Auth: auth=aiohttp.BasicAuth(self._username, self._password)
-        # 2. Token: headers={"Authorization": f"Bearer {self._get_token()}"}
-        # 3. API Key: params={"username": self._username, "key": self._password}
-
-        return await self._api_wrapper(
-            method="get",
-            url="https://jsonplaceholder.typicode.com/posts/1",
-            # For demo purposes with JSONPlaceholder (no auth required)
-            # In production, add authentication here
+    async def async_get_summary(self) -> DaynestApiResponse[DaynestSummary]:
+        """Fetch and parse the integration summary endpoint."""
+        return await self._request_model(
+            path="/api/v1/integrations/home-assistant/summary",
+            parser=DaynestSummary.from_dict,
         )
 
-    async def async_set_fan_speed(self, speed: str) -> Any:
-        """
-        Set the fan speed on the device.
-
-        Args:
-            speed: The fan speed to set (low, medium, high, auto).
-
-        Returns:
-            A dictionary containing the API response.
-
-        Raises:
-            DaynestApiClientAuthenticationError: If authentication fails.
-            DaynestApiClientCommunicationError: If communication fails.
-            DaynestApiClientError: For other API errors.
-
-        """
-        # In production: Send authenticated request to change fan speed
-        return await self._api_wrapper(
-            method="patch",
-            url="https://jsonplaceholder.typicode.com/posts/1",
-            data={"fan_speed": speed, "user": self._username},
-            headers={"Content-type": "application/json; charset=UTF-8"},
+    async def async_get_dashboard(self) -> DaynestApiResponse[DaynestDashboard]:
+        """Fetch and parse the integration dashboard endpoint."""
+        return await self._request_model(
+            path="/api/v1/integrations/home-assistant/dashboard",
+            parser=DaynestDashboard.from_dict,
         )
 
-    async def async_set_target_humidity(self, humidity: int) -> Any:
-        """
-        Set the target humidity on the device.
-
-        Args:
-            humidity: The target humidity percentage (30-80).
-
-        Returns:
-            A dictionary containing the API response.
-
-        Raises:
-            DaynestApiClientAuthenticationError: If authentication fails.
-            DaynestApiClientCommunicationError: If communication fails.
-            DaynestApiClientError: For other API errors.
-
-        """
-        # In production: Send authenticated request to change humidity setting
-        return await self._api_wrapper(
-            method="patch",
-            url="https://jsonplaceholder.typicode.com/posts/1",
-            data={"target_humidity": humidity, "user": self._username},
-            headers={"Content-type": "application/json; charset=UTF-8"},
-        )
-
-    async def _api_wrapper(
+    async def _request_model(
         self,
-        method: str,
-        url: str,
-        data: dict | None = None,
-        headers: dict | None = None,
-    ) -> Any:
-        """
-        Wrapper for API requests with error handling.
+        path: str,
+        parser: Callable[[dict[str, Any]], ModelT],
+    ) -> DaynestApiResponse[ModelT]:
+        """Request JSON endpoint and parse into a typed model."""
+        url = urljoin(f"{self._base_url}/", path.lstrip("/"))
+        headers = {"Accept": "application/json"}
+        if self._integration_key:
+            headers["X-Integration-Key"] = self._integration_key
 
-        This method handles all HTTP requests and translates exceptions
-        into integration-specific exceptions.
-
-        Args:
-            method: The HTTP method (get, post, patch, etc.).
-            url: The URL to request.
-            data: Optional data to send in the request body.
-            headers: Optional headers to include in the request.
-
-        Returns:
-            The JSON response from the API.
-
-        Raises:
-            DaynestApiClientAuthenticationError: If authentication fails.
-            DaynestApiClientCommunicationError: If communication fails.
-            DaynestApiClientError: For other API errors.
-
-        """
         try:
-            async with asyncio.timeout(10):
-                response = await self._session.request(
-                    method=method,
-                    url=url,
-                    headers=headers,
-                    json=data,
-                )
-                _verify_response_or_raise(response)
-                return await response.json()
+            async with self._session.get(url, headers=headers, timeout=aiohttp.ClientTimeout(total=10)) as response:
+                if response.status in (401, 403):
+                    msg = f"Authentication failed with status {response.status}"
+                    raise DaynestApiClientAuthenticationError(msg)
+                if response.status in (502, 503, 504):
+                    msg = f"Backend unavailable (status {response.status})"
+                    raise DaynestApiClientServerUnavailableError(msg)
+                response.raise_for_status()
 
-        except TimeoutError as exception:
-            msg = f"Timeout error fetching information - {exception}"
-            raise DaynestApiClientCommunicationError(
-                msg,
-            ) from exception
-        except (aiohttp.ClientError, socket.gaierror) as exception:
-            msg = f"Error fetching information - {exception}"
-            raise DaynestApiClientCommunicationError(
-                msg,
-            ) from exception
-        except Exception as exception:
-            msg = f"Something really wrong happened! - {exception}"
-            raise DaynestApiClientError(
-                msg,
-            ) from exception
+                contract = response.headers.get("X-Integration-Contract")
+                self.last_integration_contract = contract
+
+                payload = await response.json(content_type=None)
+                if not isinstance(payload, dict):
+                    msg = "Malformed response payload: expected JSON object"
+                    raise DaynestApiClientMalformedResponseError(msg)
+
+                model = parser(payload)
+                return DaynestApiResponse(data=model, integration_contract=contract)
+
+        except asyncio.TimeoutError as err:
+            msg = f"Request timed out for endpoint {path}"
+            raise DaynestApiClientTimeoutError(msg) from err
+        except aiohttp.ClientConnectionError as err:
+            msg = f"Server unavailable while requesting endpoint {path}: {err}"
+            raise DaynestApiClientServerUnavailableError(msg) from err
+        except aiohttp.ClientError as err:
+            msg = f"Communication error while requesting endpoint {path}: {err}"
+            raise DaynestApiClientCommunicationError(msg) from err
+        except ValueError as err:
+            msg = f"Malformed JSON response for endpoint {path}: {err}"
+            raise DaynestApiClientMalformedResponseError(msg) from err

--- a/daynest-home-assistant/custom_components/daynest/api/client.py
+++ b/daynest-home-assistant/custom_components/daynest/api/client.py
@@ -10,6 +10,8 @@ from urllib.parse import urljoin
 
 import aiohttp
 
+from ..const import DEFAULT_API_BASE_URL
+
 
 class DaynestApiClientError(Exception):
     """Base exception for API client failures."""
@@ -98,7 +100,7 @@ class DaynestApiClient:
         password: str | None = None,
     ) -> None:
         """Initialize client with optional backward-compatible parameter aliases."""
-        resolved_base_url = (base_url or username or "").strip().rstrip("/")
+        resolved_base_url = (base_url or DEFAULT_API_BASE_URL).strip().rstrip("/")
         if not resolved_base_url:
             msg = "A base URL is required to initialize DaynestApiClient"
             raise ValueError(msg)
@@ -107,11 +109,12 @@ class DaynestApiClient:
         self._base_url = resolved_base_url
         self._integration_key = integration_key or password
 
-        # Backwards-compatibility for existing diagnostics code.
-        self._username = resolved_base_url
-        self._password = self._integration_key
-
         self.last_integration_contract: str | None = None
+
+    @property
+    def has_integration_key(self) -> bool:
+        """Return whether the client has an integration key configured."""
+        return bool(self._integration_key)
 
     async def async_get_data(self) -> dict[str, Any]:
         """Fetch summary data as the coordinator's primary payload."""

--- a/daynest-home-assistant/custom_components/daynest/api/client.py
+++ b/daynest-home-assistant/custom_components/daynest/api/client.py
@@ -3,14 +3,16 @@
 from __future__ import annotations
 
 import asyncio
-from dataclasses import dataclass
 from collections.abc import Callable
+from dataclasses import dataclass
 from typing import Any, Generic, TypeVar
 from urllib.parse import urljoin
 
 import aiohttp
 
 from ..const import DEFAULT_API_BASE_URL
+
+REQUEST_TIMEOUT = aiohttp.ClientTimeout(total=10)
 
 
 class DaynestApiClientError(Exception):
@@ -41,24 +43,23 @@ class DaynestApiClientMalformedResponseError(DaynestApiClientError):
 class DaynestSummary:
     """Typed model for `/summary` payload."""
 
-    user_id: int
-    record_id: int
-    title: str
-    body: str
+    payload: dict[str, Any]
 
     @classmethod
     def from_dict(cls, payload: dict[str, Any]) -> DaynestSummary:
         """Build a typed summary model from raw JSON payload."""
-        try:
-            user_id = int(payload["userId"])
-            record_id = int(payload["id"])
-            title = str(payload["title"])
-            body = str(payload["body"])
-        except (KeyError, TypeError, ValueError) as err:
-            msg = f"Malformed summary payload: {err}"
-            raise DaynestApiClientMalformedResponseError(msg) from err
+        required_keys = {
+            "todo_daynest_today",
+            "sensor_daynest_overdue_count",
+            "sensor_daynest_next_medication",
+        }
+        missing_keys = sorted(required_keys.difference(payload))
+        if missing_keys:
+            missing = ", ".join(missing_keys)
+            msg = f"Malformed summary payload: missing required keys ({missing})"
+            raise DaynestApiClientMalformedResponseError(msg)
 
-        return cls(user_id=user_id, record_id=record_id, title=title, body=body)
+        return cls(payload=payload)
 
 
 @dataclass(slots=True, frozen=True)
@@ -107,7 +108,7 @@ class DaynestApiClient:
 
         self._session = session
         self._base_url = resolved_base_url
-        self._integration_key = integration_key or password
+        self._integration_key = integration_key if integration_key is not None else password
 
         self.last_integration_contract: str | None = None
 
@@ -119,12 +120,7 @@ class DaynestApiClient:
     async def async_get_data(self) -> dict[str, Any]:
         """Fetch summary data as the coordinator's primary payload."""
         response = await self.async_get_summary()
-        return {
-            "userId": response.data.user_id,
-            "id": response.data.record_id,
-            "title": response.data.title,
-            "body": response.data.body,
-        }
+        return response.data.payload
 
     async def async_get_summary(self) -> DaynestApiResponse[DaynestSummary]:
         """Fetch and parse the integration summary endpoint."""
@@ -152,11 +148,11 @@ class DaynestApiClient:
             headers["X-Integration-Key"] = self._integration_key
 
         try:
-            async with self._session.get(url, headers=headers, timeout=aiohttp.ClientTimeout(total=10)) as response:
+            async with self._session.get(url, headers=headers, timeout=REQUEST_TIMEOUT) as response:
                 if response.status in (401, 403):
                     msg = f"Authentication failed with status {response.status}"
                     raise DaynestApiClientAuthenticationError(msg)
-                if response.status in (502, 503, 504):
+                if 500 <= response.status < 600:
                     msg = f"Backend unavailable (status {response.status})"
                     raise DaynestApiClientServerUnavailableError(msg)
                 response.raise_for_status()

--- a/daynest-home-assistant/custom_components/daynest/button/reset_filter.py
+++ b/daynest-home-assistant/custom_components/daynest/button/reset_filter.py
@@ -50,10 +50,6 @@ class DaynestButton(ButtonEntity, DaynestEntity):
             # In production: Send reset command to device
             # await self.coordinator.config_entry.runtime_data.client.async_reset_filter()
 
-            # For demo: Store reset flag in coordinator data
-            # The filter_life sensor will read this and show 100%
-            self.coordinator.data["demo_filter_reset"] = True
-
             # Request a coordinator refresh - this simulates the real flow:
             # 1. API call to device (commented out above)
             # 2. Coordinator fetches updated data from device

--- a/daynest-home-assistant/custom_components/daynest/config_flow.py
+++ b/daynest-home-assistant/custom_components/daynest/config_flow.py
@@ -15,12 +15,13 @@ from homeassistant.loader import async_get_loaded_integration
 from .api import (
     DaynestApiClient,
     DaynestApiClientAuthenticationError,
+    DaynestApiClientMalformedResponseError,
     DaynestApiClientServerUnavailableError,
     DaynestApiClientTimeoutError,
 )
-from .const import DOMAIN, LOGGER
+from .const import DOMAIN, LOGGER, SUPPORTED_INTEGRATION_CONTRACT_VERSIONS, parse_integration_contract_version
 
-SUPPORTED_CONTRACT_VERSIONS = {"1"}
+SUPPORTED_CONTRACT_VERSIONS = SUPPORTED_INTEGRATION_CONTRACT_VERSIONS
 
 ERROR_AUTH = "invalid_auth"
 ERROR_CANNOT_CONNECT = "cannot_connect"
@@ -109,14 +110,18 @@ class DaynestConfigFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         except DaynestApiClientServerUnavailableError as err:
             LOGGER.warning("Could not connect to Daynest during setup: %s", err)
             return {"base": ERROR_CANNOT_CONNECT}
+        except DaynestApiClientMalformedResponseError as err:
+            LOGGER.warning("Malformed or unsupported Daynest setup response: %s", err)
+            return {"base": ERROR_UNSUPPORTED_CONTRACT}
         except Exception as err:  # noqa: BLE001
             LOGGER.exception("Unexpected error during Daynest setup: %s", err)
             return {"base": ERROR_UNKNOWN}
 
-        contract_version = summary_response.integration_contract
+        contract_version = parse_integration_contract_version(summary_response.integration_contract)
         if contract_version not in SUPPORTED_CONTRACT_VERSIONS:
             LOGGER.warning(
-                "Unsupported Daynest integration contract '%s' received during setup", contract_version
+                "Unsupported Daynest integration contract '%s' received during setup",
+                summary_response.integration_contract,
             )
             return {"base": ERROR_UNSUPPORTED_CONTRACT}
 

--- a/daynest-home-assistant/custom_components/daynest/config_flow.py
+++ b/daynest-home-assistant/custom_components/daynest/config_flow.py
@@ -1,12 +1,126 @@
-"""
-Config flow for daynest.
-
-This module provides backwards compatibility for hassfest.
-The actual implementation is in the config_flow_handler package.
-"""
+"""Config flow for Daynest integration."""
 
 from __future__ import annotations
 
-from .config_flow_handler import DaynestConfigFlowHandler
+from typing import Any
+
+import voluptuous as vol
+
+from homeassistant import config_entries
+from homeassistant.const import CONF_API_KEY, CONF_URL
+from homeassistant.helpers import selector
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
+from homeassistant.loader import async_get_loaded_integration
+
+from .api import (
+    DaynestApiClient,
+    DaynestApiClientAuthenticationError,
+    DaynestApiClientServerUnavailableError,
+    DaynestApiClientTimeoutError,
+)
+from .const import DOMAIN, LOGGER
+
+SUPPORTED_CONTRACT_VERSIONS = {"1"}
+
+ERROR_AUTH = "invalid_auth"
+ERROR_CANNOT_CONNECT = "cannot_connect"
+ERROR_TIMEOUT = "timeout"
+ERROR_UNSUPPORTED_CONTRACT = "unsupported_contract"
+ERROR_UNKNOWN = "unknown"
+
+
+def _user_schema(defaults: dict[str, Any] | None = None) -> vol.Schema:
+    """Return schema for user setup flow."""
+    defaults = defaults or {}
+    return vol.Schema(
+        {
+            vol.Required(
+                CONF_URL,
+                default=defaults.get(CONF_URL, vol.UNDEFINED),
+            ): selector.TextSelector(
+                selector.TextSelectorConfig(
+                    type=selector.TextSelectorType.URL,
+                ),
+            ),
+            vol.Required(CONF_API_KEY): selector.TextSelector(
+                selector.TextSelectorConfig(
+                    type=selector.TextSelectorType.PASSWORD,
+                ),
+            ),
+        }
+    )
+
+
+class DaynestConfigFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
+    """Handle a config flow for Daynest."""
+
+    VERSION = 1
+
+    async def async_step_user(
+        self,
+        user_input: dict[str, Any] | None = None,
+    ) -> config_entries.ConfigFlowResult:
+        """Handle initial config flow step."""
+        errors: dict[str, str] = {}
+
+        if user_input is not None:
+            normalized_url = str(user_input[CONF_URL]).strip().rstrip("/")
+            sanitized_input = {
+                CONF_URL: normalized_url,
+                CONF_API_KEY: str(user_input[CONF_API_KEY]),
+            }
+
+            errors = await self._async_validate_user_input(sanitized_input)
+            if not errors:
+                await self.async_set_unique_id(normalized_url)
+                self._abort_if_unique_id_configured()
+                return self.async_create_entry(
+                    title=normalized_url,
+                    data=sanitized_input,
+                )
+
+        integration = async_get_loaded_integration(self.hass, DOMAIN)
+
+        return self.async_show_form(
+            step_id="user",
+            data_schema=_user_schema(user_input),
+            errors=errors,
+            description_placeholders={
+                "documentation_url": integration.documentation or "",
+            },
+        )
+
+    async def _async_validate_user_input(self, user_input: dict[str, str]) -> dict[str, str]:
+        """Validate user input by calling Daynest summary endpoint."""
+        client = DaynestApiClient(
+            session=async_get_clientsession(self.hass),
+            base_url=user_input[CONF_URL],
+            integration_key=user_input[CONF_API_KEY],
+        )
+
+        try:
+            summary_response = await client.async_get_summary()
+        except DaynestApiClientAuthenticationError as err:
+            LOGGER.warning("Failed authentication during Daynest setup: %s", err)
+            return {"base": ERROR_AUTH}
+        except DaynestApiClientTimeoutError as err:
+            LOGGER.warning("Timeout during Daynest setup: %s", err)
+            return {"base": ERROR_TIMEOUT}
+        except DaynestApiClientServerUnavailableError as err:
+            LOGGER.warning("Could not connect to Daynest during setup: %s", err)
+            return {"base": ERROR_CANNOT_CONNECT}
+        except Exception as err:  # noqa: BLE001
+            LOGGER.exception("Unexpected error during Daynest setup: %s", err)
+            return {"base": ERROR_UNKNOWN}
+
+        contract_version = summary_response.integration_contract
+        if contract_version not in SUPPORTED_CONTRACT_VERSIONS:
+            LOGGER.warning(
+                "Unsupported Daynest integration contract '%s' received during setup", contract_version
+            )
+            return {"base": ERROR_UNSUPPORTED_CONTRACT}
+
+        return {}
+
 
 __all__ = ["DaynestConfigFlowHandler"]

--- a/daynest-home-assistant/custom_components/daynest/config_flow_handler/config_flow.py
+++ b/daynest-home-assistant/custom_components/daynest/config_flow_handler/config_flow.py
@@ -92,8 +92,8 @@ class DaynestConfigFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             try:
                 await validate_credentials(
                     self.hass,
-                    username=user_input[CONF_USERNAME],
-                    password=user_input[CONF_PASSWORD],
+                    base_url=user_input[CONF_USERNAME],
+                    integration_key=user_input[CONF_PASSWORD],
                 )
             except Exception as exception:  # noqa: BLE001
                 errors["base"] = self._map_exception_to_error(exception)
@@ -139,8 +139,8 @@ class DaynestConfigFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             try:
                 await validate_credentials(
                     self.hass,
-                    username=user_input[CONF_USERNAME],
-                    password=user_input[CONF_PASSWORD],
+                    base_url=user_input[CONF_USERNAME],
+                    integration_key=user_input[CONF_PASSWORD],
                 )
             except Exception as exception:  # noqa: BLE001
                 errors["base"] = self._map_exception_to_error(exception)
@@ -198,8 +198,8 @@ class DaynestConfigFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             try:
                 await validate_credentials(
                     self.hass,
-                    username=user_input[CONF_USERNAME],
-                    password=user_input[CONF_PASSWORD],
+                    base_url=user_input[CONF_USERNAME],
+                    integration_key=user_input[CONF_PASSWORD],
                 )
             except Exception as exception:  # noqa: BLE001
                 errors["base"] = self._map_exception_to_error(exception)

--- a/daynest-home-assistant/custom_components/daynest/config_flow_handler/config_flow.py
+++ b/daynest-home-assistant/custom_components/daynest/config_flow_handler/config_flow.py
@@ -14,8 +14,6 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
-from slugify import slugify
-
 from custom_components.daynest.config_flow_handler.schemas import (
     get_reauth_schema,
     get_reconfigure_schema,
@@ -100,12 +98,6 @@ class DaynestConfigFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             except Exception as exception:  # noqa: BLE001
                 errors["base"] = self._map_exception_to_error(exception)
             else:
-                # Set unique ID based on username
-                # NOTE: This is just an example - use a proper unique ID in production
-                # See: https://developers.home-assistant.io/docs/config_entries_config_flow_handler#unique-ids
-                await self.async_set_unique_id(slugify(user_input[CONF_USERNAME]))
-                self._abort_if_unique_id_configured()
-
                 return self.async_create_entry(
                     title=user_input[CONF_USERNAME],
                     data=user_input,

--- a/daynest-home-assistant/custom_components/daynest/config_flow_handler/validators/credentials.py
+++ b/daynest-home-assistant/custom_components/daynest/config_flow_handler/validators/credentials.py
@@ -20,14 +20,14 @@ if TYPE_CHECKING:
     from homeassistant.core import HomeAssistant
 
 
-async def validate_credentials(hass: HomeAssistant, username: str, password: str) -> None:
+async def validate_credentials(hass: HomeAssistant, base_url: str, integration_key: str) -> None:
     """
     Validate user credentials by testing API connection.
 
     Args:
         hass: Home Assistant instance.
-        username: The username to validate.
-        password: The password to validate.
+        base_url: The Daynest base URL to validate.
+        integration_key: The Daynest integration key to validate.
 
     Raises:
         DaynestApiClientAuthenticationError: If credentials are invalid.
@@ -36,11 +36,11 @@ async def validate_credentials(hass: HomeAssistant, username: str, password: str
 
     """
     client = DaynestApiClient(
-        username=username,
-        password=password,
         session=async_get_clientsession(hass),
+        base_url=base_url,
+        integration_key=integration_key,
     )
-    await client.async_get_data()  # May raise authentication/communication errors
+    await client.async_get_summary()  # May raise authentication/communication errors
 
 
 __all__ = [

--- a/daynest-home-assistant/custom_components/daynest/config_flow_handler/validators/credentials.py
+++ b/daynest-home-assistant/custom_components/daynest/config_flow_handler/validators/credentials.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from custom_components.daynest.api import DaynestApiClient
-from homeassistant.helpers.aiohttp_client import async_create_clientsession
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
 if TYPE_CHECKING:
     from homeassistant.core import HomeAssistant
@@ -38,7 +38,7 @@ async def validate_credentials(hass: HomeAssistant, username: str, password: str
     client = DaynestApiClient(
         username=username,
         password=password,
-        session=async_create_clientsession(hass),
+        session=async_get_clientsession(hass),
     )
     await client.async_get_data()  # May raise authentication/communication errors
 

--- a/daynest-home-assistant/custom_components/daynest/const.py
+++ b/daynest-home-assistant/custom_components/daynest/const.py
@@ -7,6 +7,7 @@ LOGGER: Logger = getLogger(__package__)
 # Integration metadata
 DOMAIN = "daynest"
 ATTRIBUTION = "Data provided by http://jsonplaceholder.typicode.com/"
+DEFAULT_API_BASE_URL = "https://jsonplaceholder.typicode.com"
 
 # Platform parallel updates - applied to all platforms
 PARALLEL_UPDATES = 1

--- a/daynest-home-assistant/custom_components/daynest/const.py
+++ b/daynest-home-assistant/custom_components/daynest/const.py
@@ -6,8 +6,10 @@ LOGGER: Logger = getLogger(__package__)
 
 # Integration metadata
 DOMAIN = "daynest"
-ATTRIBUTION = "Data provided by http://jsonplaceholder.typicode.com/"
+ATTRIBUTION = "Data provided by https://jsonplaceholder.typicode.com/"
 DEFAULT_API_BASE_URL = "https://jsonplaceholder.typicode.com"
+SUPPORTED_INTEGRATION_CONTRACT_VERSIONS = frozenset({"ha.v1"})
+LEGACY_CONTRACT_VERSION_ALIASES = {"1": "ha.v1"}
 
 # Platform parallel updates - applied to all platforms
 PARALLEL_UPDATES = 1
@@ -15,3 +17,22 @@ PARALLEL_UPDATES = 1
 # Default configuration values
 DEFAULT_UPDATE_INTERVAL_HOURS = 1
 DEFAULT_ENABLE_DEBUGGING = False
+
+
+def parse_integration_contract_version(contract: str | None) -> str | None:
+    """Extract and normalize the version token from a contract header value."""
+    if contract is None:
+        return None
+
+    normalized_contract = contract.strip()
+    if not normalized_contract:
+        return None
+
+    version_token = normalized_contract
+    for segment in normalized_contract.split(";"):
+        key, separator, value = segment.strip().partition("=")
+        if separator and key == "version":
+            version_token = value.strip()
+            break
+
+    return LEGACY_CONTRACT_VERSION_ALIASES.get(version_token, version_token)

--- a/daynest-home-assistant/custom_components/daynest/coordinator.py
+++ b/daynest-home-assistant/custom_components/daynest/coordinator.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from datetime import timedelta
 from typing import Any
 
+from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
@@ -15,10 +16,10 @@ from .api import (
     DaynestApiClientError,
     DaynestApiClientMalformedResponseError,
 )
-from .const import DOMAIN, LOGGER
+from .const import DOMAIN, LOGGER, SUPPORTED_INTEGRATION_CONTRACT_VERSIONS, parse_integration_contract_version
 from .data import DaynestConfigEntry
 
-SUPPORTED_CONTRACT_VERSIONS = frozenset({"1"})
+SUPPORTED_CONTRACT_VERSIONS = SUPPORTED_INTEGRATION_CONTRACT_VERSIONS
 DASHBOARD_UPDATE_INTERVAL = timedelta(minutes=15)
 
 
@@ -45,7 +46,7 @@ class DaynestDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
 
     def __init__(
         self,
-        hass,
+        hass: HomeAssistant,
         config_entry: DaynestConfigEntry,
         client: DaynestApiClient,
     ) -> None:
@@ -62,23 +63,26 @@ class DaynestDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
 
     def _normalize_dashboard(self, payload: dict[str, Any], contract: str) -> dict[str, Any]:
         """Normalize dashboard payload into stable coordinator keys."""
-        next_medication = payload.get("nextMedication")
-        if not isinstance(next_medication, dict):
-            next_medication = None
+        next_medication = payload.get("next_medication")
+        if not isinstance(next_medication, (dict, str)) and next_medication is not None:
+            next_medication = str(next_medication)
 
-        completion_ratio = _safe_float(payload.get("completionRatio"), default=0.0)
+        completion_ratio = _safe_float(payload.get("completion_ratio"), default=0.0)
         completion_ratio = max(0.0, min(completion_ratio, 1.0))
 
         return {
-            "due_today_count": max(0, _safe_int(payload.get("dueTodayCount"), default=0)),
-            "overdue_count": max(0, _safe_int(payload.get("overdueCount"), default=0)),
+            "for_date": payload.get("for_date"),
+            "due_today_count": max(0, _safe_int(payload.get("due_today_count"), default=0)),
+            "overdue_count": max(0, _safe_int(payload.get("overdue_count"), default=0)),
+            "planned_count": max(0, _safe_int(payload.get("planned_count"), default=0)),
+            "medication_due_count": max(0, _safe_int(payload.get("medication_due_count"), default=0)),
             "completion_ratio": completion_ratio,
             "next_medication": next_medication,
             "integration_contract": contract,
-            # Compatibility keys for existing entities until they are migrated.
-            "userId": max(0, _safe_int(payload.get("userId"), default=0)),
-            "id": max(0, _safe_int(payload.get("id"), default=0)),
             "model": str(payload.get("model", "Daynest")),
+            # Compatibility keys for demo entities that still derive synthetic values from coordinator data.
+            "userId": max(0, _safe_int(payload.get("due_today_count"), default=0)),
+            "id": max(0, _safe_int(payload.get("overdue_count"), default=0)),
         }
 
     async def _async_update_data(self) -> dict[str, Any]:
@@ -94,11 +98,12 @@ class DaynestDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         except DaynestApiClientError as err:
             raise UpdateFailed(f"Unexpected API error while updating dashboard: {err}") from err
 
-        contract = response.integration_contract
-        if contract not in SUPPORTED_CONTRACT_VERSIONS:
-            raise UpdateFailed(f"Unsupported or missing integration contract header: {contract}")
+        parsed_contract = parse_integration_contract_version(response.integration_contract)
+        if parsed_contract not in SUPPORTED_CONTRACT_VERSIONS:
+            unsupported_token = parsed_contract or response.integration_contract or "missing"
+            raise UpdateFailed(f"Unsupported or missing integration contract version: {unsupported_token}")
 
-        return self._normalize_dashboard(response.data.payload, contract)
+        return self._normalize_dashboard(response.data.payload, parsed_contract)
 
 
 __all__ = ["DASHBOARD_UPDATE_INTERVAL", "DaynestDataUpdateCoordinator"]

--- a/daynest-home-assistant/custom_components/daynest/coordinator.py
+++ b/daynest-home-assistant/custom_components/daynest/coordinator.py
@@ -1,7 +1,104 @@
-"""Compatibility module for coordinator imports."""
+"""Data update coordinator for Daynest dashboard data."""
 
 from __future__ import annotations
 
-from .coordinator import DaynestDataUpdateCoordinator
+from datetime import timedelta
+from typing import Any
 
-__all__ = ["DaynestDataUpdateCoordinator"]
+from homeassistant.exceptions import ConfigEntryAuthFailed
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
+
+from .api import (
+    DaynestApiClient,
+    DaynestApiClientAuthenticationError,
+    DaynestApiClientCommunicationError,
+    DaynestApiClientError,
+    DaynestApiClientMalformedResponseError,
+)
+from .const import DOMAIN, LOGGER
+from .data import DaynestConfigEntry
+
+SUPPORTED_CONTRACT_VERSIONS = frozenset({"1"})
+DASHBOARD_UPDATE_INTERVAL = timedelta(minutes=15)
+
+
+def _safe_int(value: Any, default: int = 0) -> int:
+    """Convert a value to int with fallback."""
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _safe_float(value: Any, default: float = 0.0) -> float:
+    """Convert a value to float with fallback."""
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return default
+
+
+class DaynestDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
+    """Coordinator that fetches and normalizes Daynest dashboard data."""
+
+    config_entry: DaynestConfigEntry
+
+    def __init__(
+        self,
+        hass,
+        config_entry: DaynestConfigEntry,
+        client: DaynestApiClient,
+    ) -> None:
+        """Initialize the coordinator with fixed polling interval."""
+        super().__init__(
+            hass,
+            logger=LOGGER,
+            name=DOMAIN,
+            config_entry=config_entry,
+            update_interval=DASHBOARD_UPDATE_INTERVAL,
+            always_update=False,
+        )
+        self._client = client
+
+    def _normalize_dashboard(self, payload: dict[str, Any], contract: str) -> dict[str, Any]:
+        """Normalize dashboard payload into stable coordinator keys."""
+        next_medication = payload.get("nextMedication")
+        if not isinstance(next_medication, dict):
+            next_medication = None
+
+        completion_ratio = _safe_float(payload.get("completionRatio"), default=0.0)
+        completion_ratio = max(0.0, min(completion_ratio, 1.0))
+
+        return {
+            "due_today_count": max(0, _safe_int(payload.get("dueTodayCount"), default=0)),
+            "overdue_count": max(0, _safe_int(payload.get("overdueCount"), default=0)),
+            "completion_ratio": completion_ratio,
+            "next_medication": next_medication,
+            "integration_contract": contract,
+            # Compatibility keys for existing entities until they are migrated.
+            "userId": max(0, _safe_int(payload.get("userId"), default=0)),
+            "id": max(0, _safe_int(payload.get("id"), default=0)),
+            "model": str(payload.get("model", "Daynest")),
+        }
+
+    async def _async_update_data(self) -> dict[str, Any]:
+        """Fetch dashboard data and map backend errors to HA coordinator errors."""
+        try:
+            response = await self._client.async_get_dashboard()
+        except DaynestApiClientAuthenticationError as err:
+            raise ConfigEntryAuthFailed from err
+        except DaynestApiClientCommunicationError as err:
+            raise UpdateFailed(f"Temporary communication failure: {err}") from err
+        except DaynestApiClientMalformedResponseError as err:
+            raise UpdateFailed(f"Malformed dashboard response: {err}") from err
+        except DaynestApiClientError as err:
+            raise UpdateFailed(f"Unexpected API error while updating dashboard: {err}") from err
+
+        contract = response.integration_contract
+        if contract not in SUPPORTED_CONTRACT_VERSIONS:
+            raise UpdateFailed(f"Unsupported or missing integration contract header: {contract}")
+
+        return self._normalize_dashboard(response.data.payload, contract)
+
+
+__all__ = ["DASHBOARD_UPDATE_INTERVAL", "DaynestDataUpdateCoordinator"]

--- a/daynest-home-assistant/custom_components/daynest/coordinator/base.py
+++ b/daynest-home-assistant/custom_components/daynest/coordinator/base.py
@@ -11,21 +11,24 @@ https://developers.home-assistant.io/docs/integration_fetching_data#coordinated-
 
 from __future__ import annotations
 
+from datetime import timedelta
 from typing import TYPE_CHECKING, Any
 
 from custom_components.daynest.api import (
     DaynestApiClientAuthenticationError,
     DaynestApiClientError,
 )
-from custom_components.daynest.const import LOGGER
+from custom_components.daynest.const import DEFAULT_UPDATE_INTERVAL_HOURS, DOMAIN, LOGGER
 from homeassistant.exceptions import ConfigEntryAuthFailed
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
 if TYPE_CHECKING:
+    from custom_components.daynest.api import DaynestApiClient
     from custom_components.daynest.data import DaynestConfigEntry
+    from homeassistant.core import HomeAssistant
 
 
-class DaynestDataUpdateCoordinator(DataUpdateCoordinator):
+class DaynestDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
     """
     Class to manage fetching data from the API.
 
@@ -45,6 +48,23 @@ class DaynestDataUpdateCoordinator(DataUpdateCoordinator):
     """
 
     config_entry: DaynestConfigEntry
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        config_entry: DaynestConfigEntry,
+        client: DaynestApiClient,
+    ) -> None:
+        """Initialize the data update coordinator."""
+        super().__init__(
+            hass,
+            logger=LOGGER,
+            name=DOMAIN,
+            update_interval=timedelta(hours=DEFAULT_UPDATE_INTERVAL_HOURS),
+            always_update=False,
+        )
+        self.config_entry = config_entry
+        self._client = client
 
     async def _async_setup(self) -> None:
         """
@@ -107,7 +127,7 @@ class DaynestDataUpdateCoordinator(DataUpdateCoordinator):
             # Fetch data from API
             # In production, you could pass listening_contexts to optimize the API call:
             # return await self.config_entry.runtime_data.client.async_get_data(listening_contexts)
-            return await self.config_entry.runtime_data.client.async_get_data()
+            return await self._client.async_get_data()
         except DaynestApiClientAuthenticationError as exception:
             LOGGER.warning("Authentication error - %s", exception)
             raise ConfigEntryAuthFailed(
@@ -115,7 +135,7 @@ class DaynestDataUpdateCoordinator(DataUpdateCoordinator):
                 translation_key="authentication_failed",
             ) from exception
         except DaynestApiClientError as exception:
-            LOGGER.exception("Error communicating with API")
+            LOGGER.error("Error communicating with API: %s", exception)
             # If the API provides rate limit information, you can honor it:
             # if hasattr(exception, 'retry_after'):
             #     raise UpdateFailed(retry_after=exception.retry_after) from exception

--- a/daynest-home-assistant/custom_components/daynest/diagnostics.py
+++ b/daynest-home-assistant/custom_components/daynest/diagnostics.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
-from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
+from homeassistant.const import CONF_API_KEY, CONF_URL
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.redact import async_redact_data
 
@@ -19,11 +19,12 @@ if TYPE_CHECKING:
 
 # Fields to redact from diagnostics - CRITICAL for security!
 TO_REDACT = {
-    CONF_PASSWORD,
-    CONF_USERNAME,
+    CONF_API_KEY,
+    CONF_URL,
     "username",
     "password",
     "api_key",
+    "integration_key",
     "token",
 }
 
@@ -76,8 +77,7 @@ async def async_get_config_entry_diagnostics(
 
     # API client information (no sensitive data)
     api_info = {
-        "base_endpoint": "https://jsonplaceholder.typicode.com",
-        "has_credentials": bool(client._username),  # noqa: SLF001
+        "has_credentials": bool(client._password),  # noqa: SLF001
     }
 
     # Integration information

--- a/daynest-home-assistant/custom_components/daynest/diagnostics.py
+++ b/daynest-home-assistant/custom_components/daynest/diagnostics.py
@@ -77,7 +77,7 @@ async def async_get_config_entry_diagnostics(
 
     # API client information (no sensitive data)
     api_info = {
-        "has_credentials": bool(client._password),  # noqa: SLF001
+        "has_credentials": client.has_integration_key,
     }
 
     # Integration information

--- a/daynest-home-assistant/custom_components/daynest/diagnostics.py
+++ b/daynest-home-assistant/custom_components/daynest/diagnostics.py
@@ -115,8 +115,10 @@ async def async_get_config_entry_diagnostics(
         if isinstance(coordinator.data, dict):
             # Include sample data but sanitize sensitive info
             data_sample = {
-                "title": coordinator.data.get("title"),
-                "body_length": len(coordinator.data.get("body", "")) if coordinator.data.get("body") else 0,
+                "for_date": coordinator.data.get("for_date"),
+                "due_today_count": coordinator.data.get("due_today_count"),
+                "overdue_count": coordinator.data.get("overdue_count"),
+                "next_medication": coordinator.data.get("next_medication"),
                 "has_user_id": "userId" in coordinator.data,
             }
 

--- a/daynest-home-assistant/custom_components/daynest/fan/air_purifier_fan.py
+++ b/daynest-home-assistant/custom_components/daynest/fan/air_purifier_fan.py
@@ -32,8 +32,7 @@ class DaynestFan(FanEntity, DaynestEntity):
     """
     Air purifier fan entity.
 
-    This entity is linked to the fan_speed select entity - they control the same thing.
-    When you change one, the other updates automatically.
+    This entity controls the air purifier fan speed.
     """
 
     _attr_supported_features = FanEntityFeature.SET_SPEED | FanEntityFeature.TURN_ON | FanEntityFeature.TURN_OFF
@@ -65,11 +64,7 @@ class DaynestFan(FanEntity, DaynestEntity):
         return self._percentage
 
     async def async_set_percentage(self, percentage: int) -> None:
-        """
-        Set the speed percentage of the fan.
-
-        This also updates the fan_speed select entity to match.
-        """
+        """Set the speed percentage of the fan."""
         try:
             if percentage == 0:
                 await self.async_turn_off()
@@ -87,11 +82,6 @@ class DaynestFan(FanEntity, DaynestEntity):
 
             self._percentage = percentage
             self._is_on = True
-
-            # Store in coordinator data for select entity to read
-            # This creates a link: when you change the fan speed here,
-            # the fan_speed select entity will also update
-            self.coordinator.data["demo_fan_speed"] = speed_name
 
             # Request coordinator refresh - simulates: API call → device updates → fetch new state
             await self.coordinator.async_request_refresh()

--- a/daynest-home-assistant/custom_components/daynest/select/fan_speed.py
+++ b/daynest-home-assistant/custom_components/daynest/select/fan_speed.py
@@ -48,16 +48,7 @@ class DaynestFanSpeedSelect(SelectEntity, DaynestEntity):
 
     @property
     def current_option(self) -> str | None:
-        """
-        Return the current selected option.
-
-        Demo: This is linked to the fan entity - if you change the fan speed
-        slider there, this select will also update!
-        """
-        # Check if fan entity has set a speed
-        demo_speed = self.coordinator.data.get("demo_fan_speed")
-        if demo_speed and demo_speed in [speed.value for speed in FanSpeed]:
-            return demo_speed
+        """Return the current selected option."""
         return self._attr_current_option
 
     @property
@@ -73,11 +64,7 @@ class DaynestFanSpeedSelect(SelectEntity, DaynestEntity):
         return "mdi:fan-auto"
 
     async def async_select_option(self, option: str) -> None:
-        """
-        Change the selected option.
-
-        Demo: This also updates the fan entity - they're linked!
-        """
+        """Change the selected option."""
         LOGGER.debug("Setting fan speed to: %s", option)
 
         if option not in [speed.value for speed in FanSpeed]:
@@ -86,9 +73,6 @@ class DaynestFanSpeedSelect(SelectEntity, DaynestEntity):
 
         # In production: Call API to set fan speed
         # await self.coordinator.config_entry.runtime_data.client.async_set_fan_speed(option)
-
-        # Store in coordinator data so fan entity can read it
-        self.coordinator.data["demo_fan_speed"] = option
 
         self._attr_current_option = option
 

--- a/daynest-home-assistant/custom_components/daynest/sensor/__init__.py
+++ b/daynest-home-assistant/custom_components/daynest/sensor/__init__.py
@@ -9,6 +9,7 @@ from homeassistant.components.sensor import SensorEntityDescription
 
 from .air_quality import ENTITY_DESCRIPTIONS as AIR_QUALITY_DESCRIPTIONS, DaynestAirQualitySensor
 from .diagnostic import ENTITY_DESCRIPTIONS as DIAGNOSTIC_DESCRIPTIONS, DaynestDiagnosticSensor
+from .dashboard import ENTITY_DESCRIPTIONS as DASHBOARD_DESCRIPTIONS, DaynestDashboardSensor
 
 if TYPE_CHECKING:
     from custom_components.daynest.data import DaynestConfigEntry
@@ -19,6 +20,7 @@ if TYPE_CHECKING:
 ENTITY_DESCRIPTIONS: tuple[SensorEntityDescription, ...] = (
     *AIR_QUALITY_DESCRIPTIONS,
     *DIAGNOSTIC_DESCRIPTIONS,
+    *DASHBOARD_DESCRIPTIONS,
 )
 
 
@@ -43,4 +45,12 @@ async def async_setup_entry(
             entity_description=entity_description,
         )
         for entity_description in DIAGNOSTIC_DESCRIPTIONS
+    )
+    # Add dashboard sensors
+    async_add_entities(
+        DaynestDashboardSensor(
+            coordinator=entry.runtime_data.coordinator,
+            entity_description=entity_description,
+        )
+        for entity_description in DASHBOARD_DESCRIPTIONS
     )

--- a/daynest-home-assistant/custom_components/daynest/sensor/dashboard.py
+++ b/daynest-home-assistant/custom_components/daynest/sensor/dashboard.py
@@ -5,13 +5,14 @@ from __future__ import annotations
 from datetime import datetime
 from typing import TYPE_CHECKING, Any
 
-from custom_components.daynest.entity import DaynestEntity
 from homeassistant.components.sensor import SensorEntity, SensorEntityDescription, SensorStateClass
 from homeassistant.const import PERCENTAGE
 from homeassistant.util import dt as dt_util
 
+from ..entity import DaynestEntity
+
 if TYPE_CHECKING:
-    from custom_components.daynest.coordinator import DaynestDataUpdateCoordinator
+    from ..coordinator import DaynestDataUpdateCoordinator
 
 ENTITY_DESCRIPTIONS = (
     SensorEntityDescription(
@@ -51,14 +52,6 @@ ENTITY_DESCRIPTIONS = (
 class DaynestDashboardSensor(SensorEntity, DaynestEntity):
     """Dashboard sensor class for care metrics."""
 
-    def __init__(
-        self,
-        coordinator: DaynestDataUpdateCoordinator,
-        entity_description: SensorEntityDescription,
-    ) -> None:
-        """Initialize the dashboard sensor."""
-        super().__init__(coordinator, entity_description)
-
     @property
     def native_value(self) -> int | float | str | datetime | None:
         """Return the sensor's state."""
@@ -74,10 +67,14 @@ class DaynestDashboardSensor(SensorEntity, DaynestEntity):
             return round(ratio * 100, 1)
 
         if key == "next_medication":
+            next_medication = self.coordinator.data.get("next_medication")
+            if isinstance(next_medication, str):
+                return next_medication
+
             medication = self._next_medication
             if medication is None:
                 return None
-            for field in ("name", "medicationName", "title", "id"):
+            for field in ("name", "medication_name", "medicationName", "title", "id"):
                 if (value := medication.get(field)) is not None:
                     return str(value)
             return None
@@ -94,7 +91,11 @@ class DaynestDashboardSensor(SensorEntity, DaynestEntity):
         if medication is None:
             return None
 
-        due_at = medication.get("dueAt")
+        due_at = medication.get("due_at")
+        if due_at is None:
+            due_at = medication.get("dueAt")
+        if due_at is None:
+            due_at = medication.get("scheduled_at")
         if due_at is None:
             due_at = medication.get("scheduledAt")
         if due_at is None:
@@ -106,11 +107,13 @@ class DaynestDashboardSensor(SensorEntity, DaynestEntity):
         else:
             parsed_due = None
 
+        due_at_str = parsed_due.isoformat() if parsed_due else str(due_at) if due_at is not None else None
+
         return {
             "medication_id": medication.get("id"),
             "dosage": medication.get("dosage"),
             "instructions": medication.get("instructions"),
-            "due_at": parsed_due.isoformat() if parsed_due is not None else due_at,
+            "due_at": due_at_str,
         }
 
     @property

--- a/daynest-home-assistant/custom_components/daynest/sensor/dashboard.py
+++ b/daynest-home-assistant/custom_components/daynest/sensor/dashboard.py
@@ -1,0 +1,122 @@
+"""Dashboard sensors for daynest."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import TYPE_CHECKING, Any
+
+from custom_components.daynest.entity import DaynestEntity
+from homeassistant.components.sensor import SensorEntity, SensorEntityDescription, SensorStateClass
+from homeassistant.const import PERCENTAGE
+from homeassistant.util import dt as dt_util
+
+if TYPE_CHECKING:
+    from custom_components.daynest.coordinator import DaynestDataUpdateCoordinator
+
+ENTITY_DESCRIPTIONS = (
+    SensorEntityDescription(
+        key="overdue_count",
+        translation_key="overdue_count",
+        icon="mdi:calendar-alert",
+        state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=0,
+        has_entity_name=True,
+    ),
+    SensorEntityDescription(
+        key="due_today_count",
+        translation_key="due_today_count",
+        icon="mdi:calendar-today",
+        state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=0,
+        has_entity_name=True,
+    ),
+    SensorEntityDescription(
+        key="completion_ratio",
+        translation_key="completion_ratio",
+        icon="mdi:chart-donut",
+        native_unit_of_measurement=PERCENTAGE,
+        state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=1,
+        has_entity_name=True,
+    ),
+    SensorEntityDescription(
+        key="next_medication",
+        translation_key="next_medication",
+        icon="mdi:pill",
+        has_entity_name=True,
+    ),
+)
+
+
+class DaynestDashboardSensor(SensorEntity, DaynestEntity):
+    """Dashboard sensor class for care metrics."""
+
+    def __init__(
+        self,
+        coordinator: DaynestDataUpdateCoordinator,
+        entity_description: SensorEntityDescription,
+    ) -> None:
+        """Initialize the dashboard sensor."""
+        super().__init__(coordinator, entity_description)
+
+    @property
+    def native_value(self) -> int | float | str | datetime | None:
+        """Return the sensor's state."""
+        if not self.coordinator.last_update_success:
+            return None
+
+        key = self.entity_description.key
+        if key in {"overdue_count", "due_today_count"}:
+            return self.coordinator.data[key]
+
+        if key == "completion_ratio":
+            ratio = self.coordinator.data["completion_ratio"]
+            return round(ratio * 100, 1)
+
+        if key == "next_medication":
+            medication = self._next_medication
+            if medication is None:
+                return None
+            for field in ("name", "medicationName", "title", "id"):
+                if (value := medication.get(field)) is not None:
+                    return str(value)
+            return None
+
+        return None
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any] | None:
+        """Return extra attributes for richer dashboard context."""
+        if self.entity_description.key != "next_medication" or not self.coordinator.last_update_success:
+            return None
+
+        medication = self._next_medication
+        if medication is None:
+            return None
+
+        due_at = medication.get("dueAt")
+        if due_at is None:
+            due_at = medication.get("scheduledAt")
+        if due_at is None:
+            due_at = medication.get("timestamp")
+        if isinstance(due_at, datetime):
+            parsed_due = due_at
+        elif isinstance(due_at, str):
+            parsed_due = dt_util.parse_datetime(due_at)
+        else:
+            parsed_due = None
+
+        return {
+            "medication_id": medication.get("id"),
+            "dosage": medication.get("dosage"),
+            "instructions": medication.get("instructions"),
+            "due_at": parsed_due.isoformat() if parsed_due is not None else due_at,
+        }
+
+    @property
+    def _next_medication(self) -> dict[str, Any] | None:
+        """Return the normalized next medication payload."""
+        next_medication = self.coordinator.data.get("next_medication")
+        if isinstance(next_medication, dict):
+            return next_medication
+        return None

--- a/daynest-home-assistant/custom_components/daynest/sensor/diagnostic.py
+++ b/daynest-home-assistant/custom_components/daynest/sensor/diagnostic.py
@@ -60,9 +60,6 @@ class DaynestDiagnosticSensor(SensorEntity, DaynestEntity):
 
         # Filter life remaining (0-100%)
         if self.entity_description.key == "filter_life":
-            # Demo: If reset button was pressed, show 100%!
-            if self.coordinator.data.get("demo_filter_reset"):
-                return 100
             return 100 - (user_id % 100)
 
         # Total runtime in hours

--- a/daynest-home-assistant/custom_components/daynest/translations/en.json
+++ b/daynest-home-assistant/custom_components/daynest/translations/en.json
@@ -4,8 +4,8 @@
       "user": {
         "description": "If you need help with the configuration have a look at the [documentation]({documentation_url}).",
         "data": {
-          "username": "Username",
-          "password": "Password"
+          "url": "Daynest base URL",
+          "api_key": "Integration API key"
         }
       },
       "reconfigure": {
@@ -25,8 +25,10 @@
       }
     },
     "error": {
-      "auth": "Username/Password is wrong.",
-      "connection": "Unable to connect to the server.",
+      "invalid_auth": "The API key is invalid or missing the required ha:read scope.",
+      "cannot_connect": "Unable to reach the Daynest host.",
+      "timeout": "Connection to Daynest timed out.",
+      "unsupported_contract": "The Daynest server contract version is not supported by this integration.",
       "unknown": "Unknown error occurred."
     },
     "abort": {
@@ -81,6 +83,18 @@
       },
       "runtime": {
         "name": "Total Runtime"
+      },
+      "overdue_count": {
+        "name": "Overdue Count"
+      },
+      "completion_ratio": {
+        "name": "Completion Ratio"
+      },
+      "next_medication": {
+        "name": "Next Medication"
+      },
+      "due_today_count": {
+        "name": "Due Today Count"
       }
     },
     "binary_sensor": {

--- a/daynest-home-assistant/custom_components/daynest/translations/en.json
+++ b/daynest-home-assistant/custom_components/daynest/translations/en.json
@@ -7,21 +7,6 @@
           "url": "Daynest base URL",
           "api_key": "Integration API key"
         }
-      },
-      "reconfigure": {
-        "description": "Update the credentials for this integration.",
-        "data": {
-          "username": "Username",
-          "password": "Password"
-        }
-      },
-      "reauth_confirm": {
-        "title": "Reauthenticate Integration",
-        "description": "The credentials for {username} are no longer valid. Please provide updated credentials to restore access.",
-        "data": {
-          "username": "Username",
-          "password": "Password"
-        }
       }
     },
     "error": {

--- a/daynest-home-assistant/docs/user/BACKEND_INTEGRATION_HOME_ASSISTANT.md
+++ b/daynest-home-assistant/docs/user/BACKEND_INTEGRATION_HOME_ASSISTANT.md
@@ -40,12 +40,11 @@ Purpose: Lightweight setup-time validation of the configured base URL and integr
 Expected behavior:
 
 - Returns `200 OK`
-- Returns `X-Integration-Contract: 1`
+- Returns `X-Integration-Contract: home-assistant; version=ha.v1`
 - Returns a JSON object with these required fields:
-  - `userId`
-  - `id`
-  - `title`
-  - `body`
+  - `todo_daynest_today`
+  - `sensor_daynest_overdue_count`
+  - `sensor_daynest_next_medication`
 
 ### `GET /api/v1/integrations/home-assistant/dashboard`
 
@@ -54,15 +53,15 @@ Purpose: Returns dashboard data consumed by Home Assistant sensor entities.
 Expected behavior:
 
 - Returns `200 OK`
-- Returns `X-Integration-Contract: 1`
+- Returns `X-Integration-Contract: home-assistant; version=ha.v1`
 - Returns a JSON object. The integration currently consumes:
-  - `dueTodayCount`
-  - `overdueCount`
-  - `completionRatio`
-  - `nextMedication`
-  - `userId`
-  - `id`
-  - `model`
+  - `for_date`
+  - `due_today_count`
+  - `overdue_count`
+  - `planned_count`
+  - `medication_due_count`
+  - `completion_ratio`
+  - `next_medication`
 
 ## Common Errors and Fixes
 
@@ -110,6 +109,6 @@ Fixes:
 
 - [ ] API key includes `ha:read`
 - [ ] Base URL is HTTPS and reachable from Home Assistant
-- [ ] `GET /api/v1/integrations/home-assistant/summary` returns `200 OK`, `X-Integration-Contract: 1`, and the required summary fields
-- [ ] `GET /api/v1/integrations/home-assistant/dashboard` returns `200 OK`, `X-Integration-Contract: 1`, and a JSON object
+- [ ] `GET /api/v1/integrations/home-assistant/summary` returns `200 OK`, `X-Integration-Contract: home-assistant; version=ha.v1`, and the required summary fields
+- [ ] `GET /api/v1/integrations/home-assistant/dashboard` returns `200 OK`, `X-Integration-Contract: home-assistant; version=ha.v1`, and a JSON object
 - [ ] Integration loads without entity availability errors

--- a/daynest-home-assistant/docs/user/BACKEND_INTEGRATION_HOME_ASSISTANT.md
+++ b/daynest-home-assistant/docs/user/BACKEND_INTEGRATION_HOME_ASSISTANT.md
@@ -1,0 +1,115 @@
+# Connect Daynest from a Home Assistant Custom Integration
+
+This guide explains the backend contract expected when connecting Daynest from a Home Assistant custom integration.
+
+## Authentication Requirements
+
+- Use an API key that includes the required scope: `ha:read`
+- Send the API key using the `X-Integration-Key` header:
+
+  ```http
+  X-Integration-Key: <DAYNEST_API_KEY>
+  ```
+
+If the API key is missing the `ha:read` scope, Home Assistant will not be able to fetch Daynest data.
+
+## Base URL Requirements
+
+Use the fully-qualified HTTPS origin for the Daynest backend:
+
+- ✅ `https://api.daynest.example`
+- ❌ `http://api.daynest.example` (HTTP not recommended)
+- ❌ `api.daynest.example` (scheme missing)
+- ❌ `https://api.daynest.example/v1` (the integration appends `/api/v1/...` paths)
+
+Guidelines:
+
+- Include scheme (`https://`)
+- Use a reachable host from the Home Assistant runtime environment
+- Avoid including API version path segments in the configured base URL
+- Avoid trailing slash in stored configuration to prevent double-slash request paths
+
+## Expected Endpoints
+
+The Home Assistant custom integration expects these read endpoints to be available under the configured base URL.
+
+### `GET /api/v1/integrations/home-assistant/summary`
+
+Purpose: Lightweight setup-time validation of the configured base URL and integration key.
+
+Expected behavior:
+
+- Returns `200 OK`
+- Returns `X-Integration-Contract: 1`
+- Returns a JSON object with these required fields:
+  - `userId`
+  - `id`
+  - `title`
+  - `body`
+
+### `GET /api/v1/integrations/home-assistant/dashboard`
+
+Purpose: Returns dashboard data consumed by Home Assistant sensor entities.
+
+Expected behavior:
+
+- Returns `200 OK`
+- Returns `X-Integration-Contract: 1`
+- Returns a JSON object. The integration currently consumes:
+  - `dueTodayCount`
+  - `overdueCount`
+  - `completionRatio`
+  - `nextMedication`
+  - `userId`
+  - `id`
+  - `model`
+
+## Common Errors and Fixes
+
+### Invalid API Key
+
+Symptoms:
+
+- Setup fails with unauthorized/forbidden errors (`401` or `403`)
+- Entities remain unavailable after setup
+
+Fixes:
+
+1. Verify the key is copied exactly (no extra spaces/newlines)
+2. Verify the key has the `ha:read` scope
+3. Regenerate the key and update the integration configuration if needed
+
+### Network Errors
+
+Symptoms:
+
+- Timeout, DNS, or connection refused errors
+- Setup validation or dashboard refresh fails intermittently
+
+Fixes:
+
+1. Confirm Home Assistant can resolve and reach the backend hostname
+2. Verify firewall, reverse proxy, and TLS certificate configuration
+3. Confirm base URL uses the correct scheme/port/path
+
+### Contract Mismatch
+
+Symptoms:
+
+- Parsing errors in logs
+- Sensors appear as unavailable despite successful authentication
+- Diagnostics show missing expected fields
+
+Fixes:
+
+1. Ensure expected endpoints exist and return JSON
+2. Ensure response keys and data types match the integration contract
+3. Validate endpoint versioning (`/api/v1/integrations/home-assistant/...`) matches the configured backend
+
+## Validation Checklist
+
+- [ ] API key includes `ha:read`
+- [ ] Base URL is HTTPS and reachable from Home Assistant
+- [ ] `GET /api/v1/integrations/home-assistant/summary` returns `200 OK`, `X-Integration-Contract: 1`, and the required summary fields
+- [ ] `GET /api/v1/integrations/home-assistant/dashboard` returns `200 OK`, `X-Integration-Contract: 1`, and a JSON object
+- [ ] Integration loads without entity availability errors

--- a/daynest-home-assistant/hacs.json
+++ b/daynest-home-assistant/hacs.json
@@ -1,5 +1,7 @@
 {
   "name": "Daynest",
+  "content_in_root": false,
+  "render_readme": true,
   "homeassistant": "2026.4.0",
   "hacs": "2.0.5"
 }


### PR DESCRIPTION
### Motivation
- Replace the placeholder client with a real, thin HTTP client that calls the Daynest backend endpoints used by the coordinator and supports contract/version checks from the backend.
- Surface clear, typed parsing and distinct exception types so caller code (coordinator, config flow validators) can react to auth, timeout, server, and payload errors deterministically.

### Description
- Added `custom_components/daynest/api/client.py` implementing `DaynestApiClient` with `async_get_summary`, `async_get_dashboard`, and `async_get_data` that call:
  - `/api/v1/integrations/home-assistant/summary` and `/api/v1/integrations/home-assistant/dashboard` and send `X-Integration-Key` when configured.
- Introduced typed models `DaynestSummary` and `DaynestDashboard`, and a generic `DaynestApiResponse[T]` wrapper that carries the parsed model and the `X-Integration-Contract` value; the client also exposes `last_integration_contract`.
- Added explicit exception classes `DaynestApiClientAuthenticationError`, `DaynestApiClientTimeoutError`, `DaynestApiClientServerUnavailableError`, `DaynestApiClientMalformedResponseError`, and `DaynestApiClientCommunicationError` and mapped transport/status failures into them.
- Updated `custom_components/daynest/api/__init__.py` to export the new models and exception types, and preserved backward-compatible parameter aliases (`username`/`password`) while making `base_url` and `integration_key` the primary inputs.

### Testing
- Attempted `script/python` which failed due to the workspace virtual environment not being initialized in this container; result: failed.
- Attempted `script/type-check` which failed for the same virtual environment issue; result: failed.
- Attempted `script/setup/bootstrap` to prepare the environment which failed due to a missing `python3.14` shim in the local pyenv path; result: failed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ecc4540390832ea51ba3502790c8bc)