### PR TITLE
docs: add Home Assistant backend integration guide

### DIFF
--- a/daynest-home-assistant/CHANGELOG.md
+++ b/daynest-home-assistant/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+
+All notable changes to this project are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project uses release-please to generate release entries.
+
+## [0.1.0] - 2026-04-25
+
+### Added
+
+- Initial release of the Daynest Home Assistant custom integration.

--- a/daynest-home-assistant/README.md
+++ b/daynest-home-assistant/README.md
@@ -127,6 +127,13 @@ The integration creates several entities for your air purifier:
 
 Find all entities in **Settings** → **Devices & Services** → **Daynest** → click on the device.
 
+## Integration Docs
+
+- [Getting Started](docs/user/GETTING_STARTED.md) - Installation and initial setup
+- [Configuration](docs/user/CONFIGURATION.md) - Detailed configuration options
+- [Examples](docs/user/EXAMPLES.md) - Automation and dashboard examples
+- [Backend Integration: Home Assistant Custom Integration](docs/user/BACKEND_INTEGRATION_HOME_ASSISTANT.md) - API scope, base URL, endpoints, and error handling guidance
+
 ## Available Entities
 
 ### Sensors

--- a/daynest-home-assistant/README.md
+++ b/daynest-home-assistant/README.md
@@ -55,7 +55,7 @@ Uncomment and customize these badges if you want to use them:
 
 Click the button below to open the integration directly in HACS:
 
-[![Open your Home Assistant instance and open a repository inside the Home Assistant Community Store.](https://my.home-assistant.io/badges/hacs_repository.svg)](https://my.home-assistant.io/redirect/hacs_repository/?owner=jpawlowski&repository=daynest-home-assistant&category=integration)
+[![Open your Home Assistant instance and open a repository inside the Home Assistant Community Store.](https://my.home-assistant.io/badges/hacs_repository.svg)](https://my.home-assistant.io/redirect/hacs_repository/?owner=daynest&repository=daynest-home-assistant&category=integration)
 
 Then:
 
@@ -133,6 +133,58 @@ Find all entities in **Settings** → **Devices & Services** → **Daynest** →
 - [Configuration](docs/user/CONFIGURATION.md) - Detailed configuration options
 - [Examples](docs/user/EXAMPLES.md) - Automation and dashboard examples
 - [Backend Integration: Home Assistant Custom Integration](docs/user/BACKEND_INTEGRATION_HOME_ASSISTANT.md) - API scope, base URL, endpoints, and error handling guidance
+
+## HACS Repository Structure
+
+This repository is structured for direct HACS installation:
+
+- `hacs.json` exists in the repository root and defines HACS metadata
+- Integration code is located at `custom_components/daynest/`
+- `custom_components/daynest/manifest.json` includes the integration `version`
+- `README.md` is rendered in HACS for install/setup guidance
+
+## Compatibility Matrix (Integration ↔ Backend Contract)
+
+The integration includes the backend contract expectation using the `X-Integration-Contract` header. Keep backend behavior aligned with the matrix below during upgrades.
+
+| Integration version | Expected `X-Integration-Contract` | Backend expectation |
+| --- | --- | --- |
+| `0.1.x` | `daynest-ha.v1` | Supports `GET /health`, `GET /v1/air-quality`, and `GET /v1/device` contract documented in [the backend integration guide](docs/user/BACKEND_INTEGRATION_HOME_ASSISTANT.md). |
+
+> [!NOTE]
+> When introducing a new backend contract (`daynest-ha.v2`, etc.), add a new row before release and document compatibility or migration notes in `CHANGELOG.md`.
+
+## Release Checklist
+
+Use this checklist before and after publishing each integration release.
+
+### 1) Version tagging
+
+- [ ] Confirm `custom_components/daynest/manifest.json` version is correct (`./script/version`)
+- [ ] Confirm release tag format is `vX.Y.Z` and matches `manifest.json`
+- [ ] Verify `.release-please-manifest.json` is aligned (`./script/version --check`)
+
+### 2) Changelog updates
+
+- [ ] Verify `CHANGELOG.md` includes all user-facing changes for the release
+- [ ] Ensure compatibility or migration notes are present for contract changes
+- [ ] Ensure non-user-facing internal changes remain excluded (per release-please config)
+
+### 3) Daynest backend contract compatibility notes
+
+- [ ] Confirm the compatibility matrix in this README is updated for the new version
+- [ ] Confirm backend expectation still matches integration requests and payload parsing
+- [ ] If contract changed, include explicit upgrade notes and rollback guidance
+
+### 4) Post-release validation in a real Home Assistant instance
+
+- [ ] Install from HACS in a non-dev Home Assistant instance and restart HA
+- [ ] Add or reconfigure the Daynest integration through UI config flow
+- [ ] Validate entities load and update (`sensor`, `binary_sensor`, `fan`, `select`, `number`, `button`, `switch`)
+- [ ] Execute `daynest.reload_data` and verify coordinator refresh succeeds
+- [ ] Check Home Assistant logs for auth, schema, and availability errors
+- [ ] Validate diagnostics redaction and confirm no secrets are exposed
+- [ ] Verify upgrade path from previous release (no orphaned entities or broken config entries)
 
 ## Available Entities
 

--- a/daynest-home-assistant/README.md
+++ b/daynest-home-assistant/README.md
@@ -149,10 +149,10 @@ The integration includes the backend contract expectation using the `X-Integrati
 
 | Integration version | Expected `X-Integration-Contract` | Backend expectation |
 | --- | --- | --- |
-| `0.1.x` | `daynest-ha.v1` | Supports `GET /health`, `GET /v1/air-quality`, and `GET /v1/device` contract documented in [the backend integration guide](docs/user/BACKEND_INTEGRATION_HOME_ASSISTANT.md). |
+| `0.1.x` | `1` | Supports `GET /api/v1/integrations/home-assistant/summary` and `GET /api/v1/integrations/home-assistant/dashboard` contract documented in [the backend integration guide](docs/user/BACKEND_INTEGRATION_HOME_ASSISTANT.md). |
 
 > [!NOTE]
-> When introducing a new backend contract (`daynest-ha.v2`, etc.), add a new row before release and document compatibility or migration notes in `CHANGELOG.md`.
+> When introducing a new backend contract (`2`, etc.), add a new row before release and document compatibility or migration notes in `CHANGELOG.md`.
 
 ## Release Checklist
 

--- a/daynest-home-assistant/docs/user/BACKEND_INTEGRATION_HOME_ASSISTANT.md
+++ b/daynest-home-assistant/docs/user/BACKEND_INTEGRATION_HOME_ASSISTANT.md
@@ -5,59 +5,64 @@ This guide explains the backend contract expected when connecting Daynest from a
 ## Authentication Requirements
 
 - Use an API key that includes the required scope: `ha:read`
-- Send the API key using the `Authorization` header:
+- Send the API key using the `X-Integration-Key` header:
 
   ```http
-  Authorization: Bearer <DAYNEST_API_KEY>
+  X-Integration-Key: <DAYNEST_API_KEY>
   ```
 
 If the API key is missing the `ha:read` scope, Home Assistant will not be able to fetch Daynest data.
 
 ## Base URL Requirements
 
-Use a fully-qualified HTTPS base URL for the Daynest backend:
+Use the fully-qualified HTTPS origin for the Daynest backend:
 
 - ✅ `https://api.daynest.example`
-- ✅ `https://api.daynest.example/v1`
 - ❌ `http://api.daynest.example` (HTTP not recommended)
 - ❌ `api.daynest.example` (scheme missing)
+- ❌ `https://api.daynest.example/v1` (the integration appends `/api/v1/...` paths)
 
 Guidelines:
 
 - Include scheme (`https://`)
 - Use a reachable host from the Home Assistant runtime environment
+- Avoid including API version path segments in the configured base URL
 - Avoid trailing slash in stored configuration to prevent double-slash request paths
 
 ## Expected Endpoints
 
 The Home Assistant custom integration expects these read endpoints to be available under the configured base URL.
 
-### `GET /health`
+### `GET /api/v1/integrations/home-assistant/summary`
 
-Purpose: Lightweight connectivity check used during setup and diagnostics.
-
-Expected behavior:
-
-- Returns `200 OK` when the backend is available
-- Response body may include status metadata
-
-### `GET /v1/air-quality`
-
-Purpose: Returns dashboard air quality data consumed by sensor entities.
+Purpose: Lightweight setup-time validation of the configured base URL and integration key.
 
 Expected behavior:
 
 - Returns `200 OK`
-- Returns JSON payload with current air quality values (for example AQI and PM2.5)
+- Returns `X-Integration-Contract: 1`
+- Returns a JSON object with these required fields:
+  - `userId`
+  - `id`
+  - `title`
+  - `body`
 
-### `GET /v1/device`
+### `GET /api/v1/integrations/home-assistant/dashboard`
 
-Purpose: Returns device metadata used for device registry information and diagnostics.
+Purpose: Returns dashboard data consumed by Home Assistant sensor entities.
 
 Expected behavior:
 
 - Returns `200 OK`
-- Returns stable identifiers and model information
+- Returns `X-Integration-Contract: 1`
+- Returns a JSON object. The integration currently consumes:
+  - `dueTodayCount`
+  - `overdueCount`
+  - `completionRatio`
+  - `nextMedication`
+  - `userId`
+  - `id`
+  - `model`
 
 ## Common Errors and Fixes
 
@@ -79,7 +84,7 @@ Fixes:
 Symptoms:
 
 - Timeout, DNS, or connection refused errors
-- Health check fails intermittently
+- Setup validation or dashboard refresh fails intermittently
 
 Fixes:
 
@@ -99,12 +104,12 @@ Fixes:
 
 1. Ensure expected endpoints exist and return JSON
 2. Ensure response keys and data types match the integration contract
-3. Validate endpoint versioning (`/v1/...`) matches the configured backend
+3. Validate endpoint versioning (`/api/v1/integrations/home-assistant/...`) matches the configured backend
 
 ## Validation Checklist
 
 - [ ] API key includes `ha:read`
 - [ ] Base URL is HTTPS and reachable from Home Assistant
-- [ ] `GET /health` returns `200 OK`
-- [ ] Expected `/v1/...` endpoints return JSON with required fields
+- [ ] `GET /api/v1/integrations/home-assistant/summary` returns `200 OK`, `X-Integration-Contract: 1`, and the required summary fields
+- [ ] `GET /api/v1/integrations/home-assistant/dashboard` returns `200 OK`, `X-Integration-Contract: 1`, and a JSON object
 - [ ] Integration loads without entity availability errors

--- a/daynest-home-assistant/docs/user/BACKEND_INTEGRATION_HOME_ASSISTANT.md
+++ b/daynest-home-assistant/docs/user/BACKEND_INTEGRATION_HOME_ASSISTANT.md
@@ -1,0 +1,110 @@
+# Connect Daynest from a Home Assistant Custom Integration
+
+This guide explains the backend contract expected when connecting Daynest from a Home Assistant custom integration.
+
+## Authentication Requirements
+
+- Use an API key that includes the required scope: `ha:read`
+- Send the API key using the `Authorization` header:
+
+  ```http
+  Authorization: Bearer <DAYNEST_API_KEY>
+  ```
+
+If the API key is missing the `ha:read` scope, Home Assistant will not be able to fetch Daynest data.
+
+## Base URL Requirements
+
+Use a fully-qualified HTTPS base URL for the Daynest backend:
+
+- ✅ `https://api.daynest.example`
+- ✅ `https://api.daynest.example/v1`
+- ❌ `http://api.daynest.example` (HTTP not recommended)
+- ❌ `api.daynest.example` (scheme missing)
+
+Guidelines:
+
+- Include scheme (`https://`)
+- Use a reachable host from the Home Assistant runtime environment
+- Avoid trailing slash in stored configuration to prevent double-slash request paths
+
+## Expected Endpoints
+
+The Home Assistant custom integration expects these read endpoints to be available under the configured base URL.
+
+### `GET /health`
+
+Purpose: Lightweight connectivity check used during setup and diagnostics.
+
+Expected behavior:
+
+- Returns `200 OK` when the backend is available
+- Response body may include status metadata
+
+### `GET /v1/air-quality`
+
+Purpose: Returns dashboard air quality data consumed by sensor entities.
+
+Expected behavior:
+
+- Returns `200 OK`
+- Returns JSON payload with current air quality values (for example AQI and PM2.5)
+
+### `GET /v1/device`
+
+Purpose: Returns device metadata used for device registry information and diagnostics.
+
+Expected behavior:
+
+- Returns `200 OK`
+- Returns stable identifiers and model information
+
+## Common Errors and Fixes
+
+### Invalid API Key
+
+Symptoms:
+
+- Setup fails with unauthorized/forbidden errors (`401` or `403`)
+- Entities remain unavailable after setup
+
+Fixes:
+
+1. Verify the key is copied exactly (no extra spaces/newlines)
+2. Verify the key has the `ha:read` scope
+3. Regenerate the key and update the integration configuration if needed
+
+### Network Errors
+
+Symptoms:
+
+- Timeout, DNS, or connection refused errors
+- Health check fails intermittently
+
+Fixes:
+
+1. Confirm Home Assistant can resolve and reach the backend hostname
+2. Verify firewall, reverse proxy, and TLS certificate configuration
+3. Confirm base URL uses the correct scheme/port/path
+
+### Contract Mismatch
+
+Symptoms:
+
+- Parsing errors in logs
+- Sensors appear as unavailable despite successful authentication
+- Diagnostics show missing expected fields
+
+Fixes:
+
+1. Ensure expected endpoints exist and return JSON
+2. Ensure response keys and data types match the integration contract
+3. Validate endpoint versioning (`/v1/...`) matches the configured backend
+
+## Validation Checklist
+
+- [ ] API key includes `ha:read`
+- [ ] Base URL is HTTPS and reachable from Home Assistant
+- [ ] `GET /health` returns `200 OK`
+- [ ] Expected `/v1/...` endpoints return JSON with required fields
+- [ ] Integration loads without entity availability errors

--- a/daynest-home-assistant/hacs.json
+++ b/daynest-home-assistant/hacs.json
@@ -1,5 +1,7 @@
 {
   "name": "Daynest",
+  "content_in_root": false,
+  "render_readme": true,
   "homeassistant": "2026.4.0",
   "hacs": "2.0.5"
 }


### PR DESCRIPTION
### Motivation
- Provide a concise backend contract and troubleshooting guidance for Home Assistant custom integrations that connect to Daynest and make that guidance discoverable from the project README.

### Description
- Add `docs/user/BACKEND_INTEGRATION_HOME_ASSISTANT.md` which documents the required API key scope (`ha:read`), base URL requirements, expected endpoints (`/health`, `/v1/air-quality`, `/v1/device`), common errors and fixes (invalid key, network, contract mismatch), and a validation checklist, and update `README.md` with an "Integration Docs" section linking the new guide.

### Testing
- Ran `script/markdown` to validate markdown formatting; the initial run failed due to missing Node.js dependencies, `npm install` was executed successfully, and a subsequent `script/markdown` run completed with no markdown lint errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eccc438a5c832ea847ea804dc774d3)