### PR TITLE
feat(sensor): add dashboard adherence sensors

### DIFF
--- a/backend/tests/test_integration_adapters.py
+++ b/backend/tests/test_integration_adapters.py
@@ -1,16 +1,37 @@
 from datetime import date, time
 
 from fastapi.testclient import TestClient
+from pytest import MonkeyPatch
 from sqlalchemy.orm import Session
 
 from app.api.dependencies.integration_auth import hash_integration_key
 from app.core.tokens import create_access_token
+from app.schemas.integration_contracts import (
+    HOME_ASSISTANT_ADAPTER,
+    HOME_ASSISTANT_CONTRACT_VERSION,
+    INTEGRATION_CONTRACT_HEADER,
+    integration_contract_header,
+)
 from app.models.chore_instance import ChoreInstance, ChoreStatus
 from app.models.chore_template import ChoreTemplate
 from app.models.integration_client import IntegrationClient
 from app.models.medication_plan import MedicationPlan
 from app.models.planned_item import PlannedItem
 from app.models.user import User
+
+
+HOME_ASSISTANT_ENDPOINTS = ("summary", "entities", "dashboard")
+FIXED_TODAY = date(2026, 1, 15)
+
+
+class FrozenDate(date):
+    @classmethod
+    def today(cls) -> date:
+        return FIXED_TODAY
+
+
+def _freeze_route_today(monkeypatch: MonkeyPatch, route_module: str) -> None:
+    monkeypatch.setattr(f"{route_module}.date", FrozenDate)
 
 
 def _create_user(db_session: Session, email: str) -> User:
@@ -41,6 +62,43 @@ def _create_integration_key(
     return raw_key
 
 
+def _create_home_assistant_fixture(db_session: Session, email: str) -> User:
+    user = _create_user(db_session, email)
+    template = ChoreTemplate(
+        user_id=user.id,
+        name="Home Assistant Template",
+        description=None,
+        start_date=FIXED_TODAY,
+        every_n_days=1,
+        is_active=True,
+    )
+    db_session.add(template)
+    db_session.commit()
+    db_session.refresh(template)
+    db_session.add(
+        ChoreInstance(
+            user_id=user.id,
+            chore_template_id=template.id,
+            title="Home Assistant Chore",
+            scheduled_date=FIXED_TODAY,
+            status=ChoreStatus.pending,
+        )
+    )
+    db_session.add(
+        MedicationPlan(
+            user_id=user.id,
+            name="Omega-3",
+            instructions="With lunch",
+            start_date=FIXED_TODAY,
+            schedule_time=time(12, 0),
+            every_n_days=1,
+            is_active=True,
+        )
+    )
+    db_session.commit()
+    return user
+
+
 def test_create_integration_client_and_list(client: TestClient, db_session: Session) -> None:
     user = _create_user(db_session, "client-create@example.com")
     token = create_access_token(user_id=user.id, email=user.email)
@@ -60,53 +118,115 @@ def test_create_integration_client_and_list(client: TestClient, db_session: Sess
     assert list_response.json()[0]["name"] == "Home Assistant"
 
 
-def test_home_assistant_requires_scope_and_returns_entities(client: TestClient, db_session: Session) -> None:
-    user = _create_user(db_session, "ha-scope@example.com")
-    template = ChoreTemplate(
-        user_id=user.id,
-        name="Trash Template",
-        description=None,
-        start_date=date.today(),
-        every_n_days=1,
-        is_active=True,
-    )
-    db_session.add(template)
-    db_session.commit()
-    db_session.refresh(template)
-    db_session.add(
-        ChoreInstance(
-            user_id=user.id,
-            chore_template_id=template.id,
-            title="Trash",
-            scheduled_date=date.today(),
-            status=ChoreStatus.pending,
-        )
-    )
-    db_session.add(
-        MedicationPlan(
-            user_id=user.id,
-            name="Vitamin D",
-            instructions="With breakfast",
-            start_date=date.today(),
-            schedule_time=time(8, 0),
-            every_n_days=1,
-            is_active=True,
-        )
-    )
-    db_session.commit()
-
+def test_home_assistant_routes_enforce_ha_read_scope(
+    client: TestClient,
+    db_session: Session,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    _freeze_route_today(monkeypatch, "app.api.routes.integrations.home_assistant")
+    user = _create_home_assistant_fixture(db_session, "ha-scope@example.com")
     wrong_key = _create_integration_key(db_session, user.id, scopes="mcp:read")
-    denied = client.get("/api/v1/integrations/home-assistant/entities", headers={"X-Integration-Key": wrong_key})
-    assert denied.status_code == 403
 
-    key = _create_integration_key(db_session, user.id, scopes="ha:read")
-    response = client.get("/api/v1/integrations/home-assistant/entities", headers={"X-Integration-Key": key})
-    assert response.status_code == 200
-    assert response.json()[0]["entity_id"] == "todo.daynest_tasks"
+    for endpoint in HOME_ASSISTANT_ENDPOINTS:
+        denied = client.get(
+            f"/api/v1/integrations/home-assistant/{endpoint}",
+            headers={"X-Integration-Key": wrong_key},
+        )
+        assert denied.status_code == 403
 
 
-def test_mcp_adapter_and_rate_limit(client: TestClient, db_session: Session) -> None:
+def test_home_assistant_summary_contract_is_stable(
+    client: TestClient,
+    db_session: Session,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    _freeze_route_today(monkeypatch, "app.api.routes.integrations.home_assistant")
+    user = _create_home_assistant_fixture(db_session, "ha-summary-contract@example.com")
+    ha_key = _create_integration_key(db_session, user.id, scopes="ha:read")
+    expected_contract = integration_contract_header(HOME_ASSISTANT_ADAPTER, HOME_ASSISTANT_CONTRACT_VERSION)
+
+    summary = client.get("/api/v1/integrations/home-assistant/summary", headers={"X-Integration-Key": ha_key})
+    assert summary.status_code == 200
+    assert summary.headers[INTEGRATION_CONTRACT_HEADER] == expected_contract
+    summary_payload = summary.json()
+    assert set(summary_payload.keys()) == {
+        "todo_daynest_today",
+        "sensor_daynest_overdue_count",
+        "sensor_daynest_next_medication",
+    }
+    assert isinstance(summary_payload["todo_daynest_today"], int)
+    assert isinstance(summary_payload["sensor_daynest_overdue_count"], int)
+    assert summary_payload["sensor_daynest_next_medication"] is None or isinstance(
+        summary_payload["sensor_daynest_next_medication"],
+        str,
+    )
+
+
+def test_home_assistant_entities_contract_is_stable(
+    client: TestClient,
+    db_session: Session,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    _freeze_route_today(monkeypatch, "app.api.routes.integrations.home_assistant")
+    user = _create_home_assistant_fixture(db_session, "ha-entities-contract@example.com")
+    ha_key = _create_integration_key(db_session, user.id, scopes="ha:read")
+    expected_contract = integration_contract_header(HOME_ASSISTANT_ADAPTER, HOME_ASSISTANT_CONTRACT_VERSION)
+
+    entities = client.get("/api/v1/integrations/home-assistant/entities", headers={"X-Integration-Key": ha_key})
+    assert entities.status_code == 200
+    assert entities.headers[INTEGRATION_CONTRACT_HEADER] == expected_contract
+    entities_payload = entities.json()
+    assert isinstance(entities_payload, list)
+    assert len(entities_payload) == 4
+    expected_entity_ids = {
+        "todo.daynest_tasks",
+        "sensor.daynest_overdue_count",
+        "sensor.daynest_completion_ratio",
+        "sensor.daynest_next_medication",
+    }
+    assert {item["entity_id"] for item in entities_payload} == expected_entity_ids
+    for item in entities_payload:
+        assert set(item.keys()) == {"entity_id", "state", "attributes"}
+        assert isinstance(item["state"], str)
+        assert isinstance(item["attributes"], dict)
+
+
+def test_home_assistant_dashboard_contract_is_stable(
+    client: TestClient,
+    db_session: Session,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    _freeze_route_today(monkeypatch, "app.api.routes.integrations.home_assistant")
+    user = _create_home_assistant_fixture(db_session, "ha-dashboard-contract@example.com")
+    ha_key = _create_integration_key(db_session, user.id, scopes="ha:read")
+    expected_contract = integration_contract_header(HOME_ASSISTANT_ADAPTER, HOME_ASSISTANT_CONTRACT_VERSION)
+
+    dashboard = client.get("/api/v1/integrations/home-assistant/dashboard", headers={"X-Integration-Key": ha_key})
+    assert dashboard.status_code == 200
+    assert dashboard.headers[INTEGRATION_CONTRACT_HEADER] == expected_contract
+    dashboard_payload = dashboard.json()
+    assert set(dashboard_payload.keys()) == {
+        "for_date",
+        "overdue_count",
+        "due_today_count",
+        "planned_count",
+        "medication_due_count",
+        "completion_ratio",
+        "next_medication",
+    }
+    assert isinstance(dashboard_payload["for_date"], str)
+    assert isinstance(dashboard_payload["overdue_count"], int)
+    assert isinstance(dashboard_payload["due_today_count"], int)
+    assert isinstance(dashboard_payload["planned_count"], int)
+    assert isinstance(dashboard_payload["medication_due_count"], int)
+    assert isinstance(dashboard_payload["completion_ratio"], float)
+    assert dashboard_payload["next_medication"] is None or isinstance(dashboard_payload["next_medication"], str)
+
+
+def test_mcp_adapter_and_rate_limit(client: TestClient, db_session: Session, monkeypatch: MonkeyPatch) -> None:
     import app.api.dependencies.integration_auth as auth_dep
+
+    _freeze_route_today(monkeypatch, "app.api.routes.integrations.mcp")
     auth_dep._request_log.clear()
 
     user = _create_user(db_session, "mcp-rate@example.com")
@@ -114,7 +234,7 @@ def test_mcp_adapter_and_rate_limit(client: TestClient, db_session: Session) -> 
         PlannedItem(
             user_id=user.id,
             title="Weekly planning",
-            planned_for=date.today(),
+            planned_for=FIXED_TODAY,
             notes="sync",
             is_done=False,
         )

--- a/daynest-home-assistant/CHANGELOG.md
+++ b/daynest-home-assistant/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+
+All notable changes to this project are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project uses release-please to generate release entries.
+
+## [0.1.0] - 2026-04-25
+
+### Added
+
+- Initial release of the Daynest Home Assistant custom integration.

--- a/daynest-home-assistant/README.md
+++ b/daynest-home-assistant/README.md
@@ -55,7 +55,7 @@ Uncomment and customize these badges if you want to use them:
 
 Click the button below to open the integration directly in HACS:
 
-[![Open your Home Assistant instance and open a repository inside the Home Assistant Community Store.](https://my.home-assistant.io/badges/hacs_repository.svg)](https://my.home-assistant.io/redirect/hacs_repository/?owner=jpawlowski&repository=daynest-home-assistant&category=integration)
+[![Open your Home Assistant instance and open a repository inside the Home Assistant Community Store.](https://my.home-assistant.io/badges/hacs_repository.svg)](https://my.home-assistant.io/redirect/hacs_repository/?owner=daynest&repository=daynest-home-assistant&category=integration)
 
 Then:
 
@@ -126,6 +126,65 @@ The integration creates several entities for your air purifier:
 - **Fan**: Air purifier fan control
 
 Find all entities in **Settings** → **Devices & Services** → **Daynest** → click on the device.
+
+## Integration Docs
+
+- [Getting Started](docs/user/GETTING_STARTED.md) - Installation and initial setup
+- [Configuration](docs/user/CONFIGURATION.md) - Detailed configuration options
+- [Examples](docs/user/EXAMPLES.md) - Automation and dashboard examples
+- [Backend Integration: Home Assistant Custom Integration](docs/user/BACKEND_INTEGRATION_HOME_ASSISTANT.md) - API scope, base URL, endpoints, and error handling guidance
+
+## HACS Repository Structure
+
+This repository is structured for direct HACS installation:
+
+- `hacs.json` exists in the repository root and defines HACS metadata
+- Integration code is located at `custom_components/daynest/`
+- `custom_components/daynest/manifest.json` includes the integration `version`
+- `README.md` is rendered in HACS for install/setup guidance
+
+## Compatibility Matrix (Integration ↔ Backend Contract)
+
+The integration includes the backend contract expectation using the `X-Integration-Contract` header. Keep backend behavior aligned with the matrix below during upgrades.
+
+| Integration version | Expected `X-Integration-Contract` | Backend expectation |
+| --- | --- | --- |
+| `0.1.x` | `1` | Supports `GET /api/v1/integrations/home-assistant/summary` and `GET /api/v1/integrations/home-assistant/dashboard` contract documented in [the backend integration guide](docs/user/BACKEND_INTEGRATION_HOME_ASSISTANT.md). |
+
+> [!NOTE]
+> When introducing a new backend contract (`2`, etc.), add a new row before release and document compatibility or migration notes in `CHANGELOG.md`.
+
+## Release Checklist
+
+Use this checklist before and after publishing each integration release.
+
+### 1) Version tagging
+
+- [ ] Confirm `custom_components/daynest/manifest.json` version is correct (`./script/version`)
+- [ ] Confirm release tag format is `vX.Y.Z` and matches `manifest.json`
+- [ ] Verify `.release-please-manifest.json` is aligned (`./script/version --check`)
+
+### 2) Changelog updates
+
+- [ ] Verify `CHANGELOG.md` includes all user-facing changes for the release
+- [ ] Ensure compatibility or migration notes are present for contract changes
+- [ ] Ensure non-user-facing internal changes remain excluded (per release-please config)
+
+### 3) Daynest backend contract compatibility notes
+
+- [ ] Confirm the compatibility matrix in this README is updated for the new version
+- [ ] Confirm backend expectation still matches integration requests and payload parsing
+- [ ] If contract changed, include explicit upgrade notes and rollback guidance
+
+### 4) Post-release validation in a real Home Assistant instance
+
+- [ ] Install from HACS in a non-dev Home Assistant instance and restart HA
+- [ ] Add or reconfigure the Daynest integration through UI config flow
+- [ ] Validate entities load and update (`sensor`, `binary_sensor`, `fan`, `select`, `number`, `button`, `switch`)
+- [ ] Execute `daynest.reload_data` and verify coordinator refresh succeeds
+- [ ] Check Home Assistant logs for auth, schema, and availability errors
+- [ ] Validate diagnostics redaction and confirm no secrets are exposed
+- [ ] Verify upgrade path from previous release (no orphaned entities or broken config entries)
 
 ## Available Entities
 

--- a/daynest-home-assistant/custom_components/daynest/sensor/__init__.py
+++ b/daynest-home-assistant/custom_components/daynest/sensor/__init__.py
@@ -9,6 +9,7 @@ from homeassistant.components.sensor import SensorEntityDescription
 
 from .air_quality import ENTITY_DESCRIPTIONS as AIR_QUALITY_DESCRIPTIONS, DaynestAirQualitySensor
 from .diagnostic import ENTITY_DESCRIPTIONS as DIAGNOSTIC_DESCRIPTIONS, DaynestDiagnosticSensor
+from .dashboard import ENTITY_DESCRIPTIONS as DASHBOARD_DESCRIPTIONS, DaynestDashboardSensor
 
 if TYPE_CHECKING:
     from custom_components.daynest.data import DaynestConfigEntry
@@ -19,6 +20,7 @@ if TYPE_CHECKING:
 ENTITY_DESCRIPTIONS: tuple[SensorEntityDescription, ...] = (
     *AIR_QUALITY_DESCRIPTIONS,
     *DIAGNOSTIC_DESCRIPTIONS,
+    *DASHBOARD_DESCRIPTIONS,
 )
 
 
@@ -43,4 +45,12 @@ async def async_setup_entry(
             entity_description=entity_description,
         )
         for entity_description in DIAGNOSTIC_DESCRIPTIONS
+    )
+    # Add dashboard sensors
+    async_add_entities(
+        DaynestDashboardSensor(
+            coordinator=entry.runtime_data.coordinator,
+            entity_description=entity_description,
+        )
+        for entity_description in DASHBOARD_DESCRIPTIONS
     )

--- a/daynest-home-assistant/custom_components/daynest/sensor/dashboard.py
+++ b/daynest-home-assistant/custom_components/daynest/sensor/dashboard.py
@@ -1,0 +1,116 @@
+"""Dashboard sensors for daynest."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import TYPE_CHECKING, Any
+
+from custom_components.daynest.entity import DaynestEntity
+from homeassistant.components.sensor import SensorEntity, SensorEntityDescription, SensorStateClass
+from homeassistant.const import PERCENTAGE
+from homeassistant.util import dt as dt_util
+
+if TYPE_CHECKING:
+    from custom_components.daynest.coordinator import DaynestDataUpdateCoordinator
+
+ENTITY_DESCRIPTIONS = (
+    SensorEntityDescription(
+        key="overdue_count",
+        translation_key="overdue_count",
+        icon="mdi:calendar-alert",
+        state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=0,
+        has_entity_name=True,
+    ),
+    SensorEntityDescription(
+        key="due_today_count",
+        translation_key="due_today_count",
+        icon="mdi:calendar-today",
+        state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=0,
+        has_entity_name=True,
+    ),
+    SensorEntityDescription(
+        key="completion_ratio",
+        translation_key="completion_ratio",
+        icon="mdi:chart-donut",
+        native_unit_of_measurement=PERCENTAGE,
+        state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=1,
+        has_entity_name=True,
+    ),
+    SensorEntityDescription(
+        key="next_medication",
+        translation_key="next_medication",
+        icon="mdi:pill",
+        has_entity_name=True,
+    ),
+)
+
+
+class DaynestDashboardSensor(SensorEntity, DaynestEntity):
+    """Dashboard sensor class for care metrics."""
+
+    def __init__(
+        self,
+        coordinator: DaynestDataUpdateCoordinator,
+        entity_description: SensorEntityDescription,
+    ) -> None:
+        """Initialize the dashboard sensor."""
+        super().__init__(coordinator, entity_description)
+
+    @property
+    def native_value(self) -> int | float | str | datetime | None:
+        """Return the sensor's state."""
+        if not self.coordinator.last_update_success:
+            return None
+
+        key = self.entity_description.key
+        if key in {"overdue_count", "due_today_count"}:
+            return int(self.coordinator.data.get(key, 0))
+
+        if key == "completion_ratio":
+            ratio = float(self.coordinator.data.get("completion_ratio", 0.0))
+            return round(ratio * 100, 1)
+
+        if key == "next_medication":
+            medication = self._next_medication
+            if medication is None:
+                return None
+            return str(
+                medication.get("name")
+                or medication.get("medicationName")
+                or medication.get("title")
+                or medication.get("id")
+                or ""
+            ) or None
+
+        return None
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any] | None:
+        """Return extra attributes for richer dashboard context."""
+        if self.entity_description.key != "next_medication" or not self.coordinator.last_update_success:
+            return None
+
+        medication = self._next_medication
+        if medication is None:
+            return None
+
+        due_at = medication.get("dueAt") or medication.get("scheduledAt") or medication.get("timestamp")
+        parsed_due = dt_util.parse_datetime(str(due_at)) if due_at is not None else None
+
+        return {
+            "medication_id": medication.get("id"),
+            "dosage": medication.get("dosage"),
+            "instructions": medication.get("instructions"),
+            "due_at": parsed_due.isoformat() if parsed_due is not None else due_at,
+        }
+
+    @property
+    def _next_medication(self) -> dict[str, Any] | None:
+        """Return the normalized next medication payload."""
+        next_medication = self.coordinator.data.get("next_medication")
+        if isinstance(next_medication, dict):
+            return next_medication
+        return None

--- a/daynest-home-assistant/custom_components/daynest/sensor/dashboard.py
+++ b/daynest-home-assistant/custom_components/daynest/sensor/dashboard.py
@@ -67,23 +67,20 @@ class DaynestDashboardSensor(SensorEntity, DaynestEntity):
 
         key = self.entity_description.key
         if key in {"overdue_count", "due_today_count"}:
-            return int(self.coordinator.data.get(key, 0))
+            return self.coordinator.data[key]
 
         if key == "completion_ratio":
-            ratio = float(self.coordinator.data.get("completion_ratio", 0.0))
+            ratio = self.coordinator.data["completion_ratio"]
             return round(ratio * 100, 1)
 
         if key == "next_medication":
             medication = self._next_medication
             if medication is None:
                 return None
-            return str(
-                medication.get("name")
-                or medication.get("medicationName")
-                or medication.get("title")
-                or medication.get("id")
-                or ""
-            ) or None
+            for field in ("name", "medicationName", "title", "id"):
+                if (value := medication.get(field)) is not None:
+                    return str(value)
+            return None
 
         return None
 
@@ -97,8 +94,17 @@ class DaynestDashboardSensor(SensorEntity, DaynestEntity):
         if medication is None:
             return None
 
-        due_at = medication.get("dueAt") or medication.get("scheduledAt") or medication.get("timestamp")
-        parsed_due = dt_util.parse_datetime(str(due_at)) if due_at is not None else None
+        due_at = medication.get("dueAt")
+        if due_at is None:
+            due_at = medication.get("scheduledAt")
+        if due_at is None:
+            due_at = medication.get("timestamp")
+        if isinstance(due_at, datetime):
+            parsed_due = due_at
+        elif isinstance(due_at, str):
+            parsed_due = dt_util.parse_datetime(due_at)
+        else:
+            parsed_due = None
 
         return {
             "medication_id": medication.get("id"),

--- a/daynest-home-assistant/custom_components/daynest/translations/en.json
+++ b/daynest-home-assistant/custom_components/daynest/translations/en.json
@@ -83,6 +83,18 @@
       },
       "runtime": {
         "name": "Total Runtime"
+      },
+      "overdue_count": {
+        "name": "Overdue Count"
+      },
+      "completion_ratio": {
+        "name": "Completion Ratio"
+      },
+      "next_medication": {
+        "name": "Next Medication"
+      },
+      "due_today_count": {
+        "name": "Due Today Count"
       }
     },
     "binary_sensor": {

--- a/daynest-home-assistant/docs/user/BACKEND_INTEGRATION_HOME_ASSISTANT.md
+++ b/daynest-home-assistant/docs/user/BACKEND_INTEGRATION_HOME_ASSISTANT.md
@@ -1,0 +1,115 @@
+# Connect Daynest from a Home Assistant Custom Integration
+
+This guide explains the backend contract expected when connecting Daynest from a Home Assistant custom integration.
+
+## Authentication Requirements
+
+- Use an API key that includes the required scope: `ha:read`
+- Send the API key using the `X-Integration-Key` header:
+
+  ```http
+  X-Integration-Key: <DAYNEST_API_KEY>
+  ```
+
+If the API key is missing the `ha:read` scope, Home Assistant will not be able to fetch Daynest data.
+
+## Base URL Requirements
+
+Use the fully-qualified HTTPS origin for the Daynest backend:
+
+- ✅ `https://api.daynest.example`
+- ❌ `http://api.daynest.example` (HTTP not recommended)
+- ❌ `api.daynest.example` (scheme missing)
+- ❌ `https://api.daynest.example/v1` (the integration appends `/api/v1/...` paths)
+
+Guidelines:
+
+- Include scheme (`https://`)
+- Use a reachable host from the Home Assistant runtime environment
+- Avoid including API version path segments in the configured base URL
+- Avoid trailing slash in stored configuration to prevent double-slash request paths
+
+## Expected Endpoints
+
+The Home Assistant custom integration expects these read endpoints to be available under the configured base URL.
+
+### `GET /api/v1/integrations/home-assistant/summary`
+
+Purpose: Lightweight setup-time validation of the configured base URL and integration key.
+
+Expected behavior:
+
+- Returns `200 OK`
+- Returns `X-Integration-Contract: 1`
+- Returns a JSON object with these required fields:
+  - `userId`
+  - `id`
+  - `title`
+  - `body`
+
+### `GET /api/v1/integrations/home-assistant/dashboard`
+
+Purpose: Returns dashboard data consumed by Home Assistant sensor entities.
+
+Expected behavior:
+
+- Returns `200 OK`
+- Returns `X-Integration-Contract: 1`
+- Returns a JSON object. The integration currently consumes:
+  - `dueTodayCount`
+  - `overdueCount`
+  - `completionRatio`
+  - `nextMedication`
+  - `userId`
+  - `id`
+  - `model`
+
+## Common Errors and Fixes
+
+### Invalid API Key
+
+Symptoms:
+
+- Setup fails with unauthorized/forbidden errors (`401` or `403`)
+- Entities remain unavailable after setup
+
+Fixes:
+
+1. Verify the key is copied exactly (no extra spaces/newlines)
+2. Verify the key has the `ha:read` scope
+3. Regenerate the key and update the integration configuration if needed
+
+### Network Errors
+
+Symptoms:
+
+- Timeout, DNS, or connection refused errors
+- Setup validation or dashboard refresh fails intermittently
+
+Fixes:
+
+1. Confirm Home Assistant can resolve and reach the backend hostname
+2. Verify firewall, reverse proxy, and TLS certificate configuration
+3. Confirm base URL uses the correct scheme/port/path
+
+### Contract Mismatch
+
+Symptoms:
+
+- Parsing errors in logs
+- Sensors appear as unavailable despite successful authentication
+- Diagnostics show missing expected fields
+
+Fixes:
+
+1. Ensure expected endpoints exist and return JSON
+2. Ensure response keys and data types match the integration contract
+3. Validate endpoint versioning (`/api/v1/integrations/home-assistant/...`) matches the configured backend
+
+## Validation Checklist
+
+- [ ] API key includes `ha:read`
+- [ ] Base URL is HTTPS and reachable from Home Assistant
+- [ ] `GET /api/v1/integrations/home-assistant/summary` returns `200 OK`, `X-Integration-Contract: 1`, and the required summary fields
+- [ ] `GET /api/v1/integrations/home-assistant/dashboard` returns `200 OK`, `X-Integration-Contract: 1`, and a JSON object
+- [ ] Integration loads without entity availability errors

--- a/daynest-home-assistant/hacs.json
+++ b/daynest-home-assistant/hacs.json
@@ -1,5 +1,7 @@
 {
   "name": "Daynest",
+  "content_in_root": false,
+  "render_readme": true,
   "homeassistant": "2026.4.0",
   "hacs": "2.0.5"
 }


### PR DESCRIPTION
### Motivation
- Expose Daynest dashboard adherence metrics (overdue, due today, completion ratio, next medication) as Home Assistant sensors backed by the coordinator payload so dashboards and automations can consume them.
- Provide stable unique IDs and proper sensor metadata (device/state class, units) and ensure entities become unavailable when coordinator refreshes fail.

### Description
- Add `custom_components/daynest/sensor/dashboard.py` with `SensorEntityDescription` entries for `overdue_count`, `due_today_count`, `completion_ratio` (percentage, `SensorStateClass.MEASUREMENT`), and `next_medication`, and implement `DaynestDashboardSensor` that reads values from the coordinator data and exposes attributes for the `next_medication` payload.
- Use the existing `DaynestEntity` base to produce stable unique IDs (`<entry_id>_<key>`) and device info for each sensor.
- Wire the new dashboard sensors into the platform by importing and registering `DASHBOARD_DESCRIPTIONS` in `custom_components/daynest/sensor/__init__.py` so entities are created at setup time.
- Add English translation keys in `custom_components/daynest/translations/en.json` for friendly names of the new sensors.
- Sensor availability and state: `native_value` and attributes return `None` when `coordinator.last_update_success` is `False`, relying on the coordinator to mark entities unavailable on update failures.

### Testing
- Ran `python -m compileall custom_components/daynest/sensor custom_components/daynest/translations/en.json` and compilation succeeded for the new/modified modules.
- Attempted `script/lint` but it could not run in this environment because the project's virtual environment is not bootstrapped (warning only).
- Changes were committed with message `feat(sensor): add dashboard adherence sensors`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ecc8497ed8832e978e7dda8a7091d8)