### PR TITLE
Add Android top-level feature parity routes

### DIFF
--- a/android/README.md
+++ b/android/README.md
@@ -20,6 +20,18 @@ cd android
 ./gradlew assembleDebug
 ```
 
+## Current feature parity
+
+The native app now exposes the same authenticated top-level product areas as the web app:
+
+- Today
+- Calendar
+- Medication
+- Templates
+- Settings
+
+Today is backed by the shared API read model. The other top-level areas currently provide native destination surfaces that mirror the web modules and will continue gaining editing controls from the shared backend contracts.
+
 ## Suggested split for next tasks
 
 ### Phase 1 — Foundation

--- a/android/app/src/androidTest/java/com/daynest/android/app/DaynestNavigationTest.kt
+++ b/android/app/src/androidTest/java/com/daynest/android/app/DaynestNavigationTest.kt
@@ -4,6 +4,8 @@ package com.daynest.android.app
 
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
 import androidx.navigation.NavGraph.Companion.findStartDestination
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
@@ -23,8 +25,12 @@ import com.daynest.android.data.today.TodayResponseDto
 import com.daynest.android.feature.auth.AuthRoute
 import com.daynest.android.feature.auth.AuthUiEvent
 import com.daynest.android.feature.auth.AuthViewModel
+import com.daynest.android.feature.calendar.CalendarRoute
 import com.daynest.android.feature.home.HomeRoute
 import com.daynest.android.feature.home.HomeViewModel
+import com.daynest.android.feature.medication.MedicationRoute
+import com.daynest.android.feature.settings.SettingsRoute
+import com.daynest.android.feature.templates.TemplatesRoute
 import com.daynest.android.ui.theme.DaynestTheme
 import org.junit.Assert.assertEquals
 import org.junit.Rule
@@ -131,6 +137,41 @@ class DaynestNavigationTest {
 
         assertEquals(DaynestDestination.HOME, navController.currentDestination?.route)
     }
+
+    @Test
+    fun homeBottomNavigation_opensCalendarDestination() {
+        val fakeStorage = FakeNavTokenStorage("valid-token")
+        val fakeApi = FakeNavAuthApi(restoreResult = Result.success(AuthSessionDto("token")))
+        val authRepo = AuthRepository(authApi = fakeApi, secureTokenStorage = fakeStorage)
+        val sessionVm = SessionGateViewModel(authRepo)
+        val authVm = AuthViewModel(authRepo)
+        val homeVm = makeHomeViewModel()
+
+        lateinit var navController: NavHostController
+
+        composeTestRule.setContent {
+            DaynestTheme {
+                navController = rememberNavController()
+                TestNavHost(
+                    navController = navController,
+                    sessionGateViewModel = sessionVm,
+                    authViewModel = authVm,
+                    homeViewModel = homeVm,
+                )
+            }
+        }
+
+        composeTestRule.waitUntil(timeoutMillis = 3_000L) {
+            navController.currentDestination?.route == DaynestDestination.HOME
+        }
+
+        composeTestRule.onNodeWithText("Calendar").performClick()
+        composeTestRule.waitUntil(timeoutMillis = 3_000L) {
+            navController.currentDestination?.route == DaynestDestination.CALENDAR
+        }
+
+        assertEquals(DaynestDestination.CALENDAR, navController.currentDestination?.route)
+    }
 }
 
 @Composable
@@ -171,7 +212,19 @@ private fun TestNavHost(
             )
         }
         composable(route = DaynestDestination.HOME) {
-            HomeRoute(viewModel = homeViewModel)
+            HomeRoute(viewModel = homeViewModel, onNavigate = navController::navigate)
+        }
+        composable(route = DaynestDestination.CALENDAR) {
+            CalendarRoute(onNavigate = navController::navigate)
+        }
+        composable(route = DaynestDestination.MEDICATION) {
+            MedicationRoute(onNavigate = navController::navigate)
+        }
+        composable(route = DaynestDestination.TEMPLATES) {
+            TemplatesRoute(onNavigate = navController::navigate)
+        }
+        composable(route = DaynestDestination.SETTINGS) {
+            SettingsRoute(onNavigate = navController::navigate)
         }
     }
 }

--- a/android/app/src/androidTest/java/com/daynest/android/app/DaynestNavigationTest.kt
+++ b/android/app/src/androidTest/java/com/daynest/android/app/DaynestNavigationTest.kt
@@ -11,6 +11,8 @@ import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
+import androidx.test.platform.app.InstrumentationRegistry
+import com.daynest.android.R
 import com.daynest.android.app.navigation.DaynestDestination
 import com.daynest.android.app.session.SessionGateRoute
 import com.daynest.android.app.session.SessionGateViewModel
@@ -54,106 +56,83 @@ class DaynestNavigationTest {
 
     @Test
     fun gateGoHome_navigatesToHomeDestination() {
-        val fakeStorage = FakeNavTokenStorage("valid-token")
-        val fakeApi = FakeNavAuthApi(restoreResult = Result.success(AuthSessionDto("token")))
-        val authRepo = AuthRepository(authApi = fakeApi, secureTokenStorage = fakeStorage)
-        val sessionVm = SessionGateViewModel(authRepo)
-        val authVm = AuthViewModel(authRepo)
-        val homeVm = makeHomeViewModel()
-
-        lateinit var navController: NavHostController
-
-        composeTestRule.setContent {
-            DaynestTheme {
-                navController = rememberNavController()
-                TestNavHost(
-                    navController = navController,
-                    sessionGateViewModel = sessionVm,
-                    authViewModel = authVm,
-                    homeViewModel = homeVm,
-                )
-            }
-        }
+        val harness =
+            setNavContent(
+                initialToken = "valid-token",
+                fakeApi = FakeNavAuthApi(restoreResult = Result.success(AuthSessionDto("token"))),
+            )
 
         composeTestRule.waitUntil(timeoutMillis = 3_000L) {
-            navController.currentDestination?.route == DaynestDestination.HOME
+            harness.navController.currentDestination?.route == DaynestDestination.HOME
         }
 
-        assertEquals(DaynestDestination.HOME, navController.currentDestination?.route)
+        assertEquals(DaynestDestination.HOME, harness.navController.currentDestination?.route)
     }
 
     @Test
     fun gateGoAuth_navigatesToAuthDestination() {
-        val fakeStorage = FakeNavTokenStorage(null)
-        val fakeApi = FakeNavAuthApi()
-        val authRepo = AuthRepository(authApi = fakeApi, secureTokenStorage = fakeStorage)
-        val sessionVm = SessionGateViewModel(authRepo)
-        val authVm = AuthViewModel(authRepo)
-        val homeVm = makeHomeViewModel()
-
-        lateinit var navController: NavHostController
-
-        composeTestRule.setContent {
-            DaynestTheme {
-                navController = rememberNavController()
-                TestNavHost(
-                    navController = navController,
-                    sessionGateViewModel = sessionVm,
-                    authViewModel = authVm,
-                    homeViewModel = homeVm,
-                )
-            }
-        }
+        val harness = setNavContent(initialToken = null)
 
         composeTestRule.waitUntil(timeoutMillis = 3_000L) {
-            navController.currentDestination?.route == DaynestDestination.AUTH
+            harness.navController.currentDestination?.route == DaynestDestination.AUTH
         }
 
-        assertEquals(DaynestDestination.AUTH, navController.currentDestination?.route)
+        assertEquals(DaynestDestination.AUTH, harness.navController.currentDestination?.route)
     }
 
     @Test
     fun authSignedIn_navigatesToHomeDestination() {
-        val fakeStorage = FakeNavTokenStorage(null)
-        val fakeApi = FakeNavAuthApi(signInResult = Result.success(AuthSessionDto("new-token")))
-        val authRepo = AuthRepository(authApi = fakeApi, secureTokenStorage = fakeStorage)
-        val sessionVm = SessionGateViewModel(authRepo)
-        val authVm = AuthViewModel(authRepo)
-        val homeVm = makeHomeViewModel()
-
-        lateinit var navController: NavHostController
-
-        composeTestRule.setContent {
-            DaynestTheme {
-                navController = rememberNavController()
-                TestNavHost(
-                    navController = navController,
-                    sessionGateViewModel = sessionVm,
-                    authViewModel = authVm,
-                    homeViewModel = homeVm,
-                )
-            }
-        }
+        val harness =
+            setNavContent(
+                initialToken = null,
+                fakeApi = FakeNavAuthApi(signInResult = Result.success(AuthSessionDto("new-token"))),
+            )
 
         composeTestRule.waitUntil(timeoutMillis = 3_000L) {
-            navController.currentDestination?.route == DaynestDestination.AUTH
+            harness.navController.currentDestination?.route == DaynestDestination.AUTH
         }
 
-        authVm.onEvent(AuthUiEvent.EmailChanged("user@example.com"))
-        authVm.onEvent(AuthUiEvent.PasswordChanged("password123"))
-        authVm.onEvent(AuthUiEvent.SignInClicked)
+        harness.authViewModel.onEvent(AuthUiEvent.EmailChanged("user@example.com"))
+        harness.authViewModel.onEvent(AuthUiEvent.PasswordChanged("password123"))
+        harness.authViewModel.onEvent(AuthUiEvent.SignInClicked)
 
         composeTestRule.waitUntil(timeoutMillis = 3_000L) {
-            navController.currentDestination?.route == DaynestDestination.HOME
+            harness.navController.currentDestination?.route == DaynestDestination.HOME
         }
 
-        assertEquals(DaynestDestination.HOME, navController.currentDestination?.route)
+        assertEquals(DaynestDestination.HOME, harness.navController.currentDestination?.route)
     }
 
     @Test
     fun homeBottomNavigation_opensCalendarDestination() {
-        val fakeStorage = FakeNavTokenStorage("valid-token")
-        val fakeApi = FakeNavAuthApi(restoreResult = Result.success(AuthSessionDto("token")))
+        val harness =
+            setNavContent(
+                initialToken = "valid-token",
+                fakeApi = FakeNavAuthApi(restoreResult = Result.success(AuthSessionDto("token"))),
+            )
+
+        composeTestRule.waitUntil(timeoutMillis = 3_000L) {
+            harness.navController.currentDestination?.route == DaynestDestination.HOME
+        }
+
+        val calendarTitle =
+            InstrumentationRegistry
+                .getInstrumentation()
+                .targetContext
+                .getString(R.string.calendar_title)
+        composeTestRule.onNodeWithText(calendarTitle).performClick()
+        composeTestRule.waitUntil(timeoutMillis = 3_000L) {
+            harness.navController.currentDestination?.route == DaynestDestination.CALENDAR
+        }
+
+        assertEquals(DaynestDestination.CALENDAR, harness.navController.currentDestination?.route)
+    }
+
+    private fun setNavContent(
+        initialToken: String?,
+        fakeApi: FakeNavAuthApi = FakeNavAuthApi(),
+    ): NavTestHarness {
+        val fakeStorage = FakeNavTokenStorage(initialToken)
         val authRepo = AuthRepository(authApi = fakeApi, secureTokenStorage = fakeStorage)
         val sessionVm = SessionGateViewModel(authRepo)
         val authVm = AuthViewModel(authRepo)
@@ -173,18 +152,17 @@ class DaynestNavigationTest {
             }
         }
 
-        composeTestRule.waitUntil(timeoutMillis = 3_000L) {
-            navController.currentDestination?.route == DaynestDestination.HOME
-        }
-
-        composeTestRule.onNodeWithText("Calendar").performClick()
-        composeTestRule.waitUntil(timeoutMillis = 3_000L) {
-            navController.currentDestination?.route == DaynestDestination.CALENDAR
-        }
-
-        assertEquals(DaynestDestination.CALENDAR, navController.currentDestination?.route)
+        return NavTestHarness(
+            navController = navController,
+            authViewModel = authVm,
+        )
     }
 }
+
+private data class NavTestHarness(
+    val navController: NavHostController,
+    val authViewModel: AuthViewModel,
+)
 
 @Composable
 private fun TestNavHost(

--- a/android/app/src/androidTest/java/com/daynest/android/app/DaynestNavigationTest.kt
+++ b/android/app/src/androidTest/java/com/daynest/android/app/DaynestNavigationTest.kt
@@ -14,11 +14,21 @@ import androidx.navigation.compose.rememberNavController
 import com.daynest.android.app.navigation.DaynestDestination
 import com.daynest.android.app.session.SessionGateRoute
 import com.daynest.android.app.session.SessionGateViewModel
+import com.daynest.android.core.database.today.TodaySummaryDao
+import com.daynest.android.core.database.today.TodaySummaryEntity
 import com.daynest.android.core.storage.SecureTokenStorage
 import com.daynest.android.data.auth.AuthApi
 import com.daynest.android.data.auth.AuthRepository
 import com.daynest.android.data.auth.AuthSessionDto
+import com.daynest.android.data.auth.RefreshRequestDto
 import com.daynest.android.data.auth.SignInRequestDto
+import com.daynest.android.data.today.ChoreMutationDto
+import com.daynest.android.data.today.DoseMutationDto
+import com.daynest.android.data.today.PlannedItemCreateDto
+import com.daynest.android.data.today.PlannedItemUpdateDto
+import com.daynest.android.data.today.PlannedTodayItemDto
+import com.daynest.android.data.today.TaskMutationDto
+import com.daynest.android.data.today.TodayActionsApi
 import com.daynest.android.data.today.TodayApi
 import com.daynest.android.data.today.TodayRepository
 import com.daynest.android.data.today.TodayResponseDto
@@ -32,6 +42,8 @@ import com.daynest.android.feature.medication.MedicationRoute
 import com.daynest.android.feature.settings.SettingsRoute
 import com.daynest.android.feature.templates.TemplatesRoute
 import com.daynest.android.ui.theme.DaynestTheme
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
 import org.junit.Assert.assertEquals
 import org.junit.Rule
 import org.junit.Test
@@ -237,25 +249,73 @@ private fun makeHomeViewModel(): HomeViewModel =
                     object : TodayApi {
                         override suspend fun getToday(): TodayResponseDto = TodayResponseDto()
                     },
+                todayActionsApi =
+                    object : TodayActionsApi {
+                        override suspend fun completeChore(id: Int): ChoreMutationDto = ChoreMutationDto(id, "completed")
+
+                        override suspend fun skipChore(id: Int): ChoreMutationDto = ChoreMutationDto(id, "skipped")
+
+                        override suspend fun completeTask(id: Int): TaskMutationDto = TaskMutationDto(id, "completed")
+
+                        override suspend fun skipTask(id: Int): TaskMutationDto = TaskMutationDto(id, "skipped")
+
+                        override suspend fun startTask(id: Int): TaskMutationDto = TaskMutationDto(id, "in_progress")
+
+                        override suspend fun takeDose(id: Int): DoseMutationDto = DoseMutationDto(id, "taken")
+
+                        override suspend fun skipDose(id: Int): DoseMutationDto = DoseMutationDto(id, "skipped")
+
+                        override suspend fun updatePlannedItem(
+                            id: Int,
+                            request: PlannedItemUpdateDto,
+                        ): PlannedTodayItemDto = PlannedTodayItemDto(id, request.title, request.isDone)
+
+                        override suspend fun deletePlannedItem(id: Int) = Unit
+
+                        override suspend fun createPlannedItem(request: PlannedItemCreateDto): PlannedTodayItemDto =
+                            PlannedTodayItemDto(0, request.title, false)
+                    },
+                todaySummaryDao =
+                    object : TodaySummaryDao {
+                        private val flow = MutableStateFlow<TodaySummaryEntity?>(null)
+
+                        override fun observe(): Flow<TodaySummaryEntity?> = flow
+
+                        override suspend fun upsert(entity: TodaySummaryEntity) {
+                            flow.value = entity
+                        }
+
+                        override suspend fun clear() {
+                            flow.value = null
+                        }
+                    },
             ),
     )
 
 private class FakeNavAuthApi(
-    private val signInResult: Result<AuthSessionDto> = Result.failure(UnsupportedOperationException("signIn not expected")),
-    private val restoreResult: Result<AuthSessionDto> = Result.failure(UnsupportedOperationException("restoreSession not expected")),
+    private val signInResult: Result<AuthSessionDto> =
+        Result.failure(UnsupportedOperationException("signIn not expected")),
+    private val restoreResult: Result<AuthSessionDto> =
+        Result.failure(UnsupportedOperationException("restoreSession not expected")),
 ) : AuthApi {
     override suspend fun signIn(request: SignInRequestDto): AuthSessionDto = signInResult.getOrThrow()
 
     override suspend fun restoreSession(): AuthSessionDto = restoreResult.getOrThrow()
+
+    override suspend fun refresh(request: RefreshRequestDto): AuthSessionDto = throw UnsupportedOperationException("refresh not expected")
 }
 
 private class FakeNavTokenStorage(
     initialToken: String?,
 ) : SecureTokenStorage {
     private var storedToken: String? = initialToken
+    private var storedRefreshToken: String? = null
 
     override val cachedToken: String?
         get() = storedToken
+
+    override val cachedRefreshToken: String?
+        get() = storedRefreshToken
 
     override suspend fun getToken(): String? = storedToken
 
@@ -265,5 +325,15 @@ private class FakeNavTokenStorage(
 
     override suspend fun clearToken() {
         storedToken = null
+    }
+
+    override suspend fun getRefreshToken(): String? = storedRefreshToken
+
+    override suspend fun saveRefreshToken(token: String) {
+        storedRefreshToken = token
+    }
+
+    override suspend fun clearRefreshToken() {
+        storedRefreshToken = null
     }
 }

--- a/android/app/src/androidTest/java/com/daynest/android/feature/home/HomeScreenTest.kt
+++ b/android/app/src/androidTest/java/com/daynest/android/feature/home/HomeScreenTest.kt
@@ -22,6 +22,8 @@ class HomeScreenTest {
             }
         }
 
-        composeTestRule.onNode(hasProgressBarRangeInfo(androidx.compose.ui.semantics.ProgressBarRangeInfo.Indeterminate)).assertExists()
+        composeTestRule
+            .onNode(hasProgressBarRangeInfo(androidx.compose.ui.semantics.ProgressBarRangeInfo.Indeterminate))
+            .assertExists()
     }
 }

--- a/android/app/src/main/java/com/daynest/android/app/DaynestApp.kt
+++ b/android/app/src/main/java/com/daynest/android/app/DaynestApp.kt
@@ -82,7 +82,7 @@ fun DaynestApp() {
 
 private fun NavHostController.navigateTopLevel(route: String) {
     navigate(route) {
-        popUpTo(graph.findStartDestination().id) {
+        popUpTo(DaynestDestination.HOME) {
             saveState = true
         }
         launchSingleTop = true

--- a/android/app/src/main/java/com/daynest/android/app/DaynestApp.kt
+++ b/android/app/src/main/java/com/daynest/android/app/DaynestApp.kt
@@ -70,7 +70,7 @@ fun DaynestApp() {
                     onNavigate = navController::navigateTopLevel,
                     onSignedOut = {
                         navController.navigate(DaynestDestination.AUTH) {
-                            popUpTo(navController.graph.findStartDestination().id) { inclusive = true }
+                            popUpTo(DaynestDestination.HOME) { inclusive = true }
                             launchSingleTop = true
                         }
                     },

--- a/android/app/src/main/java/com/daynest/android/app/DaynestApp.kt
+++ b/android/app/src/main/java/com/daynest/android/app/DaynestApp.kt
@@ -66,7 +66,15 @@ fun DaynestApp() {
                 TemplatesRoute(onNavigate = navController::navigateTopLevel)
             }
             composable(route = DaynestDestination.SETTINGS) {
-                SettingsRoute(onNavigate = navController::navigateTopLevel)
+                SettingsRoute(
+                    onNavigate = navController::navigateTopLevel,
+                    onSignedOut = {
+                        navController.navigate(DaynestDestination.AUTH) {
+                            popUpTo(navController.graph.findStartDestination().id) { inclusive = true }
+                            launchSingleTop = true
+                        }
+                    },
+                )
             }
         }
     }

--- a/android/app/src/main/java/com/daynest/android/app/DaynestApp.kt
+++ b/android/app/src/main/java/com/daynest/android/app/DaynestApp.kt
@@ -4,13 +4,18 @@ package com.daynest.android.app
 
 import androidx.compose.runtime.Composable
 import androidx.navigation.NavGraph.Companion.findStartDestination
+import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
 import com.daynest.android.app.navigation.DaynestDestination
 import com.daynest.android.app.session.SessionGateRoute
 import com.daynest.android.feature.auth.AuthRoute
+import com.daynest.android.feature.calendar.CalendarRoute
 import com.daynest.android.feature.home.HomeRoute
+import com.daynest.android.feature.medication.MedicationRoute
+import com.daynest.android.feature.settings.SettingsRoute
+import com.daynest.android.feature.templates.TemplatesRoute
 import com.daynest.android.ui.theme.DaynestTheme
 
 @Composable
@@ -49,8 +54,30 @@ fun DaynestApp() {
             }
 
             composable(route = DaynestDestination.HOME) {
-                HomeRoute()
+                HomeRoute(onNavigate = navController::navigateTopLevel)
+            }
+            composable(route = DaynestDestination.CALENDAR) {
+                CalendarRoute(onNavigate = navController::navigateTopLevel)
+            }
+            composable(route = DaynestDestination.MEDICATION) {
+                MedicationRoute(onNavigate = navController::navigateTopLevel)
+            }
+            composable(route = DaynestDestination.TEMPLATES) {
+                TemplatesRoute(onNavigate = navController::navigateTopLevel)
+            }
+            composable(route = DaynestDestination.SETTINGS) {
+                SettingsRoute(onNavigate = navController::navigateTopLevel)
             }
         }
+    }
+}
+
+private fun NavHostController.navigateTopLevel(route: String) {
+    navigate(route) {
+        popUpTo(graph.findStartDestination().id) {
+            saveState = true
+        }
+        launchSingleTop = true
+        restoreState = true
     }
 }

--- a/android/app/src/main/java/com/daynest/android/app/navigation/DaynestDestination.kt
+++ b/android/app/src/main/java/com/daynest/android/app/navigation/DaynestDestination.kt
@@ -3,5 +3,23 @@ package com.daynest.android.app.navigation
 object DaynestDestination {
     const val SESSION_GATE = "session_gate"
     const val AUTH = "auth"
-    const val HOME = "home"
+    const val HOME = "today"
+    const val CALENDAR = "calendar"
+    const val MEDICATION = "medication"
+    const val TEMPLATES = "templates"
+    const val SETTINGS = "settings"
 }
+
+data class DaynestTopLevelDestination(
+    val route: String,
+    val label: String,
+)
+
+val daynestTopLevelDestinations =
+    listOf(
+        DaynestTopLevelDestination(DaynestDestination.HOME, "Today"),
+        DaynestTopLevelDestination(DaynestDestination.CALENDAR, "Calendar"),
+        DaynestTopLevelDestination(DaynestDestination.MEDICATION, "Medication"),
+        DaynestTopLevelDestination(DaynestDestination.TEMPLATES, "Templates"),
+        DaynestTopLevelDestination(DaynestDestination.SETTINGS, "Settings"),
+    )

--- a/android/app/src/main/java/com/daynest/android/app/navigation/DaynestDestination.kt
+++ b/android/app/src/main/java/com/daynest/android/app/navigation/DaynestDestination.kt
@@ -1,5 +1,8 @@
 package com.daynest.android.app.navigation
 
+import androidx.annotation.StringRes
+import com.daynest.android.R
+
 object DaynestDestination {
     const val SESSION_GATE = "session_gate"
     const val AUTH = "auth"
@@ -12,14 +15,14 @@ object DaynestDestination {
 
 data class DaynestTopLevelDestination(
     val route: String,
-    val label: String,
+    @param:StringRes val labelResId: Int,
 )
 
 val daynestTopLevelDestinations =
     listOf(
-        DaynestTopLevelDestination(DaynestDestination.HOME, "Today"),
-        DaynestTopLevelDestination(DaynestDestination.CALENDAR, "Calendar"),
-        DaynestTopLevelDestination(DaynestDestination.MEDICATION, "Medication"),
-        DaynestTopLevelDestination(DaynestDestination.TEMPLATES, "Templates"),
-        DaynestTopLevelDestination(DaynestDestination.SETTINGS, "Settings"),
+        DaynestTopLevelDestination(DaynestDestination.HOME, R.string.today_title),
+        DaynestTopLevelDestination(DaynestDestination.CALENDAR, R.string.calendar_title),
+        DaynestTopLevelDestination(DaynestDestination.MEDICATION, R.string.medication_title),
+        DaynestTopLevelDestination(DaynestDestination.TEMPLATES, R.string.templates_title),
+        DaynestTopLevelDestination(DaynestDestination.SETTINGS, R.string.settings_title),
     )

--- a/android/app/src/main/java/com/daynest/android/app/navigation/DaynestNavigationScaffold.kt
+++ b/android/app/src/main/java/com/daynest/android/app/navigation/DaynestNavigationScaffold.kt
@@ -9,6 +9,7 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 
 @Composable
 fun DaynestNavigationScaffold(
@@ -22,11 +23,12 @@ fun DaynestNavigationScaffold(
         bottomBar = {
             NavigationBar {
                 daynestTopLevelDestinations.forEach { destination ->
+                    val label = stringResource(id = destination.labelResId)
                     NavigationBarItem(
                         selected = currentRoute == destination.route,
                         onClick = { onNavigate(destination.route) },
-                        label = { Text(text = destination.label) },
-                        icon = { Text(text = destination.label.take(1)) },
+                        label = { Text(text = label) },
+                        icon = { Text(text = label.take(1)) },
                     )
                 }
             }

--- a/android/app/src/main/java/com/daynest/android/app/navigation/DaynestNavigationScaffold.kt
+++ b/android/app/src/main/java/com/daynest/android/app/navigation/DaynestNavigationScaffold.kt
@@ -1,0 +1,36 @@
+@file:Suppress("ktlint:standard:function-naming", "FunctionNaming")
+
+package com.daynest.android.app.navigation
+
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.material3.NavigationBar
+import androidx.compose.material3.NavigationBarItem
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+
+@Composable
+fun DaynestNavigationScaffold(
+    currentRoute: String,
+    onNavigate: (String) -> Unit,
+    modifier: Modifier = Modifier,
+    content: @Composable (PaddingValues) -> Unit,
+) {
+    Scaffold(
+        modifier = modifier,
+        bottomBar = {
+            NavigationBar {
+                daynestTopLevelDestinations.forEach { destination ->
+                    NavigationBarItem(
+                        selected = currentRoute == destination.route,
+                        onClick = { onNavigate(destination.route) },
+                        label = { Text(text = destination.label) },
+                        icon = { Text(text = destination.label.take(1)) },
+                    )
+                }
+            }
+        },
+        content = content,
+    )
+}

--- a/android/app/src/main/java/com/daynest/android/app/navigation/ParityScreen.kt
+++ b/android/app/src/main/java/com/daynest/android/app/navigation/ParityScreen.kt
@@ -1,0 +1,75 @@
+@file:Suppress("ktlint:standard:function-naming", "FunctionNaming")
+
+package com.daynest.android.app.navigation
+
+import androidx.annotation.StringRes
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.Card
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import com.daynest.android.R
+
+@Composable
+fun DaynestParityRoute(
+    currentRoute: String,
+    onNavigate: (String) -> Unit,
+    @StringRes titleRes: Int,
+    @StringRes subtitleRes: Int,
+    capabilityResIds: List<Int>,
+) {
+    DaynestNavigationScaffold(
+        currentRoute = currentRoute,
+        onNavigate = onNavigate,
+    ) { innerPadding ->
+        LazyColumn(
+            modifier =
+                Modifier
+                    .fillMaxSize()
+                    .padding(innerPadding),
+            contentPadding = PaddingValues(24.dp),
+            verticalArrangement = Arrangement.spacedBy(16.dp),
+        ) {
+            item {
+                Column {
+                    Text(
+                        text = stringResource(id = titleRes),
+                        style = MaterialTheme.typography.headlineMedium,
+                    )
+                    Spacer(modifier = Modifier.height(8.dp))
+                    Text(
+                        text = stringResource(id = subtitleRes),
+                        style = MaterialTheme.typography.bodyLarge,
+                    )
+                }
+            }
+            items(capabilityResIds) { capabilityResId ->
+                Card(modifier = Modifier.fillMaxWidth()) {
+                    Text(
+                        text = stringResource(id = capabilityResId),
+                        modifier = Modifier.padding(16.dp),
+                        style = MaterialTheme.typography.bodyMedium,
+                    )
+                }
+            }
+            item {
+                Text(
+                    text = stringResource(id = R.string.parity_more_coming),
+                    style = MaterialTheme.typography.bodySmall,
+                )
+            }
+        }
+    }
+}

--- a/android/app/src/main/java/com/daynest/android/core/di/NetworkDiModule.kt
+++ b/android/app/src/main/java/com/daynest/android/core/di/NetworkDiModule.kt
@@ -7,6 +7,11 @@ import com.daynest.android.core.network.CertificatePinnerProvider
 import com.daynest.android.core.network.JsonSerializer
 import com.daynest.android.core.network.TokenAuthenticator
 import com.daynest.android.data.auth.AuthApi
+import com.daynest.android.data.calendar.CalendarApi
+import com.daynest.android.data.medication.MedicationApi
+import com.daynest.android.data.settings.SettingsApi
+import com.daynest.android.data.templates.TemplatesApi
+import com.daynest.android.data.today.TodayActionsApi
 import com.daynest.android.data.today.TodayApi
 import dagger.Module
 import dagger.Provides
@@ -73,5 +78,25 @@ object NetworkDiModule {
 
     @Provides
     @Singleton
+    fun provideTodayActionsApi(retrofit: Retrofit): TodayActionsApi = retrofit.create(TodayActionsApi::class.java)
+
+    @Provides
+    @Singleton
     fun provideAuthApi(retrofit: Retrofit): AuthApi = retrofit.create(AuthApi::class.java)
+
+    @Provides
+    @Singleton
+    fun provideCalendarApi(retrofit: Retrofit): CalendarApi = retrofit.create(CalendarApi::class.java)
+
+    @Provides
+    @Singleton
+    fun provideMedicationApi(retrofit: Retrofit): MedicationApi = retrofit.create(MedicationApi::class.java)
+
+    @Provides
+    @Singleton
+    fun provideTemplatesApi(retrofit: Retrofit): TemplatesApi = retrofit.create(TemplatesApi::class.java)
+
+    @Provides
+    @Singleton
+    fun provideSettingsApi(retrofit: Retrofit): SettingsApi = retrofit.create(SettingsApi::class.java)
 }

--- a/android/app/src/main/java/com/daynest/android/data/RepositoryResult.kt
+++ b/android/app/src/main/java/com/daynest/android/data/RepositoryResult.kt
@@ -1,0 +1,13 @@
+package com.daynest.android.data
+
+import kotlinx.coroutines.CancellationException
+
+@Suppress("TooGenericExceptionCaught")
+suspend fun <T> safeApiCall(call: suspend () -> T): Result<T> =
+    try {
+        Result.success(call())
+    } catch (e: CancellationException) {
+        throw e
+    } catch (e: Exception) {
+        Result.failure(e)
+    }

--- a/android/app/src/main/java/com/daynest/android/data/calendar/CalendarApi.kt
+++ b/android/app/src/main/java/com/daynest/android/data/calendar/CalendarApi.kt
@@ -1,0 +1,59 @@
+package com.daynest.android.data.calendar
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import retrofit2.http.GET
+import retrofit2.http.Query
+
+interface CalendarApi {
+    @GET("api/v1/calendar/month")
+    suspend fun getMonth(
+        @Query("year") year: Int,
+        @Query("month") month: Int,
+    ): CalendarMonthDto
+
+    @GET("api/v1/calendar/day")
+    suspend fun getDay(
+        @Query("date") date: String,
+    ): CalendarDayDto
+}
+
+@Serializable
+data class CalendarMonthDto(
+    val year: Int,
+    val month: Int,
+    val days: List<CalendarDaySummaryDto>,
+)
+
+@Serializable
+data class CalendarDaySummaryDto(
+    val date: String,
+    val total: Int,
+    val routines: Int,
+    val chores: Int,
+    val medications: Int,
+    val planned: Int,
+)
+
+@Serializable
+data class CalendarDayDto(
+    val date: String,
+    val items: List<UnifiedDayItemDto>,
+)
+
+@Serializable
+data class UnifiedDayItemDto(
+    @SerialName("item_type")
+    val itemType: String,
+    @SerialName("item_id")
+    val itemId: Int,
+    val title: String,
+    val status: String,
+    @SerialName("scheduled_at")
+    val scheduledAt: String? = null,
+    @SerialName("scheduled_date")
+    val scheduledDate: String? = null,
+    val detail: String? = null,
+    @SerialName("module_key")
+    val moduleKey: String? = null,
+)

--- a/android/app/src/main/java/com/daynest/android/data/calendar/CalendarRepository.kt
+++ b/android/app/src/main/java/com/daynest/android/data/calendar/CalendarRepository.kt
@@ -1,0 +1,35 @@
+package com.daynest.android.data.calendar
+
+import kotlinx.coroutines.CancellationException
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class CalendarRepository
+    @Inject
+    constructor(
+        private val calendarApi: CalendarApi,
+    ) {
+        @Suppress("TooGenericExceptionCaught")
+        suspend fun getMonth(
+            year: Int,
+            month: Int,
+        ): Result<CalendarMonthDto> =
+            try {
+                Result.success(calendarApi.getMonth(year, month))
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                Result.failure(e)
+            }
+
+        @Suppress("TooGenericExceptionCaught")
+        suspend fun getDay(date: String): Result<CalendarDayDto> =
+            try {
+                Result.success(calendarApi.getDay(date))
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                Result.failure(e)
+            }
+    }

--- a/android/app/src/main/java/com/daynest/android/data/calendar/CalendarRepository.kt
+++ b/android/app/src/main/java/com/daynest/android/data/calendar/CalendarRepository.kt
@@ -1,6 +1,6 @@
 package com.daynest.android.data.calendar
 
-import kotlinx.coroutines.CancellationException
+import com.daynest.android.data.safeApiCall
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -10,26 +10,10 @@ class CalendarRepository
     constructor(
         private val calendarApi: CalendarApi,
     ) {
-        @Suppress("TooGenericExceptionCaught")
         suspend fun getMonth(
             year: Int,
             month: Int,
-        ): Result<CalendarMonthDto> =
-            try {
-                Result.success(calendarApi.getMonth(year, month))
-            } catch (e: CancellationException) {
-                throw e
-            } catch (e: Exception) {
-                Result.failure(e)
-            }
+        ): Result<CalendarMonthDto> = safeApiCall { calendarApi.getMonth(year, month) }
 
-        @Suppress("TooGenericExceptionCaught")
-        suspend fun getDay(date: String): Result<CalendarDayDto> =
-            try {
-                Result.success(calendarApi.getDay(date))
-            } catch (e: CancellationException) {
-                throw e
-            } catch (e: Exception) {
-                Result.failure(e)
-            }
+        suspend fun getDay(date: String): Result<CalendarDayDto> = safeApiCall { calendarApi.getDay(date) }
     }

--- a/android/app/src/main/java/com/daynest/android/data/medication/MedicationApi.kt
+++ b/android/app/src/main/java/com/daynest/android/data/medication/MedicationApi.kt
@@ -1,0 +1,63 @@
+package com.daynest.android.data.medication
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import retrofit2.http.Body
+import retrofit2.http.GET
+import retrofit2.http.POST
+
+interface MedicationApi {
+    @GET("api/v1/medications")
+    suspend fun listPlans(): List<MedicationPlanDto>
+
+    @POST("api/v1/medications")
+    suspend fun createPlan(
+        @Body request: MedicationPlanInputDto,
+    ): MedicationPlanDto
+
+    @GET("api/v1/medication-doses/history")
+    suspend fun getHistory(): MedicationHistoryResponseDto
+}
+
+@Serializable
+data class MedicationPlanDto(
+    val id: Int,
+    val name: String,
+    val instructions: String,
+    @SerialName("start_date")
+    val startDate: String,
+    @SerialName("schedule_time")
+    val scheduleTime: String,
+    @SerialName("every_n_days")
+    val everyNDays: Int,
+    @SerialName("is_active")
+    val isActive: Boolean,
+)
+
+@Serializable
+data class MedicationPlanInputDto(
+    val name: String,
+    val instructions: String,
+    @SerialName("start_date")
+    val startDate: String,
+    @SerialName("schedule_time")
+    val scheduleTime: String,
+    @SerialName("every_n_days")
+    val everyNDays: Int,
+)
+
+@Serializable
+data class MedicationHistoryResponseDto(
+    val history: List<MedicationHistoryItemDto>,
+)
+
+@Serializable
+data class MedicationHistoryItemDto(
+    @SerialName("medication_dose_instance_id")
+    val medicationDoseInstanceId: Int,
+    val name: String,
+    val instructions: String = "",
+    @SerialName("scheduled_at")
+    val scheduledAt: String = "",
+    val status: String,
+)

--- a/android/app/src/main/java/com/daynest/android/data/medication/MedicationRepository.kt
+++ b/android/app/src/main/java/com/daynest/android/data/medication/MedicationRepository.kt
@@ -1,6 +1,6 @@
 package com.daynest.android.data.medication
 
-import kotlinx.coroutines.CancellationException
+import com.daynest.android.data.safeApiCall
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -10,33 +10,13 @@ class MedicationRepository
     constructor(
         private val medicationApi: MedicationApi,
     ) {
-        @Suppress("TooGenericExceptionCaught")
-        suspend fun listPlans(): Result<List<MedicationPlanDto>> =
-            try {
-                Result.success(medicationApi.listPlans())
-            } catch (e: CancellationException) {
-                throw e
-            } catch (e: Exception) {
-                Result.failure(e)
-            }
+        suspend fun listPlans(): Result<List<MedicationPlanDto>> = safeApiCall { medicationApi.listPlans() }
 
-        @Suppress("TooGenericExceptionCaught")
         suspend fun createPlan(request: MedicationPlanInputDto): Result<MedicationPlanDto> =
-            try {
-                Result.success(medicationApi.createPlan(request))
-            } catch (e: CancellationException) {
-                throw e
-            } catch (e: Exception) {
-                Result.failure(e)
-            }
+            safeApiCall { medicationApi.createPlan(request) }
 
-        @Suppress("TooGenericExceptionCaught")
         suspend fun getHistory(): Result<List<MedicationHistoryItemDto>> =
-            try {
-                Result.success(medicationApi.getHistory().history)
-            } catch (e: CancellationException) {
-                throw e
-            } catch (e: Exception) {
-                Result.failure(e)
+            safeApiCall {
+                medicationApi.getHistory().history
             }
     }

--- a/android/app/src/main/java/com/daynest/android/data/medication/MedicationRepository.kt
+++ b/android/app/src/main/java/com/daynest/android/data/medication/MedicationRepository.kt
@@ -1,0 +1,42 @@
+package com.daynest.android.data.medication
+
+import kotlinx.coroutines.CancellationException
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class MedicationRepository
+    @Inject
+    constructor(
+        private val medicationApi: MedicationApi,
+    ) {
+        @Suppress("TooGenericExceptionCaught")
+        suspend fun listPlans(): Result<List<MedicationPlanDto>> =
+            try {
+                Result.success(medicationApi.listPlans())
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                Result.failure(e)
+            }
+
+        @Suppress("TooGenericExceptionCaught")
+        suspend fun createPlan(request: MedicationPlanInputDto): Result<MedicationPlanDto> =
+            try {
+                Result.success(medicationApi.createPlan(request))
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                Result.failure(e)
+            }
+
+        @Suppress("TooGenericExceptionCaught")
+        suspend fun getHistory(): Result<List<MedicationHistoryItemDto>> =
+            try {
+                Result.success(medicationApi.getHistory().history)
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                Result.failure(e)
+            }
+    }

--- a/android/app/src/main/java/com/daynest/android/data/settings/SettingsApi.kt
+++ b/android/app/src/main/java/com/daynest/android/data/settings/SettingsApi.kt
@@ -1,0 +1,49 @@
+package com.daynest.android.data.settings
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import retrofit2.http.Body
+import retrofit2.http.GET
+import retrofit2.http.POST
+
+interface SettingsApi {
+    @GET("api/v1/integrations/clients")
+    suspend fun listClients(): List<IntegrationClientDto>
+
+    @POST("api/v1/integrations/clients")
+    suspend fun createClient(
+        @Body request: IntegrationClientInputDto,
+    ): IntegrationClientCreateResponseDto
+}
+
+@Serializable
+data class IntegrationClientDto(
+    val id: Int,
+    val name: String,
+    val scopes: List<String>,
+    @SerialName("rate_limit_per_minute")
+    val rateLimitPerMinute: Int,
+    @SerialName("is_active")
+    val isActive: Boolean,
+)
+
+@Serializable
+data class IntegrationClientInputDto(
+    val name: String,
+    val scopes: List<String>,
+    @SerialName("rate_limit_per_minute")
+    val rateLimitPerMinute: Int,
+)
+
+@Serializable
+data class IntegrationClientCreateResponseDto(
+    val id: Int,
+    val name: String,
+    val scopes: List<String>,
+    @SerialName("rate_limit_per_minute")
+    val rateLimitPerMinute: Int,
+    @SerialName("is_active")
+    val isActive: Boolean,
+    @SerialName("api_key")
+    val apiKey: String,
+)

--- a/android/app/src/main/java/com/daynest/android/data/settings/SettingsRepository.kt
+++ b/android/app/src/main/java/com/daynest/android/data/settings/SettingsRepository.kt
@@ -1,6 +1,6 @@
 package com.daynest.android.data.settings
 
-import kotlinx.coroutines.CancellationException
+import com.daynest.android.data.safeApiCall
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -10,23 +10,8 @@ class SettingsRepository
     constructor(
         private val settingsApi: SettingsApi,
     ) {
-        @Suppress("TooGenericExceptionCaught")
-        suspend fun listClients(): Result<List<IntegrationClientDto>> =
-            try {
-                Result.success(settingsApi.listClients())
-            } catch (e: CancellationException) {
-                throw e
-            } catch (e: Exception) {
-                Result.failure(e)
-            }
+        suspend fun listClients(): Result<List<IntegrationClientDto>> = safeApiCall { settingsApi.listClients() }
 
-        @Suppress("TooGenericExceptionCaught")
         suspend fun createClient(request: IntegrationClientInputDto): Result<IntegrationClientCreateResponseDto> =
-            try {
-                Result.success(settingsApi.createClient(request))
-            } catch (e: CancellationException) {
-                throw e
-            } catch (e: Exception) {
-                Result.failure(e)
-            }
+            safeApiCall { settingsApi.createClient(request) }
     }

--- a/android/app/src/main/java/com/daynest/android/data/settings/SettingsRepository.kt
+++ b/android/app/src/main/java/com/daynest/android/data/settings/SettingsRepository.kt
@@ -1,0 +1,32 @@
+package com.daynest.android.data.settings
+
+import kotlinx.coroutines.CancellationException
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class SettingsRepository
+    @Inject
+    constructor(
+        private val settingsApi: SettingsApi,
+    ) {
+        @Suppress("TooGenericExceptionCaught")
+        suspend fun listClients(): Result<List<IntegrationClientDto>> =
+            try {
+                Result.success(settingsApi.listClients())
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                Result.failure(e)
+            }
+
+        @Suppress("TooGenericExceptionCaught")
+        suspend fun createClient(request: IntegrationClientInputDto): Result<IntegrationClientCreateResponseDto> =
+            try {
+                Result.success(settingsApi.createClient(request))
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                Result.failure(e)
+            }
+    }

--- a/android/app/src/main/java/com/daynest/android/data/templates/TemplatesApi.kt
+++ b/android/app/src/main/java/com/daynest/android/data/templates/TemplatesApi.kt
@@ -1,0 +1,108 @@
+package com.daynest.android.data.templates
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import retrofit2.http.Body
+import retrofit2.http.DELETE
+import retrofit2.http.GET
+import retrofit2.http.POST
+import retrofit2.http.PUT
+import retrofit2.http.Path
+
+interface TemplatesApi {
+    @GET("api/v1/routines")
+    suspend fun listRoutines(): List<RoutineTemplateDto>
+
+    @POST("api/v1/routines")
+    suspend fun createRoutine(
+        @Body request: RoutineTemplateInputDto,
+    ): RoutineTemplateDto
+
+    @PUT("api/v1/routines/{id}")
+    suspend fun updateRoutine(
+        @Path("id") id: Int,
+        @Body request: RoutineTemplateInputDto,
+    ): RoutineTemplateDto
+
+    @DELETE("api/v1/routines/{id}")
+    suspend fun deleteRoutine(
+        @Path("id") id: Int,
+    )
+
+    @GET("api/v1/chore-templates")
+    suspend fun listChores(): List<ChoreTemplateDto>
+
+    @POST("api/v1/chore-templates")
+    suspend fun createChore(
+        @Body request: ChoreTemplateInputDto,
+    ): ChoreTemplateDto
+
+    @PUT("api/v1/chore-templates/{id}")
+    suspend fun updateChore(
+        @Path("id") id: Int,
+        @Body request: ChoreTemplateInputDto,
+    ): ChoreTemplateDto
+
+    @DELETE("api/v1/chore-templates/{id}")
+    suspend fun deleteChore(
+        @Path("id") id: Int,
+    )
+}
+
+@Serializable
+data class RoutineTemplateDto(
+    val id: Int,
+    val name: String,
+    val description: String? = null,
+    @SerialName("start_date")
+    val startDate: String,
+    @SerialName("every_n_days")
+    val everyNDays: Int,
+    @SerialName("due_time")
+    val dueTime: String? = null,
+    @SerialName("is_active")
+    val isActive: Boolean,
+    @SerialName("created_at")
+    val createdAt: String,
+)
+
+@Serializable
+data class RoutineTemplateInputDto(
+    val name: String,
+    val description: String? = null,
+    @SerialName("start_date")
+    val startDate: String,
+    @SerialName("every_n_days")
+    val everyNDays: Int,
+    @SerialName("due_time")
+    val dueTime: String? = null,
+    @SerialName("is_active")
+    val isActive: Boolean,
+)
+
+@Serializable
+data class ChoreTemplateDto(
+    val id: Int,
+    val name: String,
+    val description: String? = null,
+    @SerialName("start_date")
+    val startDate: String,
+    @SerialName("every_n_days")
+    val everyNDays: Int,
+    @SerialName("is_active")
+    val isActive: Boolean,
+    @SerialName("created_at")
+    val createdAt: String,
+)
+
+@Serializable
+data class ChoreTemplateInputDto(
+    val name: String,
+    val description: String? = null,
+    @SerialName("start_date")
+    val startDate: String,
+    @SerialName("every_n_days")
+    val everyNDays: Int,
+    @SerialName("is_active")
+    val isActive: Boolean,
+)

--- a/android/app/src/main/java/com/daynest/android/data/templates/TemplatesRepository.kt
+++ b/android/app/src/main/java/com/daynest/android/data/templates/TemplatesRepository.kt
@@ -1,0 +1,74 @@
+package com.daynest.android.data.templates
+
+import kotlinx.coroutines.CancellationException
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class TemplatesRepository
+    @Inject
+    constructor(
+        private val templatesApi: TemplatesApi,
+    ) {
+        @Suppress("TooGenericExceptionCaught")
+        suspend fun listRoutines(): Result<List<RoutineTemplateDto>> =
+            try {
+                Result.success(templatesApi.listRoutines())
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                Result.failure(e)
+            }
+
+        @Suppress("TooGenericExceptionCaught")
+        suspend fun createRoutine(request: RoutineTemplateInputDto): Result<RoutineTemplateDto> =
+            try {
+                Result.success(templatesApi.createRoutine(request))
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                Result.failure(e)
+            }
+
+        @Suppress("TooGenericExceptionCaught")
+        suspend fun deleteRoutine(id: Int): Result<Unit> =
+            try {
+                templatesApi.deleteRoutine(id)
+                Result.success(Unit)
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                Result.failure(e)
+            }
+
+        @Suppress("TooGenericExceptionCaught")
+        suspend fun listChores(): Result<List<ChoreTemplateDto>> =
+            try {
+                Result.success(templatesApi.listChores())
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                Result.failure(e)
+            }
+
+        @Suppress("TooGenericExceptionCaught")
+        suspend fun createChore(request: ChoreTemplateInputDto): Result<ChoreTemplateDto> =
+            try {
+                Result.success(templatesApi.createChore(request))
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                Result.failure(e)
+            }
+
+        @Suppress("TooGenericExceptionCaught")
+        suspend fun deleteChore(id: Int): Result<Unit> =
+            try {
+                templatesApi.deleteChore(id)
+                Result.success(Unit)
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                Result.failure(e)
+            }
+    }

--- a/android/app/src/main/java/com/daynest/android/data/templates/TemplatesRepository.kt
+++ b/android/app/src/main/java/com/daynest/android/data/templates/TemplatesRepository.kt
@@ -1,6 +1,6 @@
 package com.daynest.android.data.templates
 
-import kotlinx.coroutines.CancellationException
+import com.daynest.android.data.safeApiCall
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -10,65 +10,25 @@ class TemplatesRepository
     constructor(
         private val templatesApi: TemplatesApi,
     ) {
-        @Suppress("TooGenericExceptionCaught")
-        suspend fun listRoutines(): Result<List<RoutineTemplateDto>> =
-            try {
-                Result.success(templatesApi.listRoutines())
-            } catch (e: CancellationException) {
-                throw e
-            } catch (e: Exception) {
-                Result.failure(e)
-            }
+        suspend fun listRoutines(): Result<List<RoutineTemplateDto>> = safeApiCall { templatesApi.listRoutines() }
 
-        @Suppress("TooGenericExceptionCaught")
         suspend fun createRoutine(request: RoutineTemplateInputDto): Result<RoutineTemplateDto> =
-            try {
-                Result.success(templatesApi.createRoutine(request))
-            } catch (e: CancellationException) {
-                throw e
-            } catch (e: Exception) {
-                Result.failure(e)
-            }
+            safeApiCall { templatesApi.createRoutine(request) }
 
-        @Suppress("TooGenericExceptionCaught")
         suspend fun deleteRoutine(id: Int): Result<Unit> =
-            try {
+            safeApiCall {
                 templatesApi.deleteRoutine(id)
-                Result.success(Unit)
-            } catch (e: CancellationException) {
-                throw e
-            } catch (e: Exception) {
-                Result.failure(e)
+                Unit
             }
 
-        @Suppress("TooGenericExceptionCaught")
-        suspend fun listChores(): Result<List<ChoreTemplateDto>> =
-            try {
-                Result.success(templatesApi.listChores())
-            } catch (e: CancellationException) {
-                throw e
-            } catch (e: Exception) {
-                Result.failure(e)
-            }
+        suspend fun listChores(): Result<List<ChoreTemplateDto>> = safeApiCall { templatesApi.listChores() }
 
-        @Suppress("TooGenericExceptionCaught")
         suspend fun createChore(request: ChoreTemplateInputDto): Result<ChoreTemplateDto> =
-            try {
-                Result.success(templatesApi.createChore(request))
-            } catch (e: CancellationException) {
-                throw e
-            } catch (e: Exception) {
-                Result.failure(e)
-            }
+            safeApiCall { templatesApi.createChore(request) }
 
-        @Suppress("TooGenericExceptionCaught")
         suspend fun deleteChore(id: Int): Result<Unit> =
-            try {
+            safeApiCall {
                 templatesApi.deleteChore(id)
-                Result.success(Unit)
-            } catch (e: CancellationException) {
-                throw e
-            } catch (e: Exception) {
-                Result.failure(e)
+                Unit
             }
     }

--- a/android/app/src/main/java/com/daynest/android/data/today/TodayActionsApi.kt
+++ b/android/app/src/main/java/com/daynest/android/data/today/TodayActionsApi.kt
@@ -1,0 +1,109 @@
+package com.daynest.android.data.today
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import retrofit2.http.Body
+import retrofit2.http.DELETE
+import retrofit2.http.POST
+import retrofit2.http.PUT
+import retrofit2.http.Path
+
+interface TodayActionsApi {
+    @POST("api/v1/chores/{id}/complete")
+    suspend fun completeChore(
+        @Path("id") id: Int,
+    ): ChoreMutationDto
+
+    @POST("api/v1/chores/{id}/skip")
+    suspend fun skipChore(
+        @Path("id") id: Int,
+    ): ChoreMutationDto
+
+    @POST("api/v1/tasks/{id}/complete")
+    suspend fun completeTask(
+        @Path("id") id: Int,
+    ): TaskMutationDto
+
+    @POST("api/v1/tasks/{id}/skip")
+    suspend fun skipTask(
+        @Path("id") id: Int,
+    ): TaskMutationDto
+
+    @POST("api/v1/tasks/{id}/start")
+    suspend fun startTask(
+        @Path("id") id: Int,
+    ): TaskMutationDto
+
+    @POST("api/v1/medication-doses/{id}/take")
+    suspend fun takeDose(
+        @Path("id") id: Int,
+    ): DoseMutationDto
+
+    @POST("api/v1/medication-doses/{id}/skip")
+    suspend fun skipDose(
+        @Path("id") id: Int,
+    ): DoseMutationDto
+
+    @PUT("api/v1/planned-items/{id}")
+    suspend fun updatePlannedItem(
+        @Path("id") id: Int,
+        @Body request: PlannedItemUpdateDto,
+    ): PlannedTodayItemDto
+
+    @DELETE("api/v1/planned-items/{id}")
+    suspend fun deletePlannedItem(
+        @Path("id") id: Int,
+    )
+
+    @POST("api/v1/planned-items")
+    suspend fun createPlannedItem(
+        @Body request: PlannedItemCreateDto,
+    ): PlannedTodayItemDto
+}
+
+@Serializable
+data class ChoreMutationDto(
+    @SerialName("chore_instance_id")
+    val choreInstanceId: Int,
+    val status: String,
+)
+
+@Serializable
+data class TaskMutationDto(
+    @SerialName("task_instance_id")
+    val taskInstanceId: Int,
+    val status: String,
+)
+
+@Serializable
+data class DoseMutationDto(
+    @SerialName("medication_dose_instance_id")
+    val medicationDoseInstanceId: Int,
+    val status: String,
+)
+
+@Serializable
+data class PlannedItemUpdateDto(
+    val title: String,
+    @SerialName("planned_for")
+    val plannedFor: String,
+    @SerialName("is_done")
+    val isDone: Boolean,
+    val notes: String? = null,
+    @SerialName("module_key")
+    val moduleKey: String? = null,
+    @SerialName("recurrence_hint")
+    val recurrenceHint: String? = null,
+)
+
+@Serializable
+data class PlannedItemCreateDto(
+    val title: String,
+    @SerialName("planned_for")
+    val plannedFor: String,
+    val notes: String? = null,
+    @SerialName("module_key")
+    val moduleKey: String? = null,
+    @SerialName("recurrence_hint")
+    val recurrenceHint: String? = null,
+)

--- a/android/app/src/main/java/com/daynest/android/data/today/TodayApi.kt
+++ b/android/app/src/main/java/com/daynest/android/data/today/TodayApi.kt
@@ -28,6 +28,10 @@ data class MedicationTodayItemDto(
     @SerialName("medication_dose_instance_id")
     val medicationDoseInstanceId: Int,
     val name: String,
+    val instructions: String = "",
+    @SerialName("scheduled_at")
+    val scheduledAt: String = "",
+    val status: String = "scheduled",
 )
 
 @Serializable
@@ -35,6 +39,10 @@ data class MedicationHistoryItemDto(
     @SerialName("medication_dose_instance_id")
     val medicationDoseInstanceId: Int,
     val name: String,
+    val instructions: String = "",
+    @SerialName("scheduled_at")
+    val scheduledAt: String = "",
+    val status: String = "taken",
 )
 
 @Serializable
@@ -42,6 +50,9 @@ data class RoutineTodayItemDto(
     @SerialName("task_instance_id")
     val taskInstanceId: Int,
     val title: String,
+    val status: String = "pending",
+    @SerialName("scheduled_date")
+    val scheduledDate: String = "",
 )
 
 @Serializable
@@ -49,6 +60,9 @@ data class OverdueTodayItemDto(
     @SerialName("chore_instance_id")
     val choreInstanceId: Int,
     val title: String,
+    val status: String = "pending",
+    @SerialName("overdue_since")
+    val overdueSince: String = "",
 )
 
 @Serializable
@@ -56,6 +70,9 @@ data class DueTodayItemDto(
     @SerialName("chore_instance_id")
     val choreInstanceId: Int,
     val title: String,
+    val status: String = "pending",
+    @SerialName("scheduled_date")
+    val scheduledDate: String = "",
 )
 
 @Serializable
@@ -63,6 +80,8 @@ data class UpcomingTodayItemDto(
     @SerialName("chore_instance_id")
     val choreInstanceId: Int,
     val title: String,
+    @SerialName("scheduled_date")
+    val scheduledDate: String = "",
 )
 
 @Serializable
@@ -71,4 +90,11 @@ data class PlannedTodayItemDto(
     val title: String,
     @SerialName("is_done")
     val isDone: Boolean,
+    @SerialName("planned_for")
+    val plannedFor: String = "",
+    val notes: String? = null,
+    @SerialName("module_key")
+    val moduleKey: String? = null,
+    @SerialName("recurrence_hint")
+    val recurrenceHint: String? = null,
 )

--- a/android/app/src/main/java/com/daynest/android/data/today/TodayRepository.kt
+++ b/android/app/src/main/java/com/daynest/android/data/today/TodayRepository.kt
@@ -30,7 +30,6 @@ class TodayRepository
         suspend fun refresh(): Result<Unit> =
             try {
                 val today = todayApi.getToday()
-                todayResponseFlow.value = today
                 val entity =
                     TodaySummaryEntity(
                         id = 0,
@@ -41,6 +40,7 @@ class TodayRepository
                         lastFetchedEpochMillis = System.currentTimeMillis(),
                     )
                 todaySummaryDao.upsert(entity)
+                todayResponseFlow.value = today
                 Result.success(Unit)
             } catch (e: CancellationException) {
                 throw e

--- a/android/app/src/main/java/com/daynest/android/data/today/TodayRepository.kt
+++ b/android/app/src/main/java/com/daynest/android/data/today/TodayRepository.kt
@@ -5,23 +5,32 @@ import com.daynest.android.core.database.today.TodaySummaryEntity
 import com.daynest.android.core.model.TodaySummary
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.map
 import javax.inject.Inject
 import javax.inject.Singleton
 
 @Singleton
+@Suppress("TooManyFunctions")
 class TodayRepository
     @Inject
     constructor(
         private val todayApi: TodayApi,
+        private val todayActionsApi: TodayActionsApi,
         private val todaySummaryDao: TodaySummaryDao,
     ) {
+        private val todayResponseFlow = MutableStateFlow<TodayResponseDto?>(null)
+
         fun observeTodaySummary(): Flow<TodaySummary?> = todaySummaryDao.observe().map { entity -> entity?.toDomain() }
+
+        fun observeTodayResponse(): Flow<TodayResponseDto?> = todayResponseFlow.asStateFlow()
 
         @Suppress("TooGenericExceptionCaught")
         suspend fun refresh(): Result<Unit> =
             try {
                 val today = todayApi.getToday()
+                todayResponseFlow.value = today
                 val entity =
                     TodaySummaryEntity(
                         id = 0,
@@ -38,6 +47,57 @@ class TodayRepository
             } catch (e: Exception) {
                 Result.failure(e)
             }
+
+        @Suppress("TooGenericExceptionCaught")
+        suspend fun completeChore(choreInstanceId: Int): Result<ChoreMutationDto> =
+            runCatching { todayActionsApi.completeChore(choreInstanceId) }
+
+        @Suppress("TooGenericExceptionCaught", "ktlint:standard:function-signature")
+        suspend fun skipChore(choreInstanceId: Int): Result<ChoreMutationDto> =
+            runCatching { todayActionsApi.skipChore(choreInstanceId) }
+
+        @Suppress("TooGenericExceptionCaught")
+        suspend fun completeTask(taskInstanceId: Int): Result<TaskMutationDto> =
+            runCatching { todayActionsApi.completeTask(taskInstanceId) }
+
+        @Suppress("TooGenericExceptionCaught", "ktlint:standard:function-signature")
+        suspend fun skipTask(taskInstanceId: Int): Result<TaskMutationDto> =
+            runCatching { todayActionsApi.skipTask(taskInstanceId) }
+
+        @Suppress("TooGenericExceptionCaught", "ktlint:standard:function-signature")
+        suspend fun takeDose(doseInstanceId: Int): Result<DoseMutationDto> =
+            runCatching { todayActionsApi.takeDose(doseInstanceId) }
+
+        @Suppress("TooGenericExceptionCaught", "ktlint:standard:function-signature")
+        suspend fun skipDose(doseInstanceId: Int): Result<DoseMutationDto> =
+            runCatching { todayActionsApi.skipDose(doseInstanceId) }
+
+        @Suppress("TooGenericExceptionCaught")
+        suspend fun markPlannedDone(
+            id: Int,
+            item: PlannedTodayItemDto,
+            isDone: Boolean,
+        ): Result<PlannedTodayItemDto> =
+            runCatching {
+                todayActionsApi.updatePlannedItem(
+                    id,
+                    PlannedItemUpdateDto(
+                        title = item.title,
+                        plannedFor = item.plannedFor,
+                        isDone = isDone,
+                        notes = item.notes,
+                        moduleKey = item.moduleKey,
+                        recurrenceHint = item.recurrenceHint,
+                    ),
+                )
+            }
+
+        @Suppress("TooGenericExceptionCaught")
+        suspend fun deletePlannedItem(id: Int): Result<Unit> = runCatching { todayActionsApi.deletePlannedItem(id) }
+
+        @Suppress("TooGenericExceptionCaught")
+        suspend fun createPlannedItem(request: PlannedItemCreateDto): Result<PlannedTodayItemDto> =
+            runCatching { todayActionsApi.createPlannedItem(request) }
 
         private fun TodaySummaryEntity.toDomain() =
             TodaySummary(

--- a/android/app/src/main/java/com/daynest/android/data/today/TodayRepository.kt
+++ b/android/app/src/main/java/com/daynest/android/data/today/TodayRepository.kt
@@ -50,27 +50,27 @@ class TodayRepository
 
         @Suppress("TooGenericExceptionCaught")
         suspend fun completeChore(choreInstanceId: Int): Result<ChoreMutationDto> =
-            runCatching { todayActionsApi.completeChore(choreInstanceId) }
+            safeApiCall { todayActionsApi.completeChore(choreInstanceId) }
 
         @Suppress("TooGenericExceptionCaught", "ktlint:standard:function-signature")
         suspend fun skipChore(choreInstanceId: Int): Result<ChoreMutationDto> =
-            runCatching { todayActionsApi.skipChore(choreInstanceId) }
+            safeApiCall { todayActionsApi.skipChore(choreInstanceId) }
 
         @Suppress("TooGenericExceptionCaught")
         suspend fun completeTask(taskInstanceId: Int): Result<TaskMutationDto> =
-            runCatching { todayActionsApi.completeTask(taskInstanceId) }
+            safeApiCall { todayActionsApi.completeTask(taskInstanceId) }
 
         @Suppress("TooGenericExceptionCaught", "ktlint:standard:function-signature")
         suspend fun skipTask(taskInstanceId: Int): Result<TaskMutationDto> =
-            runCatching { todayActionsApi.skipTask(taskInstanceId) }
+            safeApiCall { todayActionsApi.skipTask(taskInstanceId) }
 
         @Suppress("TooGenericExceptionCaught", "ktlint:standard:function-signature")
         suspend fun takeDose(doseInstanceId: Int): Result<DoseMutationDto> =
-            runCatching { todayActionsApi.takeDose(doseInstanceId) }
+            safeApiCall { todayActionsApi.takeDose(doseInstanceId) }
 
         @Suppress("TooGenericExceptionCaught", "ktlint:standard:function-signature")
         suspend fun skipDose(doseInstanceId: Int): Result<DoseMutationDto> =
-            runCatching { todayActionsApi.skipDose(doseInstanceId) }
+            safeApiCall { todayActionsApi.skipDose(doseInstanceId) }
 
         @Suppress("TooGenericExceptionCaught")
         suspend fun markPlannedDone(
@@ -78,7 +78,7 @@ class TodayRepository
             item: PlannedTodayItemDto,
             isDone: Boolean,
         ): Result<PlannedTodayItemDto> =
-            runCatching {
+            safeApiCall {
                 todayActionsApi.updatePlannedItem(
                     id,
                     PlannedItemUpdateDto(
@@ -93,11 +93,11 @@ class TodayRepository
             }
 
         @Suppress("TooGenericExceptionCaught")
-        suspend fun deletePlannedItem(id: Int): Result<Unit> = runCatching { todayActionsApi.deletePlannedItem(id) }
+        suspend fun deletePlannedItem(id: Int): Result<Unit> = safeApiCall { todayActionsApi.deletePlannedItem(id) }
 
         @Suppress("TooGenericExceptionCaught")
         suspend fun createPlannedItem(request: PlannedItemCreateDto): Result<PlannedTodayItemDto> =
-            runCatching { todayActionsApi.createPlannedItem(request) }
+            safeApiCall { todayActionsApi.createPlannedItem(request) }
 
         private fun TodaySummaryEntity.toDomain() =
             TodaySummary(
@@ -106,4 +106,14 @@ class TodayRepository
                 medicationsCount = medicationsCount,
                 plannedPendingCount = plannedPendingCount,
             )
+
+        @Suppress("TooGenericExceptionCaught")
+        private suspend fun <T> safeApiCall(call: suspend () -> T): Result<T> =
+            try {
+                Result.success(call())
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                Result.failure(e)
+            }
     }

--- a/android/app/src/main/java/com/daynest/android/feature/calendar/CalendarRoute.kt
+++ b/android/app/src/main/java/com/daynest/android/feature/calendar/CalendarRoute.kt
@@ -2,24 +2,454 @@
 
 package com.daynest.android.feature.calendar
 
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.daynest.android.R
 import com.daynest.android.app.navigation.DaynestDestination
-import com.daynest.android.app.navigation.DaynestParityRoute
+import com.daynest.android.app.navigation.DaynestNavigationScaffold
+import com.daynest.android.data.calendar.CalendarDaySummaryDto
+import com.daynest.android.data.calendar.UnifiedDayItemDto
+import java.time.DayOfWeek
+import java.time.LocalDate
+import java.time.format.TextStyle
+import java.util.Locale
+
+private const val DAYS_IN_WEEK = 7
 
 @Composable
-fun CalendarRoute(onNavigate: (String) -> Unit = {}) {
-    DaynestParityRoute(
+fun CalendarRoute(
+    onNavigate: (String) -> Unit = {},
+    viewModel: CalendarViewModel = hiltViewModel(),
+) {
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    CalendarScreen(
+        uiState = uiState,
+        onEvent = viewModel::onEvent,
+        onNavigate = onNavigate,
+    )
+}
+
+@Composable
+private fun CalendarScreen(
+    uiState: CalendarUiState,
+    onEvent: (CalendarUiEvent) -> Unit,
+    onNavigate: (String) -> Unit,
+) {
+    DaynestNavigationScaffold(
         currentRoute = DaynestDestination.CALENDAR,
         onNavigate = onNavigate,
-        titleRes = R.string.calendar_title,
-        subtitleRes = R.string.calendar_subtitle,
-        capabilityResIds =
-            listOf(
-                R.string.calendar_capability_month,
-                R.string.calendar_capability_day,
-                R.string.calendar_capability_planned,
-                R.string.calendar_capability_backup,
-            ),
+    ) { innerPadding ->
+        when (val state = uiState) {
+            CalendarUiState.Loading -> {
+                Box(
+                    modifier =
+                        Modifier
+                            .fillMaxSize()
+                            .padding(innerPadding),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    CircularProgressIndicator()
+                }
+            }
+
+            is CalendarUiState.Error -> {
+                Column(
+                    modifier =
+                        Modifier
+                            .fillMaxSize()
+                            .padding(innerPadding)
+                            .padding(24.dp),
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                    verticalArrangement = Arrangement.Center,
+                ) {
+                    Text(
+                        text = stringResource(id = R.string.calendar_error),
+                        style = MaterialTheme.typography.bodyLarge,
+                    )
+                    Button(
+                        onClick = { onEvent(CalendarUiEvent.RetryClicked) },
+                        modifier = Modifier.padding(top = 16.dp),
+                    ) {
+                        Text(text = stringResource(id = R.string.home_retry))
+                    }
+                }
+            }
+
+            is CalendarUiState.Content -> {
+                CalendarContent(
+                    state = state,
+                    onEvent = onEvent,
+                    modifier = Modifier.padding(innerPadding),
+                )
+            }
+        }
+    }
+}
+
+@Composable
+@Suppress("LongMethod", "CyclomaticComplexMethod")
+private fun CalendarContent(
+    state: CalendarUiState.Content,
+    onEvent: (CalendarUiEvent) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    var showAddDialog by remember(state.selectedDate) { mutableStateOf(false) }
+
+    LazyColumn(
+        modifier = modifier.fillMaxSize(),
+        contentPadding = PaddingValues(16.dp),
+        verticalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        item {
+            MonthHeader(
+                displayMonth = state.displayMonth,
+                onPrevious = { onEvent(CalendarUiEvent.PreviousMonthClicked) },
+                onNext = { onEvent(CalendarUiEvent.NextMonthClicked) },
+            )
+        }
+
+        item {
+            MonthGrid(
+                displayMonth = state.displayMonth,
+                days = state.days,
+                selectedDate = state.selectedDate,
+                onDayClick = { date ->
+                    if (state.selectedDate == date) {
+                        onEvent(CalendarUiEvent.DayDeselected)
+                    } else {
+                        onEvent(CalendarUiEvent.DaySelected(date))
+                    }
+                },
+            )
+        }
+
+        if (state.selectedDate != null) {
+            item {
+                Spacer(modifier = Modifier.height(8.dp))
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    Text(
+                        text = stringResource(id = R.string.calendar_day_detail_header, state.selectedDate),
+                        style = MaterialTheme.typography.titleMedium,
+                        modifier = Modifier.weight(1f),
+                    )
+                    TextButton(onClick = { showAddDialog = true }) {
+                        Text(text = stringResource(id = R.string.calendar_add_planned))
+                    }
+                }
+            }
+
+            if (state.isLoadingDay) {
+                item {
+                    Box(modifier = Modifier.fillMaxWidth(), contentAlignment = Alignment.Center) {
+                        CircularProgressIndicator(modifier = Modifier.size(24.dp))
+                    }
+                }
+            } else if (state.dayItems.isEmpty()) {
+                item {
+                    Text(
+                        text = stringResource(id = R.string.calendar_day_empty),
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.outline,
+                    )
+                }
+            } else {
+                items(state.dayItems, key = { "${it.itemType}_${it.itemId}" }) { item ->
+                    DayItemCard(
+                        item = item,
+                        onDelete =
+                            if (item.itemType == "planned") {
+                                { onEvent(CalendarUiEvent.DeletePlannedItem(item.itemId, state.selectedDate)) }
+                            } else {
+                                null
+                            },
+                    )
+                }
+            }
+        }
+    }
+
+    if (showAddDialog && state.selectedDate != null) {
+        AddPlannedItemDialog(
+            onConfirm = { title ->
+                onEvent(CalendarUiEvent.AddPlannedItem(title, state.selectedDate))
+                showAddDialog = false
+            },
+            onDismiss = { showAddDialog = false },
+        )
+    }
+}
+
+@Composable
+private fun MonthHeader(
+    displayMonth: LocalDate,
+    onPrevious: () -> Unit,
+    onNext: () -> Unit,
+) {
+    val monthName =
+        remember(displayMonth) {
+            displayMonth.month.getDisplayName(TextStyle.FULL, Locale.getDefault())
+        }
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.SpaceBetween,
+    ) {
+        TextButton(onClick = onPrevious) {
+            Text(text = stringResource(id = R.string.calendar_prev_month))
+        }
+        Text(
+            text =
+                stringResource(
+                    id = R.string.calendar_month_year,
+                    monthName,
+                    displayMonth.year.toString(),
+                ),
+            style = MaterialTheme.typography.titleLarge,
+        )
+        TextButton(onClick = onNext) {
+            Text(text = stringResource(id = R.string.calendar_next_month))
+        }
+    }
+}
+
+@Composable
+@Suppress("LongMethod")
+private fun MonthGrid(
+    displayMonth: LocalDate,
+    days: List<CalendarDaySummaryDto>,
+    selectedDate: String?,
+    onDayClick: (String) -> Unit,
+) {
+    val today = remember { LocalDate.now().toString() }
+    val dayMap = remember(days) { days.associateBy { it.date } }
+    val firstDayOfMonth = remember(displayMonth) { displayMonth.withDayOfMonth(1) }
+    val daysInMonth = remember(displayMonth) { displayMonth.lengthOfMonth() }
+    val firstWeekday = remember(firstDayOfMonth) { firstDayOfMonth.dayOfWeek.value % DAYS_IN_WEEK }
+    val dayLabels =
+        remember {
+            (0 until DAYS_IN_WEEK).map { offset ->
+                val dayValue = (DayOfWeek.SUNDAY.value - 1 + offset) % DAYS_IN_WEEK + 1
+                DayOfWeek.of(dayValue).getDisplayName(TextStyle.SHORT, Locale.getDefault())
+            }
+        }
+
+    Column {
+        Row(modifier = Modifier.fillMaxWidth()) {
+            dayLabels.forEach { label ->
+                Text(
+                    text = label,
+                    modifier = Modifier.weight(1f),
+                    textAlign = TextAlign.Center,
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.outline,
+                )
+            }
+        }
+        Spacer(modifier = Modifier.height(4.dp))
+
+        val totalCells = firstWeekday + daysInMonth
+        val rows = (totalCells + DAYS_IN_WEEK - 1) / DAYS_IN_WEEK
+        for (row in 0 until rows) {
+            Row(modifier = Modifier.fillMaxWidth()) {
+                for (col in 0 until DAYS_IN_WEEK) {
+                    val cellIndex = row * DAYS_IN_WEEK + col
+                    val dayNum = cellIndex - firstWeekday + 1
+                    if (dayNum < 1 || dayNum > daysInMonth) {
+                        Spacer(modifier = Modifier.weight(1f).aspectRatio(1f))
+                    } else {
+                        val date = displayMonth.withDayOfMonth(dayNum).toString()
+                        val summary = dayMap[date]
+                        val isSelected = date == selectedDate
+                        val isToday = date == today
+                        DayCell(
+                            dayNum = dayNum,
+                            total = summary?.total ?: 0,
+                            isSelected = isSelected,
+                            isToday = isToday,
+                            onClick = { onDayClick(date) },
+                            modifier = Modifier.weight(1f),
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun DayCell(
+    dayNum: Int,
+    total: Int,
+    isSelected: Boolean,
+    isToday: Boolean,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val bgColor =
+        when {
+            isSelected -> MaterialTheme.colorScheme.primary
+            isToday -> MaterialTheme.colorScheme.primaryContainer
+            else -> androidx.compose.ui.graphics.Color.Transparent
+        }
+    val textColor =
+        when {
+            isSelected -> MaterialTheme.colorScheme.onPrimary
+            isToday -> MaterialTheme.colorScheme.onPrimaryContainer
+            else -> MaterialTheme.colorScheme.onSurface
+        }
+
+    Box(
+        modifier =
+            modifier
+                .aspectRatio(1f)
+                .padding(2.dp)
+                .clip(CircleShape)
+                .background(bgColor)
+                .clickable(onClick = onClick),
+        contentAlignment = Alignment.Center,
+    ) {
+        Column(horizontalAlignment = Alignment.CenterHorizontally) {
+            Text(
+                text = dayNum.toString(),
+                style = MaterialTheme.typography.bodySmall,
+                color = textColor,
+            )
+            if (total > 0) {
+                Box(
+                    modifier =
+                        Modifier
+                            .size(4.dp)
+                            .clip(CircleShape)
+                            .background(
+                                if (isSelected) {
+                                    MaterialTheme.colorScheme.onPrimary
+                                } else {
+                                    MaterialTheme.colorScheme.primary
+                                },
+                            ),
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun DayItemCard(
+    item: UnifiedDayItemDto,
+    onDelete: (() -> Unit)?,
+) {
+    Card(modifier = Modifier.fillMaxWidth()) {
+        Row(
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .padding(12.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Column(modifier = Modifier.weight(1f)) {
+                Text(text = item.title, style = MaterialTheme.typography.bodyMedium)
+                Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                    Text(
+                        text = item.itemType,
+                        style = MaterialTheme.typography.labelSmall,
+                        color = MaterialTheme.colorScheme.primary,
+                    )
+                    if (item.status.isNotEmpty()) {
+                        Text(
+                            text = item.status,
+                            style = MaterialTheme.typography.labelSmall,
+                            color = MaterialTheme.colorScheme.outline,
+                        )
+                    }
+                }
+                if (!item.detail.isNullOrBlank()) {
+                    Text(
+                        text = item.detail,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.outline,
+                    )
+                }
+            }
+            if (onDelete != null) {
+                TextButton(onClick = onDelete) {
+                    Text(
+                        text = stringResource(id = R.string.action_delete),
+                        color = MaterialTheme.colorScheme.error,
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun AddPlannedItemDialog(
+    onConfirm: (String) -> Unit,
+    onDismiss: () -> Unit,
+) {
+    var title by remember { mutableStateOf("") }
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(text = stringResource(id = R.string.calendar_add_planned_title)) },
+        text = {
+            OutlinedTextField(
+                value = title,
+                onValueChange = { title = it },
+                label = { Text(text = stringResource(id = R.string.calendar_planned_title_label)) },
+                singleLine = true,
+            )
+        },
+        confirmButton = {
+            TextButton(
+                onClick = { if (title.isNotBlank()) onConfirm(title.trim()) },
+                enabled = title.isNotBlank(),
+            ) {
+                Text(text = stringResource(id = R.string.action_add))
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) {
+                Text(text = stringResource(id = R.string.action_cancel))
+            }
+        },
     )
 }

--- a/android/app/src/main/java/com/daynest/android/feature/calendar/CalendarRoute.kt
+++ b/android/app/src/main/java/com/daynest/android/feature/calendar/CalendarRoute.kt
@@ -45,9 +45,9 @@ import com.daynest.android.app.navigation.DaynestDestination
 import com.daynest.android.app.navigation.DaynestNavigationScaffold
 import com.daynest.android.data.calendar.CalendarDaySummaryDto
 import com.daynest.android.data.calendar.UnifiedDayItemDto
-import java.time.DayOfWeek
 import java.time.LocalDate
 import java.time.format.TextStyle
+import java.time.temporal.WeekFields
 import java.util.Locale
 
 private const val DAYS_IN_WEEK = 7
@@ -263,12 +263,15 @@ private fun MonthGrid(
     val dayMap = remember(days) { days.associateBy { it.date } }
     val firstDayOfMonth = remember(displayMonth) { displayMonth.withDayOfMonth(1) }
     val daysInMonth = remember(displayMonth) { displayMonth.lengthOfMonth() }
-    val firstWeekday = remember(firstDayOfMonth) { firstDayOfMonth.dayOfWeek.value % DAYS_IN_WEEK }
+    val firstDayOfWeek = remember { WeekFields.of(Locale.getDefault()).firstDayOfWeek }
+    val firstWeekday =
+        remember(firstDayOfMonth, firstDayOfWeek) {
+            Math.floorMod(firstDayOfMonth.dayOfWeek.value - firstDayOfWeek.value, DAYS_IN_WEEK)
+        }
     val dayLabels =
-        remember {
+        remember(firstDayOfWeek) {
             (0 until DAYS_IN_WEEK).map { offset ->
-                val dayValue = (DayOfWeek.SUNDAY.value - 1 + offset) % DAYS_IN_WEEK + 1
-                DayOfWeek.of(dayValue).getDisplayName(TextStyle.SHORT, Locale.getDefault())
+                firstDayOfWeek.plus(offset.toLong()).getDisplayName(TextStyle.SHORT, Locale.getDefault())
             }
         }
 

--- a/android/app/src/main/java/com/daynest/android/feature/calendar/CalendarRoute.kt
+++ b/android/app/src/main/java/com/daynest/android/feature/calendar/CalendarRoute.kt
@@ -1,0 +1,25 @@
+@file:Suppress("ktlint:standard:function-naming", "FunctionNaming")
+
+package com.daynest.android.feature.calendar
+
+import androidx.compose.runtime.Composable
+import com.daynest.android.R
+import com.daynest.android.app.navigation.DaynestDestination
+import com.daynest.android.app.navigation.DaynestParityRoute
+
+@Composable
+fun CalendarRoute(onNavigate: (String) -> Unit = {}) {
+    DaynestParityRoute(
+        currentRoute = DaynestDestination.CALENDAR,
+        onNavigate = onNavigate,
+        titleRes = R.string.calendar_title,
+        subtitleRes = R.string.calendar_subtitle,
+        capabilityResIds =
+            listOf(
+                R.string.calendar_capability_month,
+                R.string.calendar_capability_day,
+                R.string.calendar_capability_planned,
+                R.string.calendar_capability_backup,
+            ),
+    )
+}

--- a/android/app/src/main/java/com/daynest/android/feature/calendar/CalendarViewModel.kt
+++ b/android/app/src/main/java/com/daynest/android/feature/calendar/CalendarViewModel.kt
@@ -80,17 +80,40 @@ class CalendarViewModel
                 val result = calendarRepository.getMonth(year, month)
                 result
                     .onSuccess { monthDto ->
-                        _uiState.value =
-                            CalendarUiState.Content(
-                                displayMonth = displayMonth,
-                                days = monthDto.days,
-                                selectedDate = null,
-                                dayItems = emptyList(),
-                                isLoadingMonth = false,
-                                isLoadingDay = false,
-                            )
+                        _uiState.update { current ->
+                            val currentMonth =
+                                when (current) {
+                                    is CalendarUiState.Content -> current.displayMonth
+                                    is CalendarUiState.Error -> current.displayMonth
+                                    else -> null
+                                }
+                            if (currentMonth == null || currentMonth == displayMonth) {
+                                CalendarUiState.Content(
+                                    displayMonth = displayMonth,
+                                    days = monthDto.days,
+                                    selectedDate = null,
+                                    dayItems = emptyList(),
+                                    isLoadingMonth = false,
+                                    isLoadingDay = false,
+                                )
+                            } else {
+                                current
+                            }
+                        }
                     }.onFailure {
-                        _uiState.value = CalendarUiState.Error(displayMonth = displayMonth)
+                        _uiState.update { current ->
+                            val currentMonth =
+                                when (current) {
+                                    is CalendarUiState.Content -> current.displayMonth
+                                    is CalendarUiState.Error -> current.displayMonth
+                                    else -> null
+                                }
+                            if (currentMonth == null || currentMonth == displayMonth) {
+                                CalendarUiState.Error(displayMonth = displayMonth)
+                            } else {
+                                current
+                            }
+                        }
                     }
             }
         }
@@ -108,7 +131,7 @@ class CalendarViewModel
                 result
                     .onSuccess { dayDto ->
                         _uiState.update { current ->
-                            if (current is CalendarUiState.Content) {
+                            if (current is CalendarUiState.Content && current.selectedDate == date) {
                                 current.copy(dayItems = dayDto.items, isLoadingDay = false)
                             } else {
                                 current
@@ -116,7 +139,7 @@ class CalendarViewModel
                         }
                     }.onFailure {
                         _uiState.update { current ->
-                            if (current is CalendarUiState.Content) {
+                            if (current is CalendarUiState.Content && current.selectedDate == date) {
                                 current.copy(isLoadingDay = false)
                             } else {
                                 current

--- a/android/app/src/main/java/com/daynest/android/feature/calendar/CalendarViewModel.kt
+++ b/android/app/src/main/java/com/daynest/android/feature/calendar/CalendarViewModel.kt
@@ -6,6 +6,7 @@ import com.daynest.android.data.calendar.CalendarDaySummaryDto
 import com.daynest.android.data.calendar.CalendarRepository
 import com.daynest.android.data.calendar.UnifiedDayItemDto
 import com.daynest.android.data.today.PlannedItemCreateDto
+import com.daynest.android.data.today.PlannedTodayItemDto
 import com.daynest.android.data.today.TodayRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -141,11 +142,21 @@ class CalendarViewModel
         ) {
             viewModelScope.launch {
                 val result = todayRepository.createPlannedItem(PlannedItemCreateDto(title = title, plannedFor = date))
-                if (result.isSuccess) {
-                    loadDay(date)
-                    val current = _uiState.value
-                    if (current is CalendarUiState.Content) {
-                        loadMonth(current.displayMonth.year, current.displayMonth.monthValue)
+                result.onSuccess { plannedItem ->
+                    _uiState.update { current ->
+                        if (current is CalendarUiState.Content) {
+                            current.copy(
+                                days = current.days.adjustPlannedSummary(date = date, delta = 1),
+                                dayItems =
+                                    if (current.selectedDate == date) {
+                                        current.dayItems + plannedItem.toUnifiedDayItem()
+                                    } else {
+                                        current.dayItems
+                                    },
+                            )
+                        } else {
+                            current
+                        }
                     }
                 }
             }
@@ -158,15 +169,73 @@ class CalendarViewModel
             viewModelScope.launch {
                 val result = todayRepository.deletePlannedItem(id)
                 if (result.isSuccess) {
-                    loadDay(date)
-                    val current = _uiState.value
-                    if (current is CalendarUiState.Content) {
-                        loadMonth(current.displayMonth.year, current.displayMonth.monthValue)
+                    _uiState.update { current ->
+                        if (current is CalendarUiState.Content) {
+                            current.copy(
+                                days = current.days.adjustPlannedSummary(date = date, delta = -1),
+                                dayItems =
+                                    if (current.selectedDate == date) {
+                                        current.dayItems.filterNot { it.itemType == "planned" && it.itemId == id }
+                                    } else {
+                                        current.dayItems
+                                    },
+                            )
+                        } else {
+                            current
+                        }
                     }
                 }
             }
         }
     }
+
+private fun PlannedTodayItemDto.toUnifiedDayItem() =
+    UnifiedDayItemDto(
+        itemType = "planned",
+        itemId = id,
+        title = title,
+        status = if (isDone) "done" else "planned",
+        scheduledDate = plannedFor,
+        detail = notes,
+        moduleKey = moduleKey,
+    )
+
+private fun List<CalendarDaySummaryDto>.adjustPlannedSummary(
+    date: String,
+    delta: Int,
+): List<CalendarDaySummaryDto> {
+    val existing = firstOrNull { it.date == date }
+    if (existing == null) {
+        return if (delta > 0) {
+            (
+                this +
+                    CalendarDaySummaryDto(
+                        date = date,
+                        total = delta,
+                        routines = 0,
+                        chores = 0,
+                        medications = 0,
+                        planned = delta,
+                    )
+            ).sortedBy { it.date }
+        } else {
+            this
+        }
+    }
+
+    val newPlanned = (existing.planned + delta).coerceAtLeast(0)
+    val actualDelta = newPlanned - existing.planned
+    val updated =
+        existing.copy(
+            total = (existing.total + actualDelta).coerceAtLeast(0),
+            planned = newPlanned,
+        )
+    return if (updated.total == 0) {
+        filterNot { it.date == date }
+    } else {
+        map { if (it.date == date) updated else it }
+    }
+}
 
 sealed interface CalendarUiState {
     data object Loading : CalendarUiState

--- a/android/app/src/main/java/com/daynest/android/feature/calendar/CalendarViewModel.kt
+++ b/android/app/src/main/java/com/daynest/android/feature/calendar/CalendarViewModel.kt
@@ -1,0 +1,210 @@
+package com.daynest.android.feature.calendar
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.daynest.android.data.calendar.CalendarDaySummaryDto
+import com.daynest.android.data.calendar.CalendarRepository
+import com.daynest.android.data.calendar.UnifiedDayItemDto
+import com.daynest.android.data.today.PlannedItemCreateDto
+import com.daynest.android.data.today.TodayRepository
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import java.time.LocalDate
+import javax.inject.Inject
+
+@HiltViewModel
+class CalendarViewModel
+    @Inject
+    constructor(
+        private val calendarRepository: CalendarRepository,
+        private val todayRepository: TodayRepository,
+    ) : ViewModel() {
+        private val _uiState = MutableStateFlow<CalendarUiState>(CalendarUiState.Loading)
+        val uiState: StateFlow<CalendarUiState> = _uiState.asStateFlow()
+
+        private val today = LocalDate.now()
+
+        init {
+            loadMonth(today.year, today.monthValue)
+        }
+
+        fun onEvent(event: CalendarUiEvent) {
+            when (event) {
+                is CalendarUiEvent.PreviousMonthClicked -> navigateMonth(-1)
+                is CalendarUiEvent.NextMonthClicked -> navigateMonth(1)
+                is CalendarUiEvent.DaySelected -> loadDay(event.date)
+                is CalendarUiEvent.DayDeselected -> clearDay()
+                is CalendarUiEvent.AddPlannedItem -> addPlannedItem(event.title, event.date)
+                is CalendarUiEvent.DeletePlannedItem -> deletePlannedItem(event.id, event.date)
+                is CalendarUiEvent.RetryClicked -> retryCurrentMonth()
+            }
+        }
+
+        private fun navigateMonth(delta: Int) {
+            val current = _uiState.value
+            if (current is CalendarUiState.Content) {
+                val newMonth = current.displayMonth.plusMonths(delta.toLong())
+                loadMonth(newMonth.year, newMonth.monthValue)
+            }
+        }
+
+        private fun retryCurrentMonth() {
+            val current = _uiState.value
+            val month =
+                if (current is CalendarUiState.Content) {
+                    current.displayMonth
+                } else {
+                    LocalDate.of(today.year, today.monthValue, 1)
+                }
+            loadMonth(month.year, month.monthValue)
+        }
+
+        private fun loadMonth(
+            year: Int,
+            month: Int,
+        ) {
+            viewModelScope.launch {
+                val displayMonth = LocalDate.of(year, month, 1)
+                _uiState.update { current ->
+                    if (current is CalendarUiState.Content) {
+                        current.copy(isLoadingMonth = true, displayMonth = displayMonth)
+                    } else {
+                        CalendarUiState.Loading
+                    }
+                }
+                val result = calendarRepository.getMonth(year, month)
+                result
+                    .onSuccess { monthDto ->
+                        _uiState.value =
+                            CalendarUiState.Content(
+                                displayMonth = displayMonth,
+                                days = monthDto.days,
+                                selectedDate = null,
+                                dayItems = emptyList(),
+                                isLoadingMonth = false,
+                                isLoadingDay = false,
+                            )
+                    }.onFailure {
+                        _uiState.value = CalendarUiState.Error(displayMonth = displayMonth)
+                    }
+            }
+        }
+
+        private fun loadDay(date: String) {
+            viewModelScope.launch {
+                _uiState.update { current ->
+                    if (current is CalendarUiState.Content) {
+                        current.copy(selectedDate = date, isLoadingDay = true, dayItems = emptyList())
+                    } else {
+                        current
+                    }
+                }
+                val result = calendarRepository.getDay(date)
+                result
+                    .onSuccess { dayDto ->
+                        _uiState.update { current ->
+                            if (current is CalendarUiState.Content) {
+                                current.copy(dayItems = dayDto.items, isLoadingDay = false)
+                            } else {
+                                current
+                            }
+                        }
+                    }.onFailure {
+                        _uiState.update { current ->
+                            if (current is CalendarUiState.Content) {
+                                current.copy(isLoadingDay = false)
+                            } else {
+                                current
+                            }
+                        }
+                    }
+            }
+        }
+
+        private fun clearDay() {
+            _uiState.update { current ->
+                if (current is CalendarUiState.Content) {
+                    current.copy(selectedDate = null, dayItems = emptyList())
+                } else {
+                    current
+                }
+            }
+        }
+
+        private fun addPlannedItem(
+            title: String,
+            date: String,
+        ) {
+            viewModelScope.launch {
+                val result = todayRepository.createPlannedItem(PlannedItemCreateDto(title = title, plannedFor = date))
+                if (result.isSuccess) {
+                    loadDay(date)
+                    val current = _uiState.value
+                    if (current is CalendarUiState.Content) {
+                        loadMonth(current.displayMonth.year, current.displayMonth.monthValue)
+                    }
+                }
+            }
+        }
+
+        private fun deletePlannedItem(
+            id: Int,
+            date: String,
+        ) {
+            viewModelScope.launch {
+                val result = todayRepository.deletePlannedItem(id)
+                if (result.isSuccess) {
+                    loadDay(date)
+                    val current = _uiState.value
+                    if (current is CalendarUiState.Content) {
+                        loadMonth(current.displayMonth.year, current.displayMonth.monthValue)
+                    }
+                }
+            }
+        }
+    }
+
+sealed interface CalendarUiState {
+    data object Loading : CalendarUiState
+
+    data class Content(
+        val displayMonth: LocalDate,
+        val days: List<CalendarDaySummaryDto>,
+        val selectedDate: String?,
+        val dayItems: List<UnifiedDayItemDto>,
+        val isLoadingMonth: Boolean,
+        val isLoadingDay: Boolean,
+    ) : CalendarUiState
+
+    data class Error(
+        val displayMonth: LocalDate,
+    ) : CalendarUiState
+}
+
+sealed interface CalendarUiEvent {
+    data object PreviousMonthClicked : CalendarUiEvent
+
+    data object NextMonthClicked : CalendarUiEvent
+
+    data class DaySelected(
+        val date: String,
+    ) : CalendarUiEvent
+
+    data object DayDeselected : CalendarUiEvent
+
+    data class AddPlannedItem(
+        val title: String,
+        val date: String,
+    ) : CalendarUiEvent
+
+    data class DeletePlannedItem(
+        val id: Int,
+        val date: String,
+    ) : CalendarUiEvent
+
+    data object RetryClicked : CalendarUiEvent
+}

--- a/android/app/src/main/java/com/daynest/android/feature/home/HomeRoute.kt
+++ b/android/app/src/main/java/com/daynest/android/feature/home/HomeRoute.kt
@@ -1,27 +1,41 @@
-@file:Suppress("ktlint:standard:function-naming")
+@file:Suppress("ktlint:standard:function-naming", "FunctionNaming")
 
 package com.daynest.android.feature.home
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Card
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.unit.dp
-import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.daynest.android.R
 import com.daynest.android.app.navigation.DaynestDestination
 import com.daynest.android.app.navigation.DaynestNavigationScaffold
+import com.daynest.android.data.today.MedicationTodayItemDto
+import com.daynest.android.data.today.PlannedTodayItemDto
+import com.daynest.android.data.today.RoutineTodayItemDto
+import com.daynest.android.data.today.UpcomingTodayItemDto
 
 @Composable
 @Suppress("FunctionNaming")
@@ -39,7 +53,7 @@ fun HomeRoute(
 }
 
 @Composable
-@Suppress("FunctionNaming", "LongMethod")
+@Suppress("FunctionNaming", "LongMethod", "CyclomaticComplexMethod")
 internal fun HomeScreen(
     uiState: HomeUiState,
     onEvent: (HomeUiEvent) -> Unit,
@@ -49,56 +63,40 @@ internal fun HomeScreen(
         currentRoute = DaynestDestination.HOME,
         onNavigate = onNavigate,
     ) { innerPadding ->
-        Column(
-            modifier =
-                Modifier
-                    .fillMaxSize()
-                    .padding(innerPadding)
-                    .padding(24.dp),
-            horizontalAlignment = Alignment.CenterHorizontally,
-            verticalArrangement = Arrangement.Center,
-        ) {
-            when (val state = uiState) {
-                HomeUiState.Loading -> {
+        when (val state = uiState) {
+            HomeUiState.Loading -> {
+                Column(
+                    modifier =
+                        Modifier
+                            .fillMaxSize()
+                            .padding(innerPadding),
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                    verticalArrangement = Arrangement.Center,
+                ) {
                     CircularProgressIndicator()
                 }
+            }
 
-                is HomeUiState.Content -> {
-                    Text(
-                        text = stringResource(id = R.string.home_welcome),
-                        style = MaterialTheme.typography.headlineMedium,
-                    )
-                    Text(
-                        text =
-                            pluralStringResource(
-                                id = R.plurals.home_items_remaining,
-                                count = state.summary.remainingCount,
-                                state.summary.remainingCount,
-                            ),
-                        modifier = Modifier.padding(top = 12.dp),
-                        style = MaterialTheme.typography.bodyLarge,
-                    )
-                    Button(
-                        onClick = { onEvent(HomeUiEvent.OpenTodayDetailsClicked) },
-                        modifier = Modifier.padding(top = 20.dp),
-                    ) {
-                        Text(
-                            text =
-                                if (state.summary.isCaughtUp) {
-                                    stringResource(id = R.string.home_action_caught_up)
-                                } else {
-                                    stringResource(id = R.string.home_action_plan_today)
-                                },
-                        )
-                    }
-                }
+            is HomeUiState.Content -> {
+                TodayContent(
+                    state = state,
+                    onEvent = onEvent,
+                    modifier = Modifier.padding(innerPadding),
+                )
+            }
 
-                is HomeUiState.Error -> {
+            is HomeUiState.Error -> {
+                Column(
+                    modifier =
+                        Modifier
+                            .fillMaxSize()
+                            .padding(innerPadding)
+                            .padding(24.dp),
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                    verticalArrangement = Arrangement.Center,
+                ) {
                     Text(
-                        text =
-                            when (state.error) {
-                                HomeError.LoadTodayFailed -> stringResource(id = R.string.home_error_generic)
-                            },
+                        text = stringResource(id = R.string.home_error_generic),
                         style = MaterialTheme.typography.bodyLarge,
                     )
                     Button(
@@ -108,6 +106,364 @@ internal fun HomeScreen(
                         Text(text = stringResource(id = R.string.home_retry))
                     }
                 }
+            }
+        }
+    }
+}
+
+@Composable
+@Suppress("FunctionNaming", "LongMethod", "CyclomaticComplexMethod")
+private fun TodayContent(
+    state: HomeUiState.Content,
+    onEvent: (HomeUiEvent) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    LazyColumn(
+        modifier = modifier.fillMaxSize(),
+        contentPadding = PaddingValues(16.dp),
+        verticalArrangement = Arrangement.spacedBy(12.dp),
+    ) {
+        item {
+            Column {
+                Text(
+                    text = stringResource(id = R.string.home_welcome),
+                    style = MaterialTheme.typography.headlineMedium,
+                )
+                if (state.isStale) {
+                    Text(
+                        text = stringResource(id = R.string.home_stale_notice),
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.outline,
+                    )
+                }
+                Spacer(modifier = Modifier.height(4.dp))
+                Text(
+                    text =
+                        if (state.summary.isCaughtUp) {
+                            stringResource(id = R.string.home_all_caught_up)
+                        } else {
+                            stringResource(id = R.string.home_items_remaining_label, state.summary.remainingCount)
+                        },
+                    style = MaterialTheme.typography.bodyLarge,
+                )
+            }
+        }
+
+        if (state.medication.isNotEmpty()) {
+            item {
+                SectionHeader(title = stringResource(id = R.string.today_section_medication))
+            }
+            items(state.medication, key = { "med_${it.medicationDoseInstanceId}" }) { item ->
+                MedicationTodayCard(
+                    item = item,
+                    onTake = { onEvent(HomeUiEvent.TakeMedicationClicked(item.medicationDoseInstanceId)) },
+                    onSkip = { onEvent(HomeUiEvent.SkipMedicationClicked(item.medicationDoseInstanceId)) },
+                )
+            }
+        }
+
+        if (state.routines.isNotEmpty()) {
+            item {
+                SectionHeader(title = stringResource(id = R.string.today_section_routines))
+            }
+            items(state.routines, key = { "routine_${it.taskInstanceId}" }) { item ->
+                RoutineCard(
+                    item = item,
+                    onComplete = { onEvent(HomeUiEvent.CompleteTaskClicked(item.taskInstanceId)) },
+                    onSkip = { onEvent(HomeUiEvent.SkipTaskClicked(item.taskInstanceId)) },
+                )
+            }
+        }
+
+        if (state.overdue.isNotEmpty()) {
+            item {
+                SectionHeader(
+                    title = stringResource(id = R.string.today_section_overdue),
+                    titleColor = MaterialTheme.colorScheme.error,
+                )
+            }
+            items(state.overdue, key = { "overdue_${it.choreInstanceId}" }) { item ->
+                ChoreCard(
+                    title = item.title,
+                    subtitle =
+                        if (item.overdueSince.isNotEmpty()) {
+                            stringResource(id = R.string.today_overdue_since, item.overdueSince)
+                        } else {
+                            null
+                        },
+                    onComplete = { onEvent(HomeUiEvent.CompleteChoreClicked(item.choreInstanceId)) },
+                    onSkip = { onEvent(HomeUiEvent.SkipChoreClicked(item.choreInstanceId)) },
+                )
+            }
+        }
+
+        if (state.dueToday.isNotEmpty()) {
+            item {
+                SectionHeader(title = stringResource(id = R.string.today_section_due_today))
+            }
+            items(state.dueToday, key = { "due_${it.choreInstanceId}" }) { item ->
+                ChoreCard(
+                    title = item.title,
+                    subtitle = null,
+                    onComplete = { onEvent(HomeUiEvent.CompleteChoreClicked(item.choreInstanceId)) },
+                    onSkip = { onEvent(HomeUiEvent.SkipChoreClicked(item.choreInstanceId)) },
+                )
+            }
+        }
+
+        if (state.planned.isNotEmpty()) {
+            item {
+                SectionHeader(title = stringResource(id = R.string.today_section_planned))
+            }
+            items(state.planned, key = { "planned_${it.id}" }) { item ->
+                PlannedItemCard(
+                    item = item,
+                    onToggleDone = { onEvent(HomeUiEvent.MarkPlannedDoneClicked(item.id, !item.isDone)) },
+                    onDelete = { onEvent(HomeUiEvent.DeletePlannedClicked(item.id)) },
+                )
+            }
+        }
+
+        if (state.upcoming.isNotEmpty()) {
+            item {
+                SectionHeader(title = stringResource(id = R.string.today_section_upcoming))
+            }
+            items(state.upcoming, key = { "upcoming_${it.choreInstanceId}" }) { item ->
+                UpcomingChoreCard(item = item)
+            }
+        }
+
+        if (state.medicationHistory.isNotEmpty()) {
+            item {
+                SectionHeader(title = stringResource(id = R.string.today_section_medication_history))
+            }
+            items(state.medicationHistory, key = { "medhist_${it.medicationDoseInstanceId}" }) { item ->
+                Card(modifier = Modifier.fillMaxWidth()) {
+                    Column(modifier = Modifier.padding(12.dp)) {
+                        Text(text = item.name, style = MaterialTheme.typography.bodyMedium)
+                        Text(
+                            text = item.status,
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.outline,
+                        )
+                    }
+                }
+            }
+        }
+
+        if (state.summary.isCaughtUp) {
+            item {
+                Spacer(modifier = Modifier.height(8.dp))
+                Text(
+                    text = stringResource(id = R.string.home_all_caught_up),
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.outline,
+                    modifier = Modifier.fillMaxWidth(),
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun SectionHeader(
+    title: String,
+    titleColor: androidx.compose.ui.graphics.Color = MaterialTheme.colorScheme.onSurface,
+) {
+    Text(
+        text = title,
+        style = MaterialTheme.typography.titleSmall,
+        color = titleColor,
+        modifier = Modifier.padding(top = 4.dp, bottom = 2.dp),
+    )
+}
+
+@Composable
+@Suppress("FunctionNaming")
+private fun MedicationTodayCard(
+    item: MedicationTodayItemDto,
+    onTake: () -> Unit,
+    onSkip: () -> Unit,
+) {
+    Card(modifier = Modifier.fillMaxWidth()) {
+        Row(
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .padding(12.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Column(modifier = Modifier.weight(1f)) {
+                Text(text = item.name, style = MaterialTheme.typography.bodyMedium)
+                if (item.instructions.isNotEmpty()) {
+                    Text(
+                        text = item.instructions,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.outline,
+                    )
+                }
+            }
+            TextButton(onClick = onTake) {
+                Text(text = stringResource(id = R.string.action_take))
+            }
+            TextButton(onClick = onSkip) {
+                Text(text = stringResource(id = R.string.action_skip))
+            }
+        }
+    }
+}
+
+@Composable
+@Suppress("FunctionNaming")
+private fun RoutineCard(
+    item: RoutineTodayItemDto,
+    onComplete: () -> Unit,
+    onSkip: () -> Unit,
+) {
+    val isDone = item.status == "completed"
+    Card(modifier = Modifier.fillMaxWidth()) {
+        Row(
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .padding(12.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Text(
+                text = item.title,
+                style = MaterialTheme.typography.bodyMedium,
+                textDecoration = if (isDone) TextDecoration.LineThrough else TextDecoration.None,
+                modifier = Modifier.weight(1f),
+            )
+            if (!isDone) {
+                TextButton(onClick = onComplete) {
+                    Text(text = stringResource(id = R.string.action_done))
+                }
+                TextButton(onClick = onSkip) {
+                    Text(text = stringResource(id = R.string.action_skip))
+                }
+            }
+        }
+    }
+}
+
+@Composable
+@Suppress("FunctionNaming")
+private fun ChoreCard(
+    title: String,
+    subtitle: String?,
+    onComplete: () -> Unit,
+    onSkip: () -> Unit,
+) {
+    Card(modifier = Modifier.fillMaxWidth()) {
+        Row(
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .padding(12.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Column(modifier = Modifier.weight(1f)) {
+                Text(text = title, style = MaterialTheme.typography.bodyMedium)
+                if (subtitle != null) {
+                    Text(
+                        text = subtitle,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.outline,
+                    )
+                }
+            }
+            TextButton(onClick = onComplete) {
+                Text(text = stringResource(id = R.string.action_done))
+            }
+            TextButton(onClick = onSkip) {
+                Text(text = stringResource(id = R.string.action_skip))
+            }
+        }
+    }
+}
+
+@Composable
+@Suppress("FunctionNaming")
+private fun PlannedItemCard(
+    item: PlannedTodayItemDto,
+    onToggleDone: () -> Unit,
+    onDelete: () -> Unit,
+) {
+    Card(modifier = Modifier.fillMaxWidth()) {
+        Row(
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .padding(12.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = item.title,
+                    style = MaterialTheme.typography.bodyMedium,
+                    textDecoration = if (item.isDone) TextDecoration.LineThrough else TextDecoration.None,
+                )
+                if (!item.notes.isNullOrBlank()) {
+                    Text(
+                        text = item.notes,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.outline,
+                    )
+                }
+                if (!item.moduleKey.isNullOrBlank()) {
+                    Text(
+                        text = item.moduleKey,
+                        style = MaterialTheme.typography.labelSmall,
+                        color = MaterialTheme.colorScheme.primary,
+                    )
+                }
+            }
+            TextButton(onClick = onToggleDone) {
+                Text(
+                    text =
+                        if (item.isDone) {
+                            stringResource(id = R.string.action_undo)
+                        } else {
+                            stringResource(id = R.string.action_done)
+                        },
+                )
+            }
+            TextButton(
+                onClick = onDelete,
+                colors =
+                    ButtonDefaults.textButtonColors(
+                        contentColor = MaterialTheme.colorScheme.error,
+                    ),
+            ) {
+                Text(text = stringResource(id = R.string.action_delete))
+            }
+        }
+    }
+}
+
+@Composable
+@Suppress("FunctionNaming")
+private fun UpcomingChoreCard(item: UpcomingTodayItemDto) {
+    Card(modifier = Modifier.fillMaxWidth()) {
+        Row(
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .padding(12.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Text(
+                text = item.title,
+                style = MaterialTheme.typography.bodyMedium,
+                modifier = Modifier.weight(1f),
+            )
+            if (item.scheduledDate.isNotEmpty()) {
+                Text(
+                    text = item.scheduledDate,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.outline,
+                )
             }
         }
     }

--- a/android/app/src/main/java/com/daynest/android/feature/home/HomeRoute.kt
+++ b/android/app/src/main/java/com/daynest/android/feature/home/HomeRoute.kt
@@ -24,6 +24,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.unit.dp
@@ -142,7 +143,7 @@ private fun TodayContent(
                         if (state.summary.isCaughtUp) {
                             stringResource(id = R.string.home_all_caught_up)
                         } else {
-                            stringResource(id = R.string.home_items_remaining_label, state.summary.remainingCount)
+                            pluralStringResource(id = R.plurals.home_items_remaining, count = state.summary.remainingCount, state.summary.remainingCount)
                         },
                     style = MaterialTheme.typography.bodyLarge,
                 )

--- a/android/app/src/main/java/com/daynest/android/feature/home/HomeRoute.kt
+++ b/android/app/src/main/java/com/daynest/android/feature/home/HomeRoute.kt
@@ -9,7 +9,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Button
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -21,15 +20,21 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.daynest.android.R
+import com.daynest.android.app.navigation.DaynestDestination
+import com.daynest.android.app.navigation.DaynestNavigationScaffold
 
 @Composable
 @Suppress("FunctionNaming")
-fun HomeRoute(viewModel: HomeViewModel = hiltViewModel()) {
+fun HomeRoute(
+    onNavigate: (String) -> Unit = {},
+    viewModel: HomeViewModel = hiltViewModel(),
+) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
 
     HomeScreen(
         uiState = uiState,
         onEvent = viewModel::onEvent,
+        onNavigate = onNavigate,
     )
 }
 
@@ -38,8 +43,12 @@ fun HomeRoute(viewModel: HomeViewModel = hiltViewModel()) {
 internal fun HomeScreen(
     uiState: HomeUiState,
     onEvent: (HomeUiEvent) -> Unit,
+    onNavigate: (String) -> Unit = {},
 ) {
-    Scaffold(modifier = Modifier.fillMaxSize()) { innerPadding ->
+    DaynestNavigationScaffold(
+        currentRoute = DaynestDestination.HOME,
+        onNavigate = onNavigate,
+    ) { innerPadding ->
         Column(
             modifier =
                 Modifier

--- a/android/app/src/main/java/com/daynest/android/feature/home/HomeRoute.kt
+++ b/android/app/src/main/java/com/daynest/android/feature/home/HomeRoute.kt
@@ -143,7 +143,11 @@ private fun TodayContent(
                         if (state.summary.isCaughtUp) {
                             stringResource(id = R.string.home_all_caught_up)
                         } else {
-                            pluralStringResource(id = R.plurals.home_items_remaining, count = state.summary.remainingCount, state.summary.remainingCount)
+                            pluralStringResource(
+                                id = R.plurals.home_items_remaining,
+                                count = state.summary.remainingCount,
+                                state.summary.remainingCount,
+                            )
                         },
                     style = MaterialTheme.typography.bodyLarge,
                 )

--- a/android/app/src/main/java/com/daynest/android/feature/home/HomeViewModel.kt
+++ b/android/app/src/main/java/com/daynest/android/feature/home/HomeViewModel.kt
@@ -37,8 +37,8 @@ class HomeViewModel
                             current
                         } else {
                             when (val c = current) {
-                                is HomeUiState.Content -> c.copy(summary = summary)
-                                else -> HomeUiState.Content(summary = summary)
+                                is HomeUiState.Content -> c.copy(summary = summary, isStale = false)
+                                else -> HomeUiState.Content(summary = summary, isStale = false)
                             }
                         }
                     }
@@ -58,6 +58,7 @@ class HomeViewModel
                                         dueToday = response.dueToday,
                                         upcoming = response.upcoming,
                                         planned = response.planned,
+                                        isStale = false,
                                     )
                                 else ->
                                     HomeUiState.Content(
@@ -150,7 +151,19 @@ class HomeViewModel
                 if (result.isSuccess) {
                     _uiState.update { current ->
                         if (current is HomeUiState.Content) {
-                            current.copy(planned = current.planned.filter { it.id != id })
+                            val deletedItem = current.planned.firstOrNull { it.id == id }
+                            val wasPending = deletedItem?.isDone == false
+                            current.copy(
+                                planned = current.planned.filter { it.id != id },
+                                summary =
+                                    if (wasPending) {
+                                        current.summary.copy(
+                                            plannedPendingCount = maxOf(0, current.summary.plannedPendingCount - 1),
+                                        )
+                                    } else {
+                                        current.summary
+                                    },
+                            )
                         } else {
                             current
                         }

--- a/android/app/src/main/java/com/daynest/android/feature/home/HomeViewModel.kt
+++ b/android/app/src/main/java/com/daynest/android/feature/home/HomeViewModel.kt
@@ -3,7 +3,14 @@ package com.daynest.android.feature.home
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.daynest.android.core.model.TodaySummary
+import com.daynest.android.data.today.DueTodayItemDto
+import com.daynest.android.data.today.MedicationHistoryItemDto
+import com.daynest.android.data.today.MedicationTodayItemDto
+import com.daynest.android.data.today.OverdueTodayItemDto
+import com.daynest.android.data.today.PlannedTodayItemDto
+import com.daynest.android.data.today.RoutineTodayItemDto
 import com.daynest.android.data.today.TodayRepository
+import com.daynest.android.data.today.UpcomingTodayItemDto
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -29,7 +36,47 @@ class HomeViewModel
                         if (summary == null) {
                             current
                         } else {
-                            HomeUiState.Content(summary = summary, isStale = false)
+                            when (val c = current) {
+                                is HomeUiState.Content -> c.copy(summary = summary)
+                                else -> HomeUiState.Content(summary = summary)
+                            }
+                        }
+                    }
+                }
+            }
+            viewModelScope.launch {
+                repository.observeTodayResponse().collect { response ->
+                    if (response != null) {
+                        _uiState.update { current ->
+                            when (val c = current) {
+                                is HomeUiState.Content ->
+                                    c.copy(
+                                        medication = response.medication,
+                                        medicationHistory = response.medicationHistory,
+                                        routines = response.routines,
+                                        overdue = response.overdue,
+                                        dueToday = response.dueToday,
+                                        upcoming = response.upcoming,
+                                        planned = response.planned,
+                                    )
+                                else ->
+                                    HomeUiState.Content(
+                                        summary =
+                                            TodaySummary(
+                                                routinesCount = response.routines.size,
+                                                choresCount = response.dueToday.size + response.overdue.size,
+                                                medicationsCount = response.medication.size,
+                                                plannedPendingCount = response.planned.count { !it.isDone },
+                                            ),
+                                        medication = response.medication,
+                                        medicationHistory = response.medicationHistory,
+                                        routines = response.routines,
+                                        overdue = response.overdue,
+                                        dueToday = response.dueToday,
+                                        upcoming = response.upcoming,
+                                        planned = response.planned,
+                                    )
+                            }
                         }
                     }
                 }
@@ -40,7 +87,75 @@ class HomeViewModel
         fun onEvent(event: HomeUiEvent) {
             when (event) {
                 HomeUiEvent.RetryClicked -> refresh()
-                HomeUiEvent.OpenTodayDetailsClicked -> Unit
+                HomeUiEvent.RefreshRequested -> refresh()
+                is HomeUiEvent.CompleteChoreClicked -> choreAction(event.choreInstanceId, complete = true)
+                is HomeUiEvent.SkipChoreClicked -> choreAction(event.choreInstanceId, complete = false)
+                is HomeUiEvent.CompleteTaskClicked -> taskAction(event.taskInstanceId, complete = true)
+                is HomeUiEvent.SkipTaskClicked -> taskAction(event.taskInstanceId, complete = false)
+                is HomeUiEvent.TakeMedicationClicked -> doseAction(event.doseInstanceId, take = true)
+                is HomeUiEvent.SkipMedicationClicked -> doseAction(event.doseInstanceId, take = false)
+                is HomeUiEvent.MarkPlannedDoneClicked -> markPlannedDone(event.id, event.isDone)
+                is HomeUiEvent.DeletePlannedClicked -> deletePlanned(event.id)
+            }
+        }
+
+        private fun choreAction(
+            id: Int,
+            complete: Boolean,
+        ) {
+            viewModelScope.launch {
+                val result = if (complete) repository.completeChore(id) else repository.skipChore(id)
+                if (result.isSuccess) refresh()
+            }
+        }
+
+        private fun taskAction(
+            id: Int,
+            complete: Boolean,
+        ) {
+            viewModelScope.launch {
+                val result = if (complete) repository.completeTask(id) else repository.skipTask(id)
+                if (result.isSuccess) refresh()
+            }
+        }
+
+        private fun doseAction(
+            id: Int,
+            take: Boolean,
+        ) {
+            viewModelScope.launch {
+                val result = if (take) repository.takeDose(id) else repository.skipDose(id)
+                if (result.isSuccess) refresh()
+            }
+        }
+
+        private fun markPlannedDone(
+            id: Int,
+            isDone: Boolean,
+        ) {
+            val currentPlanned =
+                (_uiState.value as? HomeUiState.Content)
+                    ?.planned
+                    ?.firstOrNull { it.id == id }
+                    ?: return
+            viewModelScope.launch {
+                val result = repository.markPlannedDone(id, currentPlanned, isDone)
+                if (result.isSuccess) refresh()
+            }
+        }
+
+        private fun deletePlanned(id: Int) {
+            viewModelScope.launch {
+                val result = repository.deletePlannedItem(id)
+                if (result.isSuccess) {
+                    _uiState.update { current ->
+                        if (current is HomeUiState.Content) {
+                            current.copy(planned = current.planned.filter { it.id != id })
+                        } else {
+                            current
+                        }
+                    }
+                }
             }
         }
 
@@ -67,6 +182,13 @@ sealed interface HomeUiState {
 
     data class Content(
         val summary: TodaySummary,
+        val medication: List<MedicationTodayItemDto> = emptyList(),
+        val medicationHistory: List<MedicationHistoryItemDto> = emptyList(),
+        val routines: List<RoutineTodayItemDto> = emptyList(),
+        val overdue: List<OverdueTodayItemDto> = emptyList(),
+        val dueToday: List<DueTodayItemDto> = emptyList(),
+        val upcoming: List<UpcomingTodayItemDto> = emptyList(),
+        val planned: List<PlannedTodayItemDto> = emptyList(),
         val isStale: Boolean = false,
     ) : HomeUiState
 
@@ -78,7 +200,40 @@ sealed interface HomeUiState {
 sealed interface HomeUiEvent {
     data object RetryClicked : HomeUiEvent
 
-    data object OpenTodayDetailsClicked : HomeUiEvent
+    data object RefreshRequested : HomeUiEvent
+
+    data class CompleteChoreClicked(
+        val choreInstanceId: Int,
+    ) : HomeUiEvent
+
+    data class SkipChoreClicked(
+        val choreInstanceId: Int,
+    ) : HomeUiEvent
+
+    data class CompleteTaskClicked(
+        val taskInstanceId: Int,
+    ) : HomeUiEvent
+
+    data class SkipTaskClicked(
+        val taskInstanceId: Int,
+    ) : HomeUiEvent
+
+    data class TakeMedicationClicked(
+        val doseInstanceId: Int,
+    ) : HomeUiEvent
+
+    data class SkipMedicationClicked(
+        val doseInstanceId: Int,
+    ) : HomeUiEvent
+
+    data class MarkPlannedDoneClicked(
+        val id: Int,
+        val isDone: Boolean,
+    ) : HomeUiEvent
+
+    data class DeletePlannedClicked(
+        val id: Int,
+    ) : HomeUiEvent
 }
 
 enum class HomeError {

--- a/android/app/src/main/java/com/daynest/android/feature/medication/MedicationRoute.kt
+++ b/android/app/src/main/java/com/daynest/android/feature/medication/MedicationRoute.kt
@@ -2,23 +2,333 @@
 
 package com.daynest.android.feature.medication
 
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.daynest.android.R
 import com.daynest.android.app.navigation.DaynestDestination
-import com.daynest.android.app.navigation.DaynestParityRoute
+import com.daynest.android.app.navigation.DaynestNavigationScaffold
+import com.daynest.android.data.medication.MedicationHistoryItemDto
+import com.daynest.android.data.medication.MedicationPlanDto
+import com.daynest.android.data.medication.MedicationPlanInputDto
+import java.time.LocalDate
 
 @Composable
-fun MedicationRoute(onNavigate: (String) -> Unit = {}) {
-    DaynestParityRoute(
+fun MedicationRoute(
+    onNavigate: (String) -> Unit = {},
+    viewModel: MedicationViewModel = hiltViewModel(),
+) {
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    MedicationScreen(uiState = uiState, onEvent = viewModel::onEvent, onNavigate = onNavigate)
+}
+
+@Composable
+private fun MedicationScreen(
+    uiState: MedicationUiState,
+    onEvent: (MedicationUiEvent) -> Unit,
+    onNavigate: (String) -> Unit,
+) {
+    DaynestNavigationScaffold(
         currentRoute = DaynestDestination.MEDICATION,
         onNavigate = onNavigate,
-        titleRes = R.string.medication_title,
-        subtitleRes = R.string.medication_subtitle,
-        capabilityResIds =
-            listOf(
-                R.string.medication_capability_today,
-                R.string.medication_capability_history,
-                R.string.medication_capability_strict,
-            ),
+    ) { innerPadding ->
+        when (uiState) {
+            MedicationUiState.Loading -> {
+                Box(
+                    modifier =
+                        Modifier
+                            .fillMaxSize()
+                            .padding(innerPadding),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    CircularProgressIndicator()
+                }
+            }
+
+            MedicationUiState.Error -> {
+                Column(
+                    modifier =
+                        Modifier
+                            .fillMaxSize()
+                            .padding(innerPadding)
+                            .padding(24.dp),
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                    verticalArrangement = Arrangement.Center,
+                ) {
+                    Text(
+                        text = stringResource(id = R.string.medication_error),
+                        style = MaterialTheme.typography.bodyLarge,
+                    )
+                    Button(
+                        onClick = { onEvent(MedicationUiEvent.RetryClicked) },
+                        modifier = Modifier.padding(top = 16.dp),
+                    ) {
+                        Text(text = stringResource(id = R.string.home_retry))
+                    }
+                }
+            }
+
+            is MedicationUiState.Content -> {
+                MedicationContent(
+                    state = uiState,
+                    onEvent = onEvent,
+                    modifier = Modifier.padding(innerPadding),
+                )
+            }
+        }
+    }
+}
+
+@Composable
+@Suppress("LongMethod")
+private fun MedicationContent(
+    state: MedicationUiState.Content,
+    onEvent: (MedicationUiEvent) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    LazyColumn(
+        modifier = modifier.fillMaxSize(),
+        contentPadding = PaddingValues(16.dp),
+        verticalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        item {
+            Text(
+                text = stringResource(id = R.string.medication_title),
+                style = MaterialTheme.typography.headlineMedium,
+            )
+        }
+
+        item {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Text(
+                    text = stringResource(id = R.string.medication_plans_section),
+                    style = MaterialTheme.typography.titleMedium,
+                    modifier = Modifier.weight(1f),
+                )
+                TextButton(onClick = { onEvent(MedicationUiEvent.ShowCreateForm) }) {
+                    Text(text = stringResource(id = R.string.medication_add_plan))
+                }
+            }
+        }
+
+        if (state.plans.isEmpty()) {
+            item {
+                Text(
+                    text = stringResource(id = R.string.medication_no_plans),
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.outline,
+                )
+            }
+        } else {
+            items(state.plans, key = { it.id }) { plan ->
+                MedicationPlanCard(plan = plan)
+            }
+        }
+
+        item {
+            Text(
+                text = stringResource(id = R.string.medication_history_section),
+                style = MaterialTheme.typography.titleMedium,
+                modifier = Modifier.padding(top = 8.dp),
+            )
+        }
+
+        if (state.history.isEmpty()) {
+            item {
+                Text(
+                    text = stringResource(id = R.string.medication_no_history),
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.outline,
+                )
+            }
+        } else {
+            items(state.history, key = { it.medicationDoseInstanceId }) { item ->
+                MedicationHistoryCard(item = item)
+            }
+        }
+    }
+
+    if (state.showCreateForm) {
+        CreateMedicationPlanDialog(
+            onConfirm = { onEvent(MedicationUiEvent.CreatePlanClicked(it)) },
+            onDismiss = { onEvent(MedicationUiEvent.DismissCreateForm) },
+        )
+    }
+}
+
+@Composable
+private fun MedicationPlanCard(plan: MedicationPlanDto) {
+    Card(modifier = Modifier.fillMaxWidth()) {
+        Column(modifier = Modifier.padding(12.dp)) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Text(
+                    text = plan.name,
+                    style = MaterialTheme.typography.bodyMedium,
+                    modifier = Modifier.weight(1f),
+                )
+                if (!plan.isActive) {
+                    Text(
+                        text = stringResource(id = R.string.medication_inactive),
+                        style = MaterialTheme.typography.labelSmall,
+                        color = MaterialTheme.colorScheme.outline,
+                    )
+                }
+            }
+            if (plan.instructions.isNotEmpty()) {
+                Text(
+                    text = plan.instructions,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.outline,
+                )
+            }
+            Text(
+                text =
+                    stringResource(
+                        id = R.string.medication_plan_schedule,
+                        plan.scheduleTime,
+                        plan.everyNDays,
+                    ),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.outline,
+            )
+        }
+    }
+}
+
+@Composable
+private fun MedicationHistoryCard(item: MedicationHistoryItemDto) {
+    Card(modifier = Modifier.fillMaxWidth()) {
+        Row(
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .padding(12.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Column(modifier = Modifier.weight(1f)) {
+                Text(text = item.name, style = MaterialTheme.typography.bodyMedium)
+                if (item.scheduledAt.isNotEmpty()) {
+                    Text(
+                        text = item.scheduledAt,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.outline,
+                    )
+                }
+            }
+            val statusColor =
+                when (item.status) {
+                    "taken" -> MaterialTheme.colorScheme.primary
+                    "skipped" -> MaterialTheme.colorScheme.outline
+                    "missed" -> MaterialTheme.colorScheme.error
+                    else -> MaterialTheme.colorScheme.outline
+                }
+            Text(
+                text = item.status,
+                style = MaterialTheme.typography.labelSmall,
+                color = statusColor,
+            )
+        }
+    }
+}
+
+@Composable
+@Suppress("LongMethod")
+private fun CreateMedicationPlanDialog(
+    onConfirm: (MedicationPlanInputDto) -> Unit,
+    onDismiss: () -> Unit,
+) {
+    var name by remember { mutableStateOf("") }
+    var instructions by remember { mutableStateOf("") }
+    var scheduleTime by remember { mutableStateOf("08:00") }
+    var everyNDays by remember { mutableStateOf("1") }
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(text = stringResource(id = R.string.medication_create_title)) },
+        text = {
+            Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                OutlinedTextField(
+                    value = name,
+                    onValueChange = { name = it },
+                    label = { Text(text = stringResource(id = R.string.medication_name_label)) },
+                    singleLine = true,
+                )
+                OutlinedTextField(
+                    value = instructions,
+                    onValueChange = { instructions = it },
+                    label = { Text(text = stringResource(id = R.string.medication_instructions_label)) },
+                    singleLine = true,
+                )
+                OutlinedTextField(
+                    value = scheduleTime,
+                    onValueChange = { scheduleTime = it },
+                    label = { Text(text = stringResource(id = R.string.medication_time_label)) },
+                    singleLine = true,
+                )
+                OutlinedTextField(
+                    value = everyNDays,
+                    onValueChange = { everyNDays = it.filter { c -> c.isDigit() } },
+                    label = { Text(text = stringResource(id = R.string.medication_every_n_days_label)) },
+                    singleLine = true,
+                )
+            }
+        },
+        confirmButton = {
+            TextButton(
+                onClick = {
+                    if (name.isNotBlank()) {
+                        onConfirm(
+                            MedicationPlanInputDto(
+                                name = name.trim(),
+                                instructions = instructions.trim(),
+                                startDate = LocalDate.now().toString(),
+                                scheduleTime = scheduleTime.trim().ifBlank { "08:00" },
+                                everyNDays = everyNDays.toIntOrNull() ?: 1,
+                            ),
+                        )
+                    }
+                },
+                enabled = name.isNotBlank(),
+            ) {
+                Text(text = stringResource(id = R.string.action_add))
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) {
+                Text(text = stringResource(id = R.string.action_cancel))
+            }
+        },
     )
 }

--- a/android/app/src/main/java/com/daynest/android/feature/medication/MedicationRoute.kt
+++ b/android/app/src/main/java/com/daynest/android/feature/medication/MedicationRoute.kt
@@ -1,0 +1,24 @@
+@file:Suppress("ktlint:standard:function-naming", "FunctionNaming")
+
+package com.daynest.android.feature.medication
+
+import androidx.compose.runtime.Composable
+import com.daynest.android.R
+import com.daynest.android.app.navigation.DaynestDestination
+import com.daynest.android.app.navigation.DaynestParityRoute
+
+@Composable
+fun MedicationRoute(onNavigate: (String) -> Unit = {}) {
+    DaynestParityRoute(
+        currentRoute = DaynestDestination.MEDICATION,
+        onNavigate = onNavigate,
+        titleRes = R.string.medication_title,
+        subtitleRes = R.string.medication_subtitle,
+        capabilityResIds =
+            listOf(
+                R.string.medication_capability_today,
+                R.string.medication_capability_history,
+                R.string.medication_capability_strict,
+            ),
+    )
+}

--- a/android/app/src/main/java/com/daynest/android/feature/medication/MedicationViewModel.kt
+++ b/android/app/src/main/java/com/daynest/android/feature/medication/MedicationViewModel.kt
@@ -42,7 +42,7 @@ class MedicationViewModel
                 val plansResult = repository.listPlans()
                 val historyResult = repository.getHistory()
 
-                if (plansResult.isSuccess) {
+                if (plansResult.isSuccess && historyResult.isSuccess) {
                     _uiState.value =
                         MedicationUiState.Content(
                             plans = plansResult.getOrElse { emptyList() },

--- a/android/app/src/main/java/com/daynest/android/feature/medication/MedicationViewModel.kt
+++ b/android/app/src/main/java/com/daynest/android/feature/medication/MedicationViewModel.kt
@@ -1,0 +1,111 @@
+package com.daynest.android.feature.medication
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.daynest.android.data.medication.MedicationHistoryItemDto
+import com.daynest.android.data.medication.MedicationPlanDto
+import com.daynest.android.data.medication.MedicationPlanInputDto
+import com.daynest.android.data.medication.MedicationRepository
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class MedicationViewModel
+    @Inject
+    constructor(
+        private val repository: MedicationRepository,
+    ) : ViewModel() {
+        private val _uiState = MutableStateFlow<MedicationUiState>(MedicationUiState.Loading)
+        val uiState: StateFlow<MedicationUiState> = _uiState.asStateFlow()
+
+        init {
+            load()
+        }
+
+        fun onEvent(event: MedicationUiEvent) {
+            when (event) {
+                is MedicationUiEvent.RetryClicked -> load()
+                is MedicationUiEvent.CreatePlanClicked -> createPlan(event.input)
+                is MedicationUiEvent.DismissCreateForm -> dismissForm()
+                is MedicationUiEvent.ShowCreateForm -> showForm()
+            }
+        }
+
+        private fun load() {
+            viewModelScope.launch {
+                _uiState.value = MedicationUiState.Loading
+                val plansResult = repository.listPlans()
+                val historyResult = repository.getHistory()
+
+                if (plansResult.isSuccess) {
+                    _uiState.value =
+                        MedicationUiState.Content(
+                            plans = plansResult.getOrElse { emptyList() },
+                            history = historyResult.getOrElse { emptyList() },
+                            showCreateForm = false,
+                        )
+                } else {
+                    _uiState.value = MedicationUiState.Error
+                }
+            }
+        }
+
+        private fun showForm() {
+            _uiState.update { current ->
+                if (current is MedicationUiState.Content) current.copy(showCreateForm = true) else current
+            }
+        }
+
+        private fun dismissForm() {
+            _uiState.update { current ->
+                if (current is MedicationUiState.Content) current.copy(showCreateForm = false) else current
+            }
+        }
+
+        private fun createPlan(input: MedicationPlanInputDto) {
+            viewModelScope.launch {
+                val result = repository.createPlan(input)
+                result.onSuccess { newPlan ->
+                    _uiState.update { current ->
+                        if (current is MedicationUiState.Content) {
+                            current.copy(
+                                plans = current.plans + newPlan,
+                                showCreateForm = false,
+                            )
+                        } else {
+                            current
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+sealed interface MedicationUiState {
+    data object Loading : MedicationUiState
+
+    data class Content(
+        val plans: List<MedicationPlanDto>,
+        val history: List<MedicationHistoryItemDto>,
+        val showCreateForm: Boolean,
+    ) : MedicationUiState
+
+    data object Error : MedicationUiState
+}
+
+sealed interface MedicationUiEvent {
+    data object RetryClicked : MedicationUiEvent
+
+    data object ShowCreateForm : MedicationUiEvent
+
+    data object DismissCreateForm : MedicationUiEvent
+
+    data class CreatePlanClicked(
+        val input: MedicationPlanInputDto,
+    ) : MedicationUiEvent
+}

--- a/android/app/src/main/java/com/daynest/android/feature/settings/SettingsRoute.kt
+++ b/android/app/src/main/java/com/daynest/android/feature/settings/SettingsRoute.kt
@@ -2,23 +2,336 @@
 
 package com.daynest.android.feature.settings
 
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Card
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.daynest.android.R
 import com.daynest.android.app.navigation.DaynestDestination
-import com.daynest.android.app.navigation.DaynestParityRoute
+import com.daynest.android.app.navigation.DaynestNavigationScaffold
+import com.daynest.android.data.settings.IntegrationClientDto
+import com.daynest.android.data.settings.IntegrationClientInputDto
 
 @Composable
-fun SettingsRoute(onNavigate: (String) -> Unit = {}) {
-    DaynestParityRoute(
+fun SettingsRoute(
+    onNavigate: (String) -> Unit = {},
+    onSignedOut: (() -> Unit)? = null,
+    viewModel: SettingsViewModel = hiltViewModel(),
+) {
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+
+    LaunchedEffect(uiState) {
+        if (uiState is SettingsUiState.SignedOut) {
+            onSignedOut?.invoke()
+        }
+    }
+
+    SettingsScreen(uiState = uiState, onEvent = viewModel::onEvent, onNavigate = onNavigate)
+}
+
+@Composable
+private fun SettingsScreen(
+    uiState: SettingsUiState,
+    onEvent: (SettingsUiEvent) -> Unit,
+    onNavigate: (String) -> Unit,
+) {
+    DaynestNavigationScaffold(
         currentRoute = DaynestDestination.SETTINGS,
         onNavigate = onNavigate,
-        titleRes = R.string.settings_title,
-        subtitleRes = R.string.settings_subtitle,
-        capabilityResIds =
-            listOf(
-                R.string.settings_capability_account,
-                R.string.settings_capability_integrations,
-                R.string.settings_capability_clients,
-            ),
+    ) { innerPadding ->
+        when (uiState) {
+            SettingsUiState.Loading, SettingsUiState.SignedOut -> {
+                Box(
+                    modifier =
+                        Modifier
+                            .fillMaxSize()
+                            .padding(innerPadding),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    CircularProgressIndicator()
+                }
+            }
+
+            is SettingsUiState.Content -> {
+                SettingsContent(
+                    state = uiState,
+                    onEvent = onEvent,
+                    modifier = Modifier.padding(innerPadding),
+                )
+            }
+        }
+    }
+}
+
+@Composable
+@Suppress("LongMethod")
+private fun SettingsContent(
+    state: SettingsUiState.Content,
+    onEvent: (SettingsUiEvent) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    LazyColumn(
+        modifier = modifier.fillMaxSize(),
+        contentPadding = PaddingValues(16.dp),
+        verticalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        item {
+            Text(
+                text = stringResource(id = R.string.settings_title),
+                style = MaterialTheme.typography.headlineMedium,
+            )
+        }
+
+        item {
+            HorizontalDivider(modifier = Modifier.padding(vertical = 4.dp))
+            Text(
+                text = stringResource(id = R.string.settings_account_section),
+                style = MaterialTheme.typography.titleMedium,
+            )
+        }
+
+        item {
+            Card(modifier = Modifier.fillMaxWidth()) {
+                Row(
+                    modifier =
+                        Modifier
+                            .fillMaxWidth()
+                            .padding(12.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    Text(
+                        text = stringResource(id = R.string.settings_session_active),
+                        style = MaterialTheme.typography.bodyMedium,
+                        modifier = Modifier.weight(1f),
+                    )
+                    TextButton(onClick = { onEvent(SettingsUiEvent.SignOutClicked) }) {
+                        Text(
+                            text = stringResource(id = R.string.settings_sign_out),
+                            color = MaterialTheme.colorScheme.error,
+                        )
+                    }
+                }
+            }
+        }
+
+        item {
+            HorizontalDivider(modifier = Modifier.padding(vertical = 4.dp))
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Text(
+                    text = stringResource(id = R.string.settings_integrations_section),
+                    style = MaterialTheme.typography.titleMedium,
+                    modifier = Modifier.weight(1f),
+                )
+                TextButton(onClick = { onEvent(SettingsUiEvent.ShowCreateClientForm) }) {
+                    Text(text = stringResource(id = R.string.settings_new_client))
+                }
+            }
+        }
+
+        if (state.loadError) {
+            item {
+                Text(
+                    text = stringResource(id = R.string.settings_clients_error),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.error,
+                )
+                TextButton(onClick = { onEvent(SettingsUiEvent.RetryClicked) }) {
+                    Text(text = stringResource(id = R.string.home_retry))
+                }
+            }
+        } else if (state.clients.isEmpty()) {
+            item {
+                Text(
+                    text = stringResource(id = R.string.settings_no_clients),
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.outline,
+                )
+            }
+        } else {
+            items(state.clients, key = { it.id }) { client ->
+                IntegrationClientCard(client = client)
+            }
+        }
+    }
+
+    if (state.showCreateForm) {
+        CreateClientDialog(
+            onConfirm = { onEvent(SettingsUiEvent.CreateClient(it)) },
+            onDismiss = { onEvent(SettingsUiEvent.DismissCreateClientForm) },
+        )
+    }
+
+    if (state.newApiKey != null) {
+        NewApiKeyDialog(
+            apiKey = state.newApiKey,
+            onDismiss = { onEvent(SettingsUiEvent.DismissNewKeyDialog) },
+        )
+    }
+}
+
+@Composable
+private fun IntegrationClientCard(client: IntegrationClientDto) {
+    Card(modifier = Modifier.fillMaxWidth()) {
+        Column(modifier = Modifier.padding(12.dp)) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Text(
+                    text = client.name,
+                    style = MaterialTheme.typography.bodyMedium,
+                    modifier = Modifier.weight(1f),
+                )
+                Text(
+                    text =
+                        if (client.isActive) {
+                            stringResource(id = R.string.settings_client_active)
+                        } else {
+                            stringResource(id = R.string.settings_client_inactive)
+                        },
+                    style = MaterialTheme.typography.labelSmall,
+                    color =
+                        if (client.isActive) {
+                            MaterialTheme.colorScheme.primary
+                        } else {
+                            MaterialTheme.colorScheme.outline
+                        },
+                )
+            }
+            if (client.scopes.isNotEmpty()) {
+                Text(
+                    text = client.scopes.joinToString(", "),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.outline,
+                )
+            }
+            Text(
+                text =
+                    stringResource(
+                        id = R.string.settings_client_rate_limit,
+                        client.rateLimitPerMinute,
+                    ),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.outline,
+            )
+        }
+    }
+}
+
+@Composable
+private fun CreateClientDialog(
+    onConfirm: (IntegrationClientInputDto) -> Unit,
+    onDismiss: () -> Unit,
+) {
+    var name by remember { mutableStateOf("") }
+    var scopes by remember { mutableStateOf("read") }
+    var rateLimit by remember { mutableStateOf("60") }
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(text = stringResource(id = R.string.settings_create_client_title)) },
+        text = {
+            Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                OutlinedTextField(
+                    value = name,
+                    onValueChange = { name = it },
+                    label = { Text(text = stringResource(id = R.string.settings_client_name_label)) },
+                    singleLine = true,
+                )
+                OutlinedTextField(
+                    value = scopes,
+                    onValueChange = { scopes = it },
+                    label = { Text(text = stringResource(id = R.string.settings_client_scopes_label)) },
+                    singleLine = true,
+                )
+                OutlinedTextField(
+                    value = rateLimit,
+                    onValueChange = { rateLimit = it.filter { c -> c.isDigit() } },
+                    label = { Text(text = stringResource(id = R.string.settings_client_rate_limit_label)) },
+                    singleLine = true,
+                )
+            }
+        },
+        confirmButton = {
+            TextButton(
+                onClick = {
+                    if (name.isNotBlank()) {
+                        onConfirm(
+                            IntegrationClientInputDto(
+                                name = name.trim(),
+                                scopes = scopes.split(",").map { it.trim() }.filter { it.isNotBlank() },
+                                rateLimitPerMinute = rateLimit.toIntOrNull() ?: 60,
+                            ),
+                        )
+                    }
+                },
+                enabled = name.isNotBlank(),
+            ) {
+                Text(text = stringResource(id = R.string.action_add))
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) {
+                Text(text = stringResource(id = R.string.action_cancel))
+            }
+        },
+    )
+}
+
+@Composable
+private fun NewApiKeyDialog(
+    apiKey: String,
+    onDismiss: () -> Unit,
+) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(text = stringResource(id = R.string.settings_new_key_title)) },
+        text = {
+            Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                Text(
+                    text = stringResource(id = R.string.settings_new_key_notice),
+                    style = MaterialTheme.typography.bodyMedium,
+                )
+                Text(
+                    text = apiKey,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.primary,
+                )
+            }
+        },
+        confirmButton = {
+            TextButton(onClick = onDismiss) {
+                Text(text = stringResource(id = R.string.settings_new_key_dismiss))
+            }
+        },
     )
 }

--- a/android/app/src/main/java/com/daynest/android/feature/settings/SettingsRoute.kt
+++ b/android/app/src/main/java/com/daynest/android/feature/settings/SettingsRoute.kt
@@ -1,0 +1,24 @@
+@file:Suppress("ktlint:standard:function-naming", "FunctionNaming")
+
+package com.daynest.android.feature.settings
+
+import androidx.compose.runtime.Composable
+import com.daynest.android.R
+import com.daynest.android.app.navigation.DaynestDestination
+import com.daynest.android.app.navigation.DaynestParityRoute
+
+@Composable
+fun SettingsRoute(onNavigate: (String) -> Unit = {}) {
+    DaynestParityRoute(
+        currentRoute = DaynestDestination.SETTINGS,
+        onNavigate = onNavigate,
+        titleRes = R.string.settings_title,
+        subtitleRes = R.string.settings_subtitle,
+        capabilityResIds =
+            listOf(
+                R.string.settings_capability_account,
+                R.string.settings_capability_integrations,
+                R.string.settings_capability_clients,
+            ),
+    )
+}

--- a/android/app/src/main/java/com/daynest/android/feature/settings/SettingsViewModel.kt
+++ b/android/app/src/main/java/com/daynest/android/feature/settings/SettingsViewModel.kt
@@ -8,11 +8,11 @@ import com.daynest.android.data.settings.IntegrationClientDto
 import com.daynest.android.data.settings.IntegrationClientInputDto
 import com.daynest.android.data.settings.SettingsRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
-import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 

--- a/android/app/src/main/java/com/daynest/android/feature/settings/SettingsViewModel.kt
+++ b/android/app/src/main/java/com/daynest/android/feature/settings/SettingsViewModel.kt
@@ -92,6 +92,7 @@ class SettingsViewModel
             }
         }
 
+        @Suppress("TooGenericExceptionCaught", "SwallowedException")
         private fun signOut() {
             viewModelScope.launch {
                 try {

--- a/android/app/src/main/java/com/daynest/android/feature/settings/SettingsViewModel.kt
+++ b/android/app/src/main/java/com/daynest/android/feature/settings/SettingsViewModel.kt
@@ -1,0 +1,138 @@
+package com.daynest.android.feature.settings
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.daynest.android.data.auth.AuthRepository
+import com.daynest.android.data.settings.IntegrationClientCreateResponseDto
+import com.daynest.android.data.settings.IntegrationClientDto
+import com.daynest.android.data.settings.IntegrationClientInputDto
+import com.daynest.android.data.settings.SettingsRepository
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class SettingsViewModel
+    @Inject
+    constructor(
+        private val settingsRepository: SettingsRepository,
+        private val authRepository: AuthRepository,
+    ) : ViewModel() {
+        private val _uiState = MutableStateFlow<SettingsUiState>(SettingsUiState.Loading)
+        val uiState: StateFlow<SettingsUiState> = _uiState.asStateFlow()
+
+        init {
+            load()
+        }
+
+        fun onEvent(event: SettingsUiEvent) {
+            when (event) {
+                SettingsUiEvent.RetryClicked -> load()
+                SettingsUiEvent.SignOutClicked -> signOut()
+                SettingsUiEvent.ShowCreateClientForm -> showCreateForm()
+                SettingsUiEvent.DismissCreateClientForm -> dismissCreateForm()
+                SettingsUiEvent.DismissNewKeyDialog -> dismissNewKeyDialog()
+                is SettingsUiEvent.CreateClient -> createClient(event.input)
+            }
+        }
+
+        private fun load() {
+            viewModelScope.launch {
+                _uiState.value = SettingsUiState.Loading
+                val result = settingsRepository.listClients()
+                _uiState.value =
+                    SettingsUiState.Content(
+                        clients = result.getOrElse { emptyList() },
+                        showCreateForm = false,
+                        newApiKey = null,
+                        loadError = result.isFailure,
+                    )
+            }
+        }
+
+        private fun showCreateForm() {
+            _uiState.update { current ->
+                if (current is SettingsUiState.Content) current.copy(showCreateForm = true) else current
+            }
+        }
+
+        private fun dismissCreateForm() {
+            _uiState.update { current ->
+                if (current is SettingsUiState.Content) current.copy(showCreateForm = false) else current
+            }
+        }
+
+        private fun dismissNewKeyDialog() {
+            _uiState.update { current ->
+                if (current is SettingsUiState.Content) current.copy(newApiKey = null) else current
+            }
+        }
+
+        private fun createClient(input: IntegrationClientInputDto) {
+            viewModelScope.launch {
+                val result = settingsRepository.createClient(input)
+                result.onSuccess { created ->
+                    _uiState.update { current ->
+                        if (current is SettingsUiState.Content) {
+                            current.copy(
+                                clients = current.clients + created.toDto(),
+                                showCreateForm = false,
+                                newApiKey = created.apiKey,
+                            )
+                        } else {
+                            current
+                        }
+                    }
+                }
+            }
+        }
+
+        private fun signOut() {
+            viewModelScope.launch {
+                authRepository.signOut()
+                _uiState.value = SettingsUiState.SignedOut
+            }
+        }
+
+        private fun IntegrationClientCreateResponseDto.toDto() =
+            IntegrationClientDto(
+                id = id,
+                name = name,
+                scopes = scopes,
+                rateLimitPerMinute = rateLimitPerMinute,
+                isActive = isActive,
+            )
+    }
+
+sealed interface SettingsUiState {
+    data object Loading : SettingsUiState
+
+    data class Content(
+        val clients: List<IntegrationClientDto>,
+        val showCreateForm: Boolean,
+        val newApiKey: String?,
+        val loadError: Boolean,
+    ) : SettingsUiState
+
+    data object SignedOut : SettingsUiState
+}
+
+sealed interface SettingsUiEvent {
+    data object RetryClicked : SettingsUiEvent
+
+    data object SignOutClicked : SettingsUiEvent
+
+    data object ShowCreateClientForm : SettingsUiEvent
+
+    data object DismissCreateClientForm : SettingsUiEvent
+
+    data object DismissNewKeyDialog : SettingsUiEvent
+
+    data class CreateClient(
+        val input: IntegrationClientInputDto,
+    ) : SettingsUiEvent
+}

--- a/android/app/src/main/java/com/daynest/android/feature/settings/SettingsViewModel.kt
+++ b/android/app/src/main/java/com/daynest/android/feature/settings/SettingsViewModel.kt
@@ -12,6 +12,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
@@ -93,8 +94,14 @@ class SettingsViewModel
 
         private fun signOut() {
             viewModelScope.launch {
-                authRepository.signOut()
-                _uiState.value = SettingsUiState.SignedOut
+                try {
+                    authRepository.signOut()
+                    _uiState.value = SettingsUiState.SignedOut
+                } catch (e: CancellationException) {
+                    throw e
+                } catch (e: Exception) {
+                    // sign-out failed; leave state unchanged so the UI remains responsive
+                }
             }
         }
 

--- a/android/app/src/main/java/com/daynest/android/feature/templates/TemplatesRoute.kt
+++ b/android/app/src/main/java/com/daynest/android/feature/templates/TemplatesRoute.kt
@@ -2,23 +2,458 @@
 
 package com.daynest.android.feature.templates
 
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Card
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.daynest.android.R
 import com.daynest.android.app.navigation.DaynestDestination
-import com.daynest.android.app.navigation.DaynestParityRoute
+import com.daynest.android.app.navigation.DaynestNavigationScaffold
+import com.daynest.android.data.templates.ChoreTemplateDto
+import com.daynest.android.data.templates.ChoreTemplateInputDto
+import com.daynest.android.data.templates.RoutineTemplateDto
+import com.daynest.android.data.templates.RoutineTemplateInputDto
+import java.time.LocalDate
 
 @Composable
-fun TemplatesRoute(onNavigate: (String) -> Unit = {}) {
-    DaynestParityRoute(
+fun TemplatesRoute(
+    onNavigate: (String) -> Unit = {},
+    viewModel: TemplatesViewModel = hiltViewModel(),
+) {
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    TemplatesScreen(uiState = uiState, onEvent = viewModel::onEvent, onNavigate = onNavigate)
+}
+
+@Composable
+private fun TemplatesScreen(
+    uiState: TemplatesUiState,
+    onEvent: (TemplatesUiEvent) -> Unit,
+    onNavigate: (String) -> Unit,
+) {
+    DaynestNavigationScaffold(
         currentRoute = DaynestDestination.TEMPLATES,
         onNavigate = onNavigate,
-        titleRes = R.string.templates_title,
-        subtitleRes = R.string.templates_subtitle,
-        capabilityResIds =
-            listOf(
-                R.string.templates_capability_routines,
-                R.string.templates_capability_chores,
-                R.string.templates_capability_recurring,
-            ),
+    ) { innerPadding ->
+        when (uiState) {
+            TemplatesUiState.Loading -> {
+                Box(
+                    modifier =
+                        Modifier
+                            .fillMaxSize()
+                            .padding(innerPadding),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    CircularProgressIndicator()
+                }
+            }
+
+            TemplatesUiState.Error -> {
+                Column(
+                    modifier =
+                        Modifier
+                            .fillMaxSize()
+                            .padding(innerPadding)
+                            .padding(24.dp),
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                    verticalArrangement = Arrangement.Center,
+                ) {
+                    Text(
+                        text = stringResource(id = R.string.templates_error),
+                        style = MaterialTheme.typography.bodyLarge,
+                    )
+                    Button(
+                        onClick = { onEvent(TemplatesUiEvent.RetryClicked) },
+                        modifier = Modifier.padding(top = 16.dp),
+                    ) {
+                        Text(text = stringResource(id = R.string.home_retry))
+                    }
+                }
+            }
+
+            is TemplatesUiState.Content -> {
+                TemplatesContent(
+                    state = uiState,
+                    onEvent = onEvent,
+                    modifier = Modifier.padding(innerPadding),
+                )
+            }
+        }
+    }
+}
+
+@Composable
+@Suppress("LongMethod", "CyclomaticComplexMethod")
+private fun TemplatesContent(
+    state: TemplatesUiState.Content,
+    onEvent: (TemplatesUiEvent) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    LazyColumn(
+        modifier = modifier.fillMaxSize(),
+        contentPadding = PaddingValues(16.dp),
+        verticalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        item {
+            Text(
+                text = stringResource(id = R.string.templates_title),
+                style = MaterialTheme.typography.headlineMedium,
+            )
+        }
+
+        item {
+            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                FilterChip(
+                    selected = state.selectedTab == TemplateTab.Routines,
+                    onClick = { onEvent(TemplatesUiEvent.TabSelected(TemplateTab.Routines)) },
+                    label = { Text(text = stringResource(id = R.string.templates_tab_routines)) },
+                )
+                FilterChip(
+                    selected = state.selectedTab == TemplateTab.Chores,
+                    onClick = { onEvent(TemplatesUiEvent.TabSelected(TemplateTab.Chores)) },
+                    label = { Text(text = stringResource(id = R.string.templates_tab_chores)) },
+                )
+            }
+        }
+
+        when (state.selectedTab) {
+            TemplateTab.Routines -> {
+                item {
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        Text(
+                            text = stringResource(id = R.string.templates_tab_routines),
+                            style = MaterialTheme.typography.titleMedium,
+                            modifier = Modifier.weight(1f),
+                        )
+                        TextButton(onClick = { onEvent(TemplatesUiEvent.ShowCreateRoutineForm) }) {
+                            Text(text = stringResource(id = R.string.templates_add_routine))
+                        }
+                    }
+                }
+                if (state.routines.isEmpty()) {
+                    item {
+                        Text(
+                            text = stringResource(id = R.string.templates_no_routines),
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = MaterialTheme.colorScheme.outline,
+                        )
+                    }
+                } else {
+                    items(state.routines, key = { "routine_${it.id}" }) { routine ->
+                        RoutineTemplateCard(
+                            routine = routine,
+                            onDelete = { onEvent(TemplatesUiEvent.DeleteRoutine(routine.id)) },
+                        )
+                    }
+                }
+            }
+
+            TemplateTab.Chores -> {
+                item {
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        Text(
+                            text = stringResource(id = R.string.templates_tab_chores),
+                            style = MaterialTheme.typography.titleMedium,
+                            modifier = Modifier.weight(1f),
+                        )
+                        TextButton(onClick = { onEvent(TemplatesUiEvent.ShowCreateChoreForm) }) {
+                            Text(text = stringResource(id = R.string.templates_add_chore))
+                        }
+                    }
+                }
+                if (state.chores.isEmpty()) {
+                    item {
+                        Text(
+                            text = stringResource(id = R.string.templates_no_chores),
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = MaterialTheme.colorScheme.outline,
+                        )
+                    }
+                } else {
+                    items(state.chores, key = { "chore_${it.id}" }) { chore ->
+                        ChoreTemplateCard(
+                            chore = chore,
+                            onDelete = { onEvent(TemplatesUiEvent.DeleteChore(chore.id)) },
+                        )
+                    }
+                }
+            }
+        }
+    }
+
+    when (state.createForm) {
+        TemplateCreateForm.Routine ->
+            CreateRoutineDialog(
+                onConfirm = { onEvent(TemplatesUiEvent.CreateRoutine(it)) },
+                onDismiss = { onEvent(TemplatesUiEvent.DismissCreateForm) },
+            )
+
+        TemplateCreateForm.Chore ->
+            CreateChoreDialog(
+                onConfirm = { onEvent(TemplatesUiEvent.CreateChore(it)) },
+                onDismiss = { onEvent(TemplatesUiEvent.DismissCreateForm) },
+            )
+
+        null -> Unit
+    }
+}
+
+@Composable
+private fun RoutineTemplateCard(
+    routine: RoutineTemplateDto,
+    onDelete: () -> Unit,
+) {
+    Card(modifier = Modifier.fillMaxWidth()) {
+        Row(
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .padding(12.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Column(modifier = Modifier.weight(1f)) {
+                Text(text = routine.name, style = MaterialTheme.typography.bodyMedium)
+                if (!routine.description.isNullOrBlank()) {
+                    Text(
+                        text = routine.description,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.outline,
+                    )
+                }
+                Text(
+                    text =
+                        stringResource(
+                            id = R.string.templates_every_n_days,
+                            routine.everyNDays,
+                        ),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.outline,
+                )
+                if (!routine.isActive) {
+                    Text(
+                        text = stringResource(id = R.string.templates_inactive),
+                        style = MaterialTheme.typography.labelSmall,
+                        color = MaterialTheme.colorScheme.outline,
+                    )
+                }
+            }
+            TextButton(
+                onClick = onDelete,
+                colors =
+                    ButtonDefaults.textButtonColors(
+                        contentColor = MaterialTheme.colorScheme.error,
+                    ),
+            ) {
+                Text(text = stringResource(id = R.string.action_delete))
+            }
+        }
+    }
+}
+
+@Composable
+private fun ChoreTemplateCard(
+    chore: ChoreTemplateDto,
+    onDelete: () -> Unit,
+) {
+    Card(modifier = Modifier.fillMaxWidth()) {
+        Row(
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .padding(12.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Column(modifier = Modifier.weight(1f)) {
+                Text(text = chore.name, style = MaterialTheme.typography.bodyMedium)
+                if (!chore.description.isNullOrBlank()) {
+                    Text(
+                        text = chore.description,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.outline,
+                    )
+                }
+                Text(
+                    text =
+                        stringResource(
+                            id = R.string.templates_every_n_days,
+                            chore.everyNDays,
+                        ),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.outline,
+                )
+                if (!chore.isActive) {
+                    Text(
+                        text = stringResource(id = R.string.templates_inactive),
+                        style = MaterialTheme.typography.labelSmall,
+                        color = MaterialTheme.colorScheme.outline,
+                    )
+                }
+            }
+            TextButton(
+                onClick = onDelete,
+                colors =
+                    ButtonDefaults.textButtonColors(
+                        contentColor = MaterialTheme.colorScheme.error,
+                    ),
+            ) {
+                Text(text = stringResource(id = R.string.action_delete))
+            }
+        }
+    }
+}
+
+@Composable
+private fun CreateRoutineDialog(
+    onConfirm: (RoutineTemplateInputDto) -> Unit,
+    onDismiss: () -> Unit,
+) {
+    var name by remember { mutableStateOf("") }
+    var description by remember { mutableStateOf("") }
+    var everyNDays by remember { mutableStateOf("1") }
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(text = stringResource(id = R.string.templates_create_routine_title)) },
+        text = {
+            Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                OutlinedTextField(
+                    value = name,
+                    onValueChange = { name = it },
+                    label = { Text(text = stringResource(id = R.string.templates_name_label)) },
+                    singleLine = true,
+                )
+                OutlinedTextField(
+                    value = description,
+                    onValueChange = { description = it },
+                    label = { Text(text = stringResource(id = R.string.templates_description_label)) },
+                    singleLine = true,
+                )
+                OutlinedTextField(
+                    value = everyNDays,
+                    onValueChange = { everyNDays = it.filter { c -> c.isDigit() } },
+                    label = { Text(text = stringResource(id = R.string.templates_every_n_days_label)) },
+                    singleLine = true,
+                )
+            }
+        },
+        confirmButton = {
+            TextButton(
+                onClick = {
+                    if (name.isNotBlank()) {
+                        onConfirm(
+                            RoutineTemplateInputDto(
+                                name = name.trim(),
+                                description = description.trim().ifBlank { null },
+                                startDate = LocalDate.now().toString(),
+                                everyNDays = everyNDays.toIntOrNull() ?: 1,
+                                isActive = true,
+                            ),
+                        )
+                    }
+                },
+                enabled = name.isNotBlank(),
+            ) {
+                Text(text = stringResource(id = R.string.action_add))
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) {
+                Text(text = stringResource(id = R.string.action_cancel))
+            }
+        },
+    )
+}
+
+@Composable
+private fun CreateChoreDialog(
+    onConfirm: (ChoreTemplateInputDto) -> Unit,
+    onDismiss: () -> Unit,
+) {
+    var name by remember { mutableStateOf("") }
+    var description by remember { mutableStateOf("") }
+    var everyNDays by remember { mutableStateOf("7") }
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(text = stringResource(id = R.string.templates_create_chore_title)) },
+        text = {
+            Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                OutlinedTextField(
+                    value = name,
+                    onValueChange = { name = it },
+                    label = { Text(text = stringResource(id = R.string.templates_name_label)) },
+                    singleLine = true,
+                )
+                OutlinedTextField(
+                    value = description,
+                    onValueChange = { description = it },
+                    label = { Text(text = stringResource(id = R.string.templates_description_label)) },
+                    singleLine = true,
+                )
+                OutlinedTextField(
+                    value = everyNDays,
+                    onValueChange = { everyNDays = it.filter { c -> c.isDigit() } },
+                    label = { Text(text = stringResource(id = R.string.templates_every_n_days_label)) },
+                    singleLine = true,
+                )
+            }
+        },
+        confirmButton = {
+            TextButton(
+                onClick = {
+                    if (name.isNotBlank()) {
+                        onConfirm(
+                            ChoreTemplateInputDto(
+                                name = name.trim(),
+                                description = description.trim().ifBlank { null },
+                                startDate = LocalDate.now().toString(),
+                                everyNDays = everyNDays.toIntOrNull() ?: 7,
+                                isActive = true,
+                            ),
+                        )
+                    }
+                },
+                enabled = name.isNotBlank(),
+            ) {
+                Text(text = stringResource(id = R.string.action_add))
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) {
+                Text(text = stringResource(id = R.string.action_cancel))
+            }
+        },
     )
 }

--- a/android/app/src/main/java/com/daynest/android/feature/templates/TemplatesRoute.kt
+++ b/android/app/src/main/java/com/daynest/android/feature/templates/TemplatesRoute.kt
@@ -1,0 +1,24 @@
+@file:Suppress("ktlint:standard:function-naming", "FunctionNaming")
+
+package com.daynest.android.feature.templates
+
+import androidx.compose.runtime.Composable
+import com.daynest.android.R
+import com.daynest.android.app.navigation.DaynestDestination
+import com.daynest.android.app.navigation.DaynestParityRoute
+
+@Composable
+fun TemplatesRoute(onNavigate: (String) -> Unit = {}) {
+    DaynestParityRoute(
+        currentRoute = DaynestDestination.TEMPLATES,
+        onNavigate = onNavigate,
+        titleRes = R.string.templates_title,
+        subtitleRes = R.string.templates_subtitle,
+        capabilityResIds =
+            listOf(
+                R.string.templates_capability_routines,
+                R.string.templates_capability_chores,
+                R.string.templates_capability_recurring,
+            ),
+    )
+}

--- a/android/app/src/main/java/com/daynest/android/feature/templates/TemplatesViewModel.kt
+++ b/android/app/src/main/java/com/daynest/android/feature/templates/TemplatesViewModel.kt
@@ -1,0 +1,182 @@
+package com.daynest.android.feature.templates
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.daynest.android.data.templates.ChoreTemplateDto
+import com.daynest.android.data.templates.ChoreTemplateInputDto
+import com.daynest.android.data.templates.RoutineTemplateDto
+import com.daynest.android.data.templates.RoutineTemplateInputDto
+import com.daynest.android.data.templates.TemplatesRepository
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class TemplatesViewModel
+    @Inject
+    constructor(
+        private val repository: TemplatesRepository,
+    ) : ViewModel() {
+        private val _uiState = MutableStateFlow<TemplatesUiState>(TemplatesUiState.Loading)
+        val uiState: StateFlow<TemplatesUiState> = _uiState.asStateFlow()
+
+        init {
+            load()
+        }
+
+        fun onEvent(event: TemplatesUiEvent) {
+            when (event) {
+                TemplatesUiEvent.RetryClicked -> load()
+                is TemplatesUiEvent.TabSelected -> setTab(event.tab)
+                TemplatesUiEvent.ShowCreateRoutineForm -> setCreateForm(TemplateCreateForm.Routine)
+                TemplatesUiEvent.ShowCreateChoreForm -> setCreateForm(TemplateCreateForm.Chore)
+                TemplatesUiEvent.DismissCreateForm -> setCreateForm(null)
+                is TemplatesUiEvent.CreateRoutine -> createRoutine(event.input)
+                is TemplatesUiEvent.CreateChore -> createChore(event.input)
+                is TemplatesUiEvent.DeleteRoutine -> deleteRoutine(event.id)
+                is TemplatesUiEvent.DeleteChore -> deleteChore(event.id)
+            }
+        }
+
+        private fun load() {
+            viewModelScope.launch {
+                _uiState.value = TemplatesUiState.Loading
+                val routinesResult = repository.listRoutines()
+                val choresResult = repository.listChores()
+                if (routinesResult.isSuccess || choresResult.isSuccess) {
+                    _uiState.value =
+                        TemplatesUiState.Content(
+                            routines = routinesResult.getOrElse { emptyList() },
+                            chores = choresResult.getOrElse { emptyList() },
+                            selectedTab = TemplateTab.Routines,
+                            createForm = null,
+                        )
+                } else {
+                    _uiState.value = TemplatesUiState.Error
+                }
+            }
+        }
+
+        private fun setTab(tab: TemplateTab) {
+            _uiState.update { current ->
+                if (current is TemplatesUiState.Content) current.copy(selectedTab = tab) else current
+            }
+        }
+
+        private fun setCreateForm(form: TemplateCreateForm?) {
+            _uiState.update { current ->
+                if (current is TemplatesUiState.Content) current.copy(createForm = form) else current
+            }
+        }
+
+        private fun createRoutine(input: RoutineTemplateInputDto) {
+            viewModelScope.launch {
+                val result = repository.createRoutine(input)
+                result.onSuccess { newRoutine ->
+                    _uiState.update { current ->
+                        if (current is TemplatesUiState.Content) {
+                            current.copy(routines = current.routines + newRoutine, createForm = null)
+                        } else {
+                            current
+                        }
+                    }
+                }
+            }
+        }
+
+        private fun createChore(input: ChoreTemplateInputDto) {
+            viewModelScope.launch {
+                val result = repository.createChore(input)
+                result.onSuccess { newChore ->
+                    _uiState.update { current ->
+                        if (current is TemplatesUiState.Content) {
+                            current.copy(chores = current.chores + newChore, createForm = null)
+                        } else {
+                            current
+                        }
+                    }
+                }
+            }
+        }
+
+        private fun deleteRoutine(id: Int) {
+            viewModelScope.launch {
+                val result = repository.deleteRoutine(id)
+                if (result.isSuccess) {
+                    _uiState.update { current ->
+                        if (current is TemplatesUiState.Content) {
+                            current.copy(routines = current.routines.filter { it.id != id })
+                        } else {
+                            current
+                        }
+                    }
+                }
+            }
+        }
+
+        private fun deleteChore(id: Int) {
+            viewModelScope.launch {
+                val result = repository.deleteChore(id)
+                if (result.isSuccess) {
+                    _uiState.update { current ->
+                        if (current is TemplatesUiState.Content) {
+                            current.copy(chores = current.chores.filter { it.id != id })
+                        } else {
+                            current
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+enum class TemplateTab { Routines, Chores }
+
+enum class TemplateCreateForm { Routine, Chore }
+
+sealed interface TemplatesUiState {
+    data object Loading : TemplatesUiState
+
+    data class Content(
+        val routines: List<RoutineTemplateDto>,
+        val chores: List<ChoreTemplateDto>,
+        val selectedTab: TemplateTab,
+        val createForm: TemplateCreateForm?,
+    ) : TemplatesUiState
+
+    data object Error : TemplatesUiState
+}
+
+sealed interface TemplatesUiEvent {
+    data object RetryClicked : TemplatesUiEvent
+
+    data class TabSelected(
+        val tab: TemplateTab,
+    ) : TemplatesUiEvent
+
+    data object ShowCreateRoutineForm : TemplatesUiEvent
+
+    data object ShowCreateChoreForm : TemplatesUiEvent
+
+    data object DismissCreateForm : TemplatesUiEvent
+
+    data class CreateRoutine(
+        val input: RoutineTemplateInputDto,
+    ) : TemplatesUiEvent
+
+    data class CreateChore(
+        val input: ChoreTemplateInputDto,
+    ) : TemplatesUiEvent
+
+    data class DeleteRoutine(
+        val id: Int,
+    ) : TemplatesUiEvent
+
+    data class DeleteChore(
+        val id: Int,
+    ) : TemplatesUiEvent
+}

--- a/android/app/src/main/java/com/daynest/android/feature/templates/TemplatesViewModel.kt
+++ b/android/app/src/main/java/com/daynest/android/feature/templates/TemplatesViewModel.kt
@@ -52,7 +52,12 @@ class TemplatesViewModel
                         TemplatesUiState.Content(
                             routines = routinesResult.getOrElse { emptyList() },
                             chores = choresResult.getOrElse { emptyList() },
-                            selectedTab = TemplateTab.Routines,
+                            selectedTab =
+                                if (routinesResult.isFailure && choresResult.isSuccess) {
+                                    TemplateTab.Chores
+                                } else {
+                                    TemplateTab.Routines
+                                },
                             createForm = null,
                         )
                 } else {

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -7,8 +7,6 @@
     <string name="home_error_generic">Unable to load today data.</string>
     <string name="home_stale_notice">Showing cached data.</string>
     <string name="home_all_caught_up">You\'re all caught up for today.</string>
-    <string name="home_items_remaining_label">%1$d item(s) remaining</string>
-
     <string name="auth_title">Sign in to Daynest</string>
     <string name="auth_email_label">Email</string>
     <string name="auth_password_label">Password</string>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -35,8 +35,11 @@
     <string name="action_add">Add</string>
     <string name="action_cancel">Cancel</string>
 
-    <!-- Calendar -->
+    <!-- Top-level destinations -->
+    <string name="today_title">Today</string>
     <string name="calendar_title">Calendar</string>
+
+    <!-- Calendar -->
     <string name="calendar_subtitle">Month and day planning, matching the web calendar workspace.</string>
     <string name="calendar_capability_month">Review month-level counts for routines, chores, medication, and planned items.</string>
     <string name="calendar_capability_day">Open a day detail view that keeps completed, pending, and overdue work visible.</string>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -1,10 +1,13 @@
 <resources>
     <string name="app_name">Daynest</string>
-    <string name="home_welcome">Welcome to Daynest</string>
+    <string name="home_welcome">Today</string>
     <string name="home_action_plan_today">Plan today</string>
     <string name="home_action_caught_up">You\'re all caught up</string>
     <string name="home_retry">Retry</string>
     <string name="home_error_generic">Unable to load today data.</string>
+    <string name="home_stale_notice">Showing cached data.</string>
+    <string name="home_all_caught_up">You\'re all caught up for today.</string>
+    <string name="home_items_remaining_label">%1$d item(s) remaining</string>
 
     <string name="auth_title">Sign in to Daynest</string>
     <string name="auth_email_label">Email</string>
@@ -13,30 +16,106 @@
     <string name="auth_error_missing_credentials">Enter both email and password.</string>
     <string name="auth_error_sign_in_failed">Unable to sign in. Please try again.</string>
 
+    <!-- Today screen sections -->
+    <string name="today_section_medication">Medication</string>
+    <string name="today_section_medication_history">Medication History</string>
+    <string name="today_section_routines">Routines</string>
+    <string name="today_section_overdue">Overdue</string>
+    <string name="today_section_due_today">Due Today</string>
+    <string name="today_section_upcoming">Upcoming</string>
+    <string name="today_section_planned">Planned</string>
+    <string name="today_overdue_since">Overdue since %1$s</string>
+
+    <!-- Common actions -->
+    <string name="action_done">Done</string>
+    <string name="action_undo">Undo</string>
+    <string name="action_skip">Skip</string>
+    <string name="action_take">Take</string>
+    <string name="action_delete">Delete</string>
+    <string name="action_add">Add</string>
+    <string name="action_cancel">Cancel</string>
+
+    <!-- Calendar -->
     <string name="calendar_title">Calendar</string>
     <string name="calendar_subtitle">Month and day planning, matching the web calendar workspace.</string>
     <string name="calendar_capability_month">Review month-level counts for routines, chores, medication, and planned items.</string>
     <string name="calendar_capability_day">Open a day detail view that keeps completed, pending, and overdue work visible.</string>
     <string name="calendar_capability_planned">Create and organize planned items with optional notes and module metadata.</string>
     <string name="calendar_capability_backup">Export and import planned-item backups from the same product surface.</string>
+    <string name="calendar_error">Unable to load calendar data.</string>
+    <string name="calendar_prev_month">Previous month</string>
+    <string name="calendar_next_month">Next month</string>
+    <string name="calendar_month_year">%1$s %2$s</string>
+    <string name="calendar_day_detail_header">%1$s</string>
+    <string name="calendar_day_empty">No items for this day.</string>
+    <string name="calendar_add_planned">+ Add planned</string>
+    <string name="calendar_add_planned_title">Add planned item</string>
+    <string name="calendar_planned_title_label">Title</string>
 
+    <!-- Medication -->
     <string name="medication_title">Medication</string>
     <string name="medication_subtitle">Medication planning and dose tracking are available from native navigation.</string>
     <string name="medication_capability_today">Track today\'s scheduled medication doses alongside the Today checklist.</string>
     <string name="medication_capability_history">Review dose history statuses such as taken, skipped, and missed.</string>
     <string name="medication_capability_strict">Keep medication modeled separately from routine chores for safer reminders.</string>
+    <string name="medication_error">Unable to load medication data.</string>
+    <string name="medication_plans_section">Plans</string>
+    <string name="medication_history_section">History</string>
+    <string name="medication_no_plans">No medication plans yet.</string>
+    <string name="medication_no_history">No dose history yet.</string>
+    <string name="medication_inactive">Inactive</string>
+    <string name="medication_add_plan">+ Add plan</string>
+    <string name="medication_create_title">Add medication plan</string>
+    <string name="medication_name_label">Name</string>
+    <string name="medication_instructions_label">Instructions</string>
+    <string name="medication_time_label">Schedule time (HH:MM)</string>
+    <string name="medication_every_n_days_label">Every N days</string>
+    <string name="medication_plan_schedule">%1$s · every %2$d day(s)</string>
 
+    <!-- Templates -->
     <string name="templates_title">Templates</string>
     <string name="templates_subtitle">Reusable routine and chore setup now has a native destination.</string>
     <string name="templates_capability_routines">Manage routine templates that generate daily task instances.</string>
     <string name="templates_capability_chores">Manage chore templates for recurring household work.</string>
     <string name="templates_capability_recurring">Keep recurrence understandable while supporting repeating work.</string>
+    <string name="templates_error">Unable to load templates.</string>
+    <string name="templates_tab_routines">Routines</string>
+    <string name="templates_tab_chores">Chores</string>
+    <string name="templates_no_routines">No routine templates yet.</string>
+    <string name="templates_no_chores">No chore templates yet.</string>
+    <string name="templates_add_routine">+ Add routine</string>
+    <string name="templates_add_chore">+ Add chore</string>
+    <string name="templates_create_routine_title">Add routine template</string>
+    <string name="templates_create_chore_title">Add chore template</string>
+    <string name="templates_name_label">Name</string>
+    <string name="templates_description_label">Description (optional)</string>
+    <string name="templates_every_n_days_label">Every N days</string>
+    <string name="templates_every_n_days">Every %1$d day(s)</string>
+    <string name="templates_inactive">Inactive</string>
 
+    <!-- Settings -->
     <string name="settings_title">Settings</string>
     <string name="settings_subtitle">Account and integration controls are represented across platforms.</string>
     <string name="settings_capability_account">Review account session state and future profile preferences.</string>
     <string name="settings_capability_integrations">Connect integration surfaces such as Home Assistant and MCP clients.</string>
     <string name="settings_capability_clients">Prepare integration clients with scoped access from one settings area.</string>
+    <string name="settings_account_section">Account</string>
+    <string name="settings_session_active">Signed in</string>
+    <string name="settings_sign_out">Sign out</string>
+    <string name="settings_integrations_section">Integration Clients</string>
+    <string name="settings_new_client">+ New client</string>
+    <string name="settings_no_clients">No integration clients configured.</string>
+    <string name="settings_clients_error">Unable to load integration clients.</string>
+    <string name="settings_client_active">Active</string>
+    <string name="settings_client_inactive">Inactive</string>
+    <string name="settings_client_rate_limit">%1$d req/min</string>
+    <string name="settings_create_client_title">New integration client</string>
+    <string name="settings_client_name_label">Name</string>
+    <string name="settings_client_scopes_label">Scopes (comma-separated)</string>
+    <string name="settings_client_rate_limit_label">Rate limit (per minute)</string>
+    <string name="settings_new_key_title">API Key Created</string>
+    <string name="settings_new_key_notice">Copy this key now — it will not be shown again.</string>
+    <string name="settings_new_key_dismiss">I\'ve copied it</string>
 
     <string name="parity_more_coming">Native editing controls will continue to grow from the same shared API contracts.</string>
 

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -13,6 +13,32 @@
     <string name="auth_error_missing_credentials">Enter both email and password.</string>
     <string name="auth_error_sign_in_failed">Unable to sign in. Please try again.</string>
 
+    <string name="calendar_title">Calendar</string>
+    <string name="calendar_subtitle">Month and day planning, matching the web calendar workspace.</string>
+    <string name="calendar_capability_month">Review month-level counts for routines, chores, medication, and planned items.</string>
+    <string name="calendar_capability_day">Open a day detail view that keeps completed, pending, and overdue work visible.</string>
+    <string name="calendar_capability_planned">Create and organize planned items with optional notes and module metadata.</string>
+    <string name="calendar_capability_backup">Export and import planned-item backups from the same product surface.</string>
+
+    <string name="medication_title">Medication</string>
+    <string name="medication_subtitle">Medication planning and dose tracking are available from native navigation.</string>
+    <string name="medication_capability_today">Track today\'s scheduled medication doses alongside the Today checklist.</string>
+    <string name="medication_capability_history">Review dose history statuses such as taken, skipped, and missed.</string>
+    <string name="medication_capability_strict">Keep medication modeled separately from routine chores for safer reminders.</string>
+
+    <string name="templates_title">Templates</string>
+    <string name="templates_subtitle">Reusable routine and chore setup now has a native destination.</string>
+    <string name="templates_capability_routines">Manage routine templates that generate daily task instances.</string>
+    <string name="templates_capability_chores">Manage chore templates for recurring household work.</string>
+    <string name="templates_capability_recurring">Keep recurrence understandable while supporting repeating work.</string>
+
+    <string name="settings_title">Settings</string>
+    <string name="settings_subtitle">Account and integration controls are represented across platforms.</string>
+    <string name="settings_capability_account">Review account session state and future profile preferences.</string>
+    <string name="settings_capability_integrations">Connect integration surfaces such as Home Assistant and MCP clients.</string>
+    <string name="settings_capability_clients">Prepare integration clients with scoped access from one settings area.</string>
+
+    <string name="parity_more_coming">Native editing controls will continue to grow from the same shared API contracts.</string>
 
     <plurals name="home_items_remaining">
         <item quantity="one">You have %1$d item to handle today.</item>

--- a/android/app/src/test/java/com/daynest/android/app/navigation/DaynestDestinationTest.kt
+++ b/android/app/src/test/java/com/daynest/android/app/navigation/DaynestDestinationTest.kt
@@ -1,0 +1,30 @@
+package com.daynest.android.app.navigation
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class DaynestDestinationTest {
+    @Test
+    fun topLevelDestinations_matchWebApplicationSections() {
+        val routes = daynestTopLevelDestinations.map { it.route }
+
+        assertEquals(
+            listOf(
+                DaynestDestination.HOME,
+                DaynestDestination.CALENDAR,
+                DaynestDestination.MEDICATION,
+                DaynestDestination.TEMPLATES,
+                DaynestDestination.SETTINGS,
+            ),
+            routes,
+        )
+    }
+
+    @Test
+    fun topLevelDestinations_haveUserFacingLabels() {
+        daynestTopLevelDestinations.forEach { destination ->
+            assertTrue(destination.label.isNotBlank())
+        }
+    }
+}

--- a/android/app/src/test/java/com/daynest/android/app/navigation/DaynestDestinationTest.kt
+++ b/android/app/src/test/java/com/daynest/android/app/navigation/DaynestDestinationTest.kt
@@ -24,7 +24,7 @@ class DaynestDestinationTest {
     @Test
     fun topLevelDestinations_haveUserFacingLabels() {
         daynestTopLevelDestinations.forEach { destination ->
-            assertTrue(destination.label.isNotBlank())
+            assertTrue(destination.labelResId != 0)
         }
     }
 }

--- a/android/app/src/test/java/com/daynest/android/data/today/TodayRepositoryTest.kt
+++ b/android/app/src/test/java/com/daynest/android/data/today/TodayRepositoryTest.kt
@@ -3,6 +3,7 @@ package com.daynest.android.data.today
 import app.cash.turbine.test
 import com.daynest.android.core.database.today.TodaySummaryDao
 import com.daynest.android.core.database.today.TodaySummaryEntity
+import com.daynest.android.fakes.StubTodayActionsApi
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow

--- a/android/app/src/test/java/com/daynest/android/data/today/TodayRepositoryTest.kt
+++ b/android/app/src/test/java/com/daynest/android/data/today/TodayRepositoryTest.kt
@@ -176,28 +176,3 @@ private sealed interface FakeApiResponse {
     ) : FakeApiResponse
 }
 
-private class StubTodayActionsApi : TodayActionsApi {
-    override suspend fun completeChore(id: Int): ChoreMutationDto = ChoreMutationDto(id, "completed")
-
-    override suspend fun skipChore(id: Int): ChoreMutationDto = ChoreMutationDto(id, "skipped")
-
-    override suspend fun completeTask(id: Int): TaskMutationDto = TaskMutationDto(id, "completed")
-
-    override suspend fun skipTask(id: Int): TaskMutationDto = TaskMutationDto(id, "skipped")
-
-    override suspend fun startTask(id: Int): TaskMutationDto = TaskMutationDto(id, "in_progress")
-
-    override suspend fun takeDose(id: Int): DoseMutationDto = DoseMutationDto(id, "taken")
-
-    override suspend fun skipDose(id: Int): DoseMutationDto = DoseMutationDto(id, "skipped")
-
-    override suspend fun updatePlannedItem(
-        id: Int,
-        request: PlannedItemUpdateDto,
-    ): PlannedTodayItemDto = PlannedTodayItemDto(id, request.title, request.isDone)
-
-    override suspend fun deletePlannedItem(id: Int) = Unit
-
-    override suspend fun createPlannedItem(request: PlannedItemCreateDto): PlannedTodayItemDto =
-        PlannedTodayItemDto(0, request.title, false)
-}

--- a/android/app/src/test/java/com/daynest/android/data/today/TodayRepositoryTest.kt
+++ b/android/app/src/test/java/com/daynest/android/data/today/TodayRepositoryTest.kt
@@ -36,7 +36,12 @@ class TodayRepositoryTest {
                         ),
                     )
                 }
-            val repository = TodayRepository(todayApi = api, todaySummaryDao = dao)
+            val repository =
+                TodayRepository(
+                    todayApi = api,
+                    todayActionsApi = StubTodayActionsApi(),
+                    todaySummaryDao = dao,
+                )
 
             repository.observeTodaySummary().test {
                 assertNull(awaitItem())
@@ -76,7 +81,12 @@ class TodayRepositoryTest {
                 FakeTodayApi().apply {
                     enqueueError(RuntimeException("network unavailable"))
                 }
-            val repository = TodayRepository(todayApi = api, todaySummaryDao = dao)
+            val repository =
+                TodayRepository(
+                    todayApi = api,
+                    todayActionsApi = StubTodayActionsApi(),
+                    todaySummaryDao = dao,
+                )
 
             repository.observeTodaySummary().test {
                 val cached = awaitItem()
@@ -99,7 +109,12 @@ class TodayRepositoryTest {
                 FakeTodayApi().apply {
                     enqueueError(RuntimeException("no connection"))
                 }
-            val repository = TodayRepository(todayApi = api, todaySummaryDao = dao)
+            val repository =
+                TodayRepository(
+                    todayApi = api,
+                    todayActionsApi = StubTodayActionsApi(),
+                    todaySummaryDao = dao,
+                )
 
             repository.observeTodaySummary().test {
                 assertNull(awaitItem())
@@ -158,4 +173,30 @@ private sealed interface FakeApiResponse {
     data class Error(
         val error: Throwable,
     ) : FakeApiResponse
+}
+
+private class StubTodayActionsApi : TodayActionsApi {
+    override suspend fun completeChore(id: Int): ChoreMutationDto = ChoreMutationDto(id, "completed")
+
+    override suspend fun skipChore(id: Int): ChoreMutationDto = ChoreMutationDto(id, "skipped")
+
+    override suspend fun completeTask(id: Int): TaskMutationDto = TaskMutationDto(id, "completed")
+
+    override suspend fun skipTask(id: Int): TaskMutationDto = TaskMutationDto(id, "skipped")
+
+    override suspend fun startTask(id: Int): TaskMutationDto = TaskMutationDto(id, "in_progress")
+
+    override suspend fun takeDose(id: Int): DoseMutationDto = DoseMutationDto(id, "taken")
+
+    override suspend fun skipDose(id: Int): DoseMutationDto = DoseMutationDto(id, "skipped")
+
+    override suspend fun updatePlannedItem(
+        id: Int,
+        request: PlannedItemUpdateDto,
+    ): PlannedTodayItemDto = PlannedTodayItemDto(id, request.title, request.isDone)
+
+    override suspend fun deletePlannedItem(id: Int) = Unit
+
+    override suspend fun createPlannedItem(request: PlannedItemCreateDto): PlannedTodayItemDto =
+        PlannedTodayItemDto(0, request.title, false)
 }

--- a/android/app/src/test/java/com/daynest/android/data/today/TodayRepositoryTest.kt
+++ b/android/app/src/test/java/com/daynest/android/data/today/TodayRepositoryTest.kt
@@ -175,4 +175,3 @@ private sealed interface FakeApiResponse {
         val error: Throwable,
     ) : FakeApiResponse
 }
-

--- a/android/app/src/test/java/com/daynest/android/fakes/StubTodayActionsApi.kt
+++ b/android/app/src/test/java/com/daynest/android/fakes/StubTodayActionsApi.kt
@@ -1,0 +1,35 @@
+package com.daynest.android.fakes
+
+import com.daynest.android.data.today.ChoreMutationDto
+import com.daynest.android.data.today.DoseMutationDto
+import com.daynest.android.data.today.PlannedItemCreateDto
+import com.daynest.android.data.today.PlannedItemUpdateDto
+import com.daynest.android.data.today.PlannedTodayItemDto
+import com.daynest.android.data.today.TaskMutationDto
+import com.daynest.android.data.today.TodayActionsApi
+
+class StubTodayActionsApi : TodayActionsApi {
+    override suspend fun completeChore(id: Int): ChoreMutationDto = ChoreMutationDto(id, "completed")
+
+    override suspend fun skipChore(id: Int): ChoreMutationDto = ChoreMutationDto(id, "skipped")
+
+    override suspend fun completeTask(id: Int): TaskMutationDto = TaskMutationDto(id, "completed")
+
+    override suspend fun skipTask(id: Int): TaskMutationDto = TaskMutationDto(id, "skipped")
+
+    override suspend fun startTask(id: Int): TaskMutationDto = TaskMutationDto(id, "in_progress")
+
+    override suspend fun takeDose(id: Int): DoseMutationDto = DoseMutationDto(id, "taken")
+
+    override suspend fun skipDose(id: Int): DoseMutationDto = DoseMutationDto(id, "skipped")
+
+    override suspend fun updatePlannedItem(
+        id: Int,
+        request: PlannedItemUpdateDto,
+    ): PlannedTodayItemDto = PlannedTodayItemDto(id, request.title, request.isDone)
+
+    override suspend fun deletePlannedItem(id: Int) = Unit
+
+    override suspend fun createPlannedItem(request: PlannedItemCreateDto): PlannedTodayItemDto =
+        PlannedTodayItemDto(0, request.title, false)
+}

--- a/android/app/src/test/java/com/daynest/android/fakes/StubTodayActionsApi.kt
+++ b/android/app/src/test/java/com/daynest/android/fakes/StubTodayActionsApi.kt
@@ -10,6 +10,7 @@ import com.daynest.android.data.today.TodayActionsApi
 
 class StubTodayActionsApi : TodayActionsApi {
     private var nextId = 1
+
     override suspend fun completeChore(id: Int): ChoreMutationDto = ChoreMutationDto(id, "completed")
 
     override suspend fun skipChore(id: Int): ChoreMutationDto = ChoreMutationDto(id, "skipped")

--- a/android/app/src/test/java/com/daynest/android/fakes/StubTodayActionsApi.kt
+++ b/android/app/src/test/java/com/daynest/android/fakes/StubTodayActionsApi.kt
@@ -9,6 +9,7 @@ import com.daynest.android.data.today.TaskMutationDto
 import com.daynest.android.data.today.TodayActionsApi
 
 class StubTodayActionsApi : TodayActionsApi {
+    private var nextId = 1
     override suspend fun completeChore(id: Int): ChoreMutationDto = ChoreMutationDto(id, "completed")
 
     override suspend fun skipChore(id: Int): ChoreMutationDto = ChoreMutationDto(id, "skipped")
@@ -31,5 +32,5 @@ class StubTodayActionsApi : TodayActionsApi {
     override suspend fun deletePlannedItem(id: Int) = Unit
 
     override suspend fun createPlannedItem(request: PlannedItemCreateDto): PlannedTodayItemDto =
-        PlannedTodayItemDto(0, request.title, false)
+        PlannedTodayItemDto(nextId++, request.title, false)
 }

--- a/android/app/src/test/java/com/daynest/android/feature/home/HomeViewModelTest.kt
+++ b/android/app/src/test/java/com/daynest/android/feature/home/HomeViewModelTest.kt
@@ -2,12 +2,18 @@ package com.daynest.android.feature.home
 
 import com.daynest.android.core.database.today.TodaySummaryDao
 import com.daynest.android.core.database.today.TodaySummaryEntity
+import com.daynest.android.data.today.ChoreMutationDto
+import com.daynest.android.data.today.DoseMutationDto
 import com.daynest.android.data.today.DueTodayItemDto
 import com.daynest.android.data.today.MedicationHistoryItemDto
 import com.daynest.android.data.today.MedicationTodayItemDto
 import com.daynest.android.data.today.OverdueTodayItemDto
+import com.daynest.android.data.today.PlannedItemCreateDto
+import com.daynest.android.data.today.PlannedItemUpdateDto
 import com.daynest.android.data.today.PlannedTodayItemDto
 import com.daynest.android.data.today.RoutineTodayItemDto
+import com.daynest.android.data.today.TaskMutationDto
+import com.daynest.android.data.today.TodayActionsApi
 import com.daynest.android.data.today.TodayApi
 import com.daynest.android.data.today.TodayRepository
 import com.daynest.android.data.today.TodayResponseDto
@@ -56,6 +62,7 @@ class HomeViewModelTest {
                                 FakeTodayApi().apply {
                                     enqueueSuccess(todayResponse())
                                 },
+                            todayActionsApi = StubTodayActionsApi(),
                             todaySummaryDao = FakeTodaySummaryDao(),
                         ),
                 )
@@ -82,6 +89,7 @@ class HomeViewModelTest {
                                 FakeTodayApi().apply {
                                     enqueueError(IllegalStateException("boom"))
                                 },
+                            todayActionsApi = StubTodayActionsApi(),
                             todaySummaryDao = FakeTodaySummaryDao(),
                         ),
                 )
@@ -103,7 +111,12 @@ class HomeViewModelTest {
                     enqueueError(IllegalStateException("initial load failure"))
                     enqueueSuccess(todayResponse(), gate = loadGate)
                 }
-            val repository = TodayRepository(todayApi = api, todaySummaryDao = FakeTodaySummaryDao())
+            val repository =
+                TodayRepository(
+                    todayApi = api,
+                    todayActionsApi = StubTodayActionsApi(),
+                    todaySummaryDao = FakeTodaySummaryDao(),
+                )
             val viewModel = HomeViewModel(repository = repository)
 
             advanceUntilIdle()
@@ -129,7 +142,15 @@ class HomeViewModelTest {
                     enqueueSuccess(todayResponse())
                     enqueueError(IllegalStateException("network gone"))
                 }
-            val viewModel = HomeViewModel(repository = TodayRepository(todayApi = api, todaySummaryDao = dao))
+            val viewModel =
+                HomeViewModel(
+                    repository =
+                        TodayRepository(
+                            todayApi = api,
+                            todayActionsApi = StubTodayActionsApi(),
+                            todaySummaryDao = dao,
+                        ),
+                )
 
             advanceUntilIdle()
             assertTrue(viewModel.uiState.value is HomeUiState.Content)
@@ -218,3 +239,29 @@ private fun todayResponse() =
                 PlannedTodayItemDto(8, "Call insurance", isDone = true),
             ),
     )
+
+private class StubTodayActionsApi : TodayActionsApi {
+    override suspend fun completeChore(id: Int): ChoreMutationDto = ChoreMutationDto(id, "completed")
+
+    override suspend fun skipChore(id: Int): ChoreMutationDto = ChoreMutationDto(id, "skipped")
+
+    override suspend fun completeTask(id: Int): TaskMutationDto = TaskMutationDto(id, "completed")
+
+    override suspend fun skipTask(id: Int): TaskMutationDto = TaskMutationDto(id, "skipped")
+
+    override suspend fun startTask(id: Int): TaskMutationDto = TaskMutationDto(id, "in_progress")
+
+    override suspend fun takeDose(id: Int): DoseMutationDto = DoseMutationDto(id, "taken")
+
+    override suspend fun skipDose(id: Int): DoseMutationDto = DoseMutationDto(id, "skipped")
+
+    override suspend fun updatePlannedItem(
+        id: Int,
+        request: PlannedItemUpdateDto,
+    ): PlannedTodayItemDto = PlannedTodayItemDto(id, request.title, request.isDone)
+
+    override suspend fun deletePlannedItem(id: Int) = Unit
+
+    override suspend fun createPlannedItem(request: PlannedItemCreateDto): PlannedTodayItemDto =
+        PlannedTodayItemDto(0, request.title, false)
+}

--- a/android/app/src/test/java/com/daynest/android/feature/home/HomeViewModelTest.kt
+++ b/android/app/src/test/java/com/daynest/android/feature/home/HomeViewModelTest.kt
@@ -18,6 +18,7 @@ import com.daynest.android.data.today.TodayApi
 import com.daynest.android.data.today.TodayRepository
 import com.daynest.android.data.today.TodayResponseDto
 import com.daynest.android.data.today.UpcomingTodayItemDto
+import com.daynest.android.fakes.StubTodayActionsApi
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi

--- a/backend/app/api/routes/integrations/home_assistant.py
+++ b/backend/app/api/routes/integrations/home_assistant.py
@@ -19,6 +19,8 @@ from app.schemas.integrations import (
     HAActionResult,
     HomeAssistantEntity,
     MarkMedicationTakenRequest,
+    SkipMedicationRequest,
+    SkipTaskRequest,
     SnoozeTaskRequest,
 )
 from app.services.today_service import TodayService
@@ -95,8 +97,8 @@ def home_assistant_complete_task(
 ) -> HAActionResult:
     """Mark a chore instance as complete via Home Assistant automation."""
     service = TodayService(TodayRepository(db))
-    service.complete_chore(user_id=integration_user.id, chore_instance_id=request.task_id)
-    return HAActionResult(success=True, detail=f"Task {request.task_id} marked as complete")
+    service.complete_chore(user_id=integration_user.id, chore_instance_id=request.chore_instance_id)
+    return HAActionResult(success=True, detail=f"Task {request.chore_instance_id} marked as complete")
 
 
 @router.post("/actions/snooze-task", response_model=HAActionResult)
@@ -108,8 +110,8 @@ def home_assistant_snooze_task(
     """Reschedule a chore instance N days into the future via Home Assistant automation."""
     service = TodayService(TodayRepository(db))
     new_date = date.today() + timedelta(days=request.days)
-    service.reschedule_chore(user_id=integration_user.id, chore_instance_id=request.task_id, scheduled_date=new_date)
-    return HAActionResult(success=True, detail=f"Task {request.task_id} rescheduled by {request.days} day(s)")
+    service.reschedule_chore(user_id=integration_user.id, chore_instance_id=request.chore_instance_id, scheduled_date=new_date)
+    return HAActionResult(success=True, detail=f"Task {request.chore_instance_id} rescheduled by {request.days} day(s)")
 
 
 @router.post("/actions/mark-medication-taken", response_model=HAActionResult)
@@ -126,3 +128,31 @@ def home_assistant_mark_medication_taken(
         action="take",
     )
     return HAActionResult(success=True, detail=f"Medication dose {request.medication_dose_id} marked as taken")
+
+
+@router.post("/actions/skip-task", response_model=HAActionResult)
+def home_assistant_skip_task(
+    request: SkipTaskRequest,
+    db: Session = Depends(get_db),
+    integration_user: User = Depends(require_integration_scope("ha:write")),
+) -> HAActionResult:
+    """Skip a chore instance via Home Assistant automation."""
+    service = TodayService(TodayRepository(db))
+    service.skip_chore(user_id=integration_user.id, chore_instance_id=request.chore_instance_id)
+    return HAActionResult(success=True, detail=f"Task {request.chore_instance_id} skipped")
+
+
+@router.post("/actions/skip-medication", response_model=HAActionResult)
+def home_assistant_skip_medication(
+    request: SkipMedicationRequest,
+    db: Session = Depends(get_db),
+    integration_user: User = Depends(require_integration_scope("ha:write")),
+) -> HAActionResult:
+    """Skip a medication dose via Home Assistant automation."""
+    service = TodayService(TodayRepository(db))
+    service.mutate_medication_status(
+        user_id=integration_user.id,
+        medication_dose_instance_id=request.medication_dose_id,
+        action="skip",
+    )
+    return HAActionResult(success=True, detail=f"Medication dose {request.medication_dose_id} skipped")

--- a/backend/app/schemas/integrations.py
+++ b/backend/app/schemas/integrations.py
@@ -11,16 +11,24 @@ class TodaySummary(BaseModel):
 
 
 class CompleteTaskRequest(BaseModel):
-    task_id: int = Field(gt=0, description="The chore instance ID to mark as complete")
+    chore_instance_id: int = Field(gt=0, description="The chore instance ID to mark as complete")
 
 
 class SnoozeTaskRequest(BaseModel):
-    task_id: int = Field(gt=0, description="The chore instance ID to reschedule")
+    chore_instance_id: int = Field(gt=0, description="The chore instance ID to reschedule")
     days: int = Field(default=1, ge=1, le=30, description="Number of days to snooze the task")
 
 
 class MarkMedicationTakenRequest(BaseModel):
     medication_dose_id: int = Field(gt=0, description="The medication dose instance ID to mark as taken")
+
+
+class SkipTaskRequest(BaseModel):
+    chore_instance_id: int = Field(gt=0, description="The chore instance ID to skip")
+
+
+class SkipMedicationRequest(BaseModel):
+    medication_dose_id: int = Field(gt=0, description="The medication dose instance ID to skip")
 
 
 class HAActionResult(BaseModel):
@@ -65,3 +73,4 @@ class DashboardReadModel(BaseModel):
     medication_due_count: int
     completion_ratio: float
     next_medication: str | None = None
+    routines_open_count: int = 0

--- a/backend/app/services/today_service.py
+++ b/backend/app/services/today_service.py
@@ -104,6 +104,7 @@ class TodayService:
             medication_due_count=len([item for item in data.medication if item.status == MedicationDoseStatus.scheduled]),
             completion_ratio=round(completed_count / total if total else 0.0, 3),
             next_medication=self._format_next_medication(data.medication),
+            routines_open_count=len([item for item in data.routines if item.status in (TaskStatus.pending, TaskStatus.in_progress)]),
         )
 
     def get_today(self, user_id: int, for_date: date) -> TodayResponse:

--- a/backend/docs/integrations/HOME_ASSISTANT_CONNECTION_GUIDE.md
+++ b/backend/docs/integrations/HOME_ASSISTANT_CONNECTION_GUIDE.md
@@ -13,7 +13,7 @@ X-Integration-Key: <DAYNEST_API_KEY>
 ```
 
 If the API key is missing the `ha:read` scope, Home Assistant will not be able to fetch Daynest data.
-If the API key is missing the `ha:write` scope, write services (`complete_task`, `snooze_task`, `mark_medication_taken`) will be rejected with `403 Forbidden`.
+If the API key is missing the `ha:write` scope, write services (`complete_task`, `snooze_task`, `mark_medication_taken`, `skip_task`, `skip_medication`) will be rejected with `403 Forbidden`.
 
 ## Base URL Requirements
 
@@ -66,7 +66,7 @@ Expected behavior:
 Used by the `daynest.complete_task` Home Assistant service.
 
 - Requires `ha:write` scope
-- Request body: `{"task_id": <int>}`
+- Request body: `{"chore_instance_id": <int>}`
 - Returns `{"success": true, "detail": "..."}`
 
 ### `POST /api/v1/integrations/home-assistant/actions/snooze-task`
@@ -74,7 +74,7 @@ Used by the `daynest.complete_task` Home Assistant service.
 Used by the `daynest.snooze_task` Home Assistant service.
 
 - Requires `ha:write` scope
-- Request body: `{"task_id": <int>, "days": <int, 1–30, default 1>}`
+- Request body: `{"chore_instance_id": <int>, "days": <int, 1–30, default 1>}`
 - Returns `{"success": true, "detail": "..."}`
 
 ### `POST /api/v1/integrations/home-assistant/actions/mark-medication-taken`
@@ -85,12 +85,28 @@ Used by the `daynest.mark_medication_taken` Home Assistant service.
 - Request body: `{"medication_dose_id": <int>}`
 - Returns `{"success": true, "detail": "..."}`
 
+### `POST /api/v1/integrations/home-assistant/actions/skip-task`
+
+Used by the `daynest.skip_task` Home Assistant service.
+
+- Requires `ha:write` scope
+- Request body: `{"chore_instance_id": <int>}`
+- Returns `{"success": true, "detail": "..."}`
+
+### `POST /api/v1/integrations/home-assistant/actions/skip-medication`
+
+Used by the `daynest.skip_medication` Home Assistant service.
+
+- Requires `ha:write` scope
+- Request body: `{"medication_dose_id": <int>}`
+- Returns `{"success": true, "detail": "..."}`
+
 ## Auth Scopes
 
 | Scope | Required for |
 |-------|-------------|
 | `ha:read` | All GET endpoints (summary, dashboard, entities); required for setup |
-| `ha:write` | All POST action endpoints (complete-task, snooze-task, mark-medication-taken) |
+| `ha:write` | All POST action endpoints (complete-task, snooze-task, mark-medication-taken, skip-task, skip-medication) |
 
 Use least-privilege: create a read-only key (`ha:read`) for sensor-only setups and add `ha:write` only when you need automation write support.
 

--- a/backend/tests/test_integration_adapters.py
+++ b/backend/tests/test_integration_adapters.py
@@ -212,6 +212,7 @@ def test_home_assistant_dashboard_contract_is_stable(
         "medication_due_count",
         "completion_ratio",
         "next_medication",
+        "routines_open_count",
     }
     assert isinstance(dashboard_payload["for_date"], str)
     assert isinstance(dashboard_payload["overdue_count"], int)
@@ -232,8 +233,8 @@ def test_home_assistant_write_endpoints_require_ha_write_scope(
     read_only_key = _create_integration_key(db_session, user.id, scopes="ha:read")
 
     for path, payload in [
-        ("/api/v1/integrations/home-assistant/actions/complete-task", {"task_id": 1}),
-        ("/api/v1/integrations/home-assistant/actions/snooze-task", {"task_id": 1}),
+        ("/api/v1/integrations/home-assistant/actions/complete-task", {"chore_instance_id": 1}),
+        ("/api/v1/integrations/home-assistant/actions/snooze-task", {"chore_instance_id": 1}),
         ("/api/v1/integrations/home-assistant/actions/mark-medication-taken", {"medication_dose_id": 1}),
     ]:
         denied = client.post(path, json=payload, headers={"X-Integration-Key": read_only_key})
@@ -255,7 +256,7 @@ def test_home_assistant_complete_task_marks_chore_complete(
 
     response = client.post(
         "/api/v1/integrations/home-assistant/actions/complete-task",
-        json={"task_id": chore.id},
+        json={"chore_instance_id": chore.id},
         headers={"X-Integration-Key": write_key},
     )
     assert response.status_code == 200
@@ -281,7 +282,7 @@ def test_home_assistant_snooze_task_reschedules_chore(
 
     response = client.post(
         "/api/v1/integrations/home-assistant/actions/snooze-task",
-        json={"task_id": chore.id, "days": 2},
+        json={"chore_instance_id": chore.id, "days": 2},
         headers={"X-Integration-Key": write_key},
     )
     assert response.status_code == 200

--- a/backend/tests/test_integration_adapters.py
+++ b/backend/tests/test_integration_adapters.py
@@ -236,6 +236,8 @@ def test_home_assistant_write_endpoints_require_ha_write_scope(
         ("/api/v1/integrations/home-assistant/actions/complete-task", {"chore_instance_id": 1}),
         ("/api/v1/integrations/home-assistant/actions/snooze-task", {"chore_instance_id": 1}),
         ("/api/v1/integrations/home-assistant/actions/mark-medication-taken", {"medication_dose_id": 1}),
+        ("/api/v1/integrations/home-assistant/actions/skip-task", {"chore_instance_id": 1}),
+        ("/api/v1/integrations/home-assistant/actions/skip-medication", {"medication_dose_id": 1}),
     ]:
         denied = client.post(path, json=payload, headers={"X-Integration-Key": read_only_key})
         assert denied.status_code == 403, f"Expected 403 for {path} with ha:read scope"

--- a/custom_components/daynest/api/client.py
+++ b/custom_components/daynest/api/client.py
@@ -146,24 +146,38 @@ class DaynestApiClient:
             parser=DaynestDashboard.from_dict,
         )
 
-    async def async_complete_task(self, task_id: int) -> dict[str, Any]:
+    async def async_complete_task(self, chore_instance_id: int) -> dict[str, Any]:
         """Complete a chore instance by ID via the HA write endpoint."""
         return await self._post_action(
             path="/api/v1/integrations/home-assistant/actions/complete-task",
-            payload={"task_id": task_id},
+            payload={"chore_instance_id": chore_instance_id},
         )
 
-    async def async_snooze_task(self, task_id: int, days: int = 1) -> dict[str, Any]:
+    async def async_snooze_task(self, chore_instance_id: int, days: int = 1) -> dict[str, Any]:
         """Reschedule a chore instance N days into the future via the HA write endpoint."""
         return await self._post_action(
             path="/api/v1/integrations/home-assistant/actions/snooze-task",
-            payload={"task_id": task_id, "days": days},
+            payload={"chore_instance_id": chore_instance_id, "days": days},
         )
 
     async def async_mark_medication_taken(self, medication_dose_id: int) -> dict[str, Any]:
         """Mark a medication dose as taken via the HA write endpoint."""
         return await self._post_action(
             path="/api/v1/integrations/home-assistant/actions/mark-medication-taken",
+            payload={"medication_dose_id": medication_dose_id},
+        )
+
+    async def async_skip_task(self, chore_instance_id: int) -> dict[str, Any]:
+        """Skip a chore instance via the HA write endpoint."""
+        return await self._post_action(
+            path="/api/v1/integrations/home-assistant/actions/skip-task",
+            payload={"chore_instance_id": chore_instance_id},
+        )
+
+    async def async_skip_medication(self, medication_dose_id: int) -> dict[str, Any]:
+        """Skip a medication dose via the HA write endpoint."""
+        return await self._post_action(
+            path="/api/v1/integrations/home-assistant/actions/skip-medication",
             payload={"medication_dose_id": medication_dose_id},
         )
 

--- a/custom_components/daynest/coordinator.py
+++ b/custom_components/daynest/coordinator.py
@@ -77,6 +77,7 @@ class DaynestDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             "medication_due_count": max(0, _safe_int(payload.get("medication_due_count"), default=0)),
             "completion_ratio": completion_ratio,
             "next_medication": next_medication,
+            "routines_open_count": max(0, _safe_int(payload.get("routines_open_count"), default=0)),
             "integration_contract": contract,
         }
 

--- a/custom_components/daynest/sensor/__init__.py
+++ b/custom_components/daynest/sensor/__init__.py
@@ -72,6 +72,13 @@ ENTITY_DESCRIPTIONS: tuple[DaynestSensorEntityDescription, ...] = (
         icon="mdi:clock-time-eight-outline",
         value_key="next_medication",
     ),
+    DaynestSensorEntityDescription(
+        key="routines_open_count",
+        translation_key="routines_open_count",
+        icon="mdi:clipboard-list-outline",
+        state_class=SensorStateClass.MEASUREMENT,
+        value_key="routines_open_count",
+    ),
 )
 
 

--- a/custom_components/daynest/services.py
+++ b/custom_components/daynest/services.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from functools import partial
 from typing import TYPE_CHECKING
 
 import voluptuous as vol
@@ -20,25 +21,39 @@ SERVICE_REFRESH = "refresh"
 SERVICE_COMPLETE_TASK = "complete_task"
 SERVICE_SNOOZE_TASK = "snooze_task"
 SERVICE_MARK_MEDICATION_TAKEN = "mark_medication_taken"
+SERVICE_SKIP_TASK = "skip_task"
+SERVICE_SKIP_MEDICATION = "skip_medication"
 
-ATTR_TASK_ID = "task_id"
+ATTR_CHORE_INSTANCE_ID = "chore_instance_id"
 ATTR_MEDICATION_DOSE_ID = "medication_dose_id"
 ATTR_DAYS = "days"
 
 SERVICE_COMPLETE_TASK_SCHEMA = vol.Schema(
     {
-        vol.Required(ATTR_TASK_ID): vol.All(int, vol.Range(min=1)),
+        vol.Required(ATTR_CHORE_INSTANCE_ID): vol.All(int, vol.Range(min=1)),
     }
 )
 
 SERVICE_SNOOZE_TASK_SCHEMA = vol.Schema(
     {
-        vol.Required(ATTR_TASK_ID): vol.All(int, vol.Range(min=1)),
+        vol.Required(ATTR_CHORE_INSTANCE_ID): vol.All(int, vol.Range(min=1)),
         vol.Optional(ATTR_DAYS, default=1): vol.All(int, vol.Range(min=1, max=30)),
     }
 )
 
 SERVICE_MARK_MEDICATION_TAKEN_SCHEMA = vol.Schema(
+    {
+        vol.Required(ATTR_MEDICATION_DOSE_ID): vol.All(int, vol.Range(min=1)),
+    }
+)
+
+SERVICE_SKIP_TASK_SCHEMA = vol.Schema(
+    {
+        vol.Required(ATTR_CHORE_INSTANCE_ID): vol.All(int, vol.Range(min=1)),
+    }
+)
+
+SERVICE_SKIP_MEDICATION_SCHEMA = vol.Schema(
     {
         vol.Required(ATTR_MEDICATION_DOSE_ID): vol.All(int, vol.Range(min=1)),
     }
@@ -50,116 +65,155 @@ def _get_entries(hass: HomeAssistant) -> list[DaynestConfigEntry]:
     return hass.config_entries.async_entries(DOMAIN)  # type: ignore[return-value]
 
 
+def _get_single_entry(hass: HomeAssistant, service_name: str) -> DaynestConfigEntry | None:
+    """Return the single loaded Daynest entry, or None if zero or multiple are loaded."""
+    entries = _get_entries(hass)
+    if not entries:
+        LOGGER.warning("daynest.%s called but no Daynest entries are loaded", service_name)
+        return None
+    if len(entries) != 1:
+        LOGGER.warning(
+            "daynest.%s: multiple Daynest entries loaded; specify an entry_id to target",
+            service_name,
+        )
+        return None
+    return entries[0]
+
+
+async def _handle_refresh(hass: HomeAssistant, call: ServiceCall) -> None:
+    """Trigger an immediate coordinator refresh for all Daynest entries."""
+    entries = _get_entries(hass)
+    if not entries:
+        LOGGER.warning("daynest.refresh called but no Daynest entries are loaded")
+        return
+    for entry in entries:
+        LOGGER.debug("Refreshing Daynest coordinator for entry %s", entry.entry_id)
+        await entry.runtime_data.coordinator.async_refresh()
+
+
+async def _handle_complete_task(hass: HomeAssistant, call: ServiceCall) -> None:
+    """Mark a chore instance as complete."""
+    chore_instance_id: int = call.data[ATTR_CHORE_INSTANCE_ID]
+    entry = _get_single_entry(hass, "complete_task")
+    if entry is None:
+        return
+    try:
+        await entry.runtime_data.client.async_complete_task(chore_instance_id=chore_instance_id)
+    except DaynestApiClientAuthenticationError as err:
+        LOGGER.error("daynest.complete_task: authentication error for chore %s", chore_instance_id)
+        raise HomeAssistantError(f"Authentication error completing chore {chore_instance_id}") from err
+    except DaynestApiClientCommunicationError as err:
+        LOGGER.error("daynest.complete_task: communication error for chore %s: %s", chore_instance_id, err)
+        raise HomeAssistantError(f"Communication error completing chore {chore_instance_id}") from err
+    except DaynestApiClientError as err:
+        LOGGER.error("daynest.complete_task: unexpected error for chore %s: %s", chore_instance_id, err)
+        raise HomeAssistantError(f"Error completing chore {chore_instance_id}") from err
+    LOGGER.debug("daynest.complete_task: chore %s marked as complete", chore_instance_id)
+    await entry.runtime_data.coordinator.async_refresh()
+
+
+async def _handle_snooze_task(hass: HomeAssistant, call: ServiceCall) -> None:
+    """Reschedule a chore instance N days into the future."""
+    chore_instance_id: int = call.data[ATTR_CHORE_INSTANCE_ID]
+    days: int = call.data[ATTR_DAYS]
+    entry = _get_single_entry(hass, "snooze_task")
+    if entry is None:
+        return
+    try:
+        await entry.runtime_data.client.async_snooze_task(chore_instance_id=chore_instance_id, days=days)
+    except DaynestApiClientAuthenticationError as err:
+        LOGGER.error("daynest.snooze_task: authentication error for chore %s", chore_instance_id)
+        raise HomeAssistantError(f"Authentication error snoozing chore {chore_instance_id}") from err
+    except DaynestApiClientCommunicationError as err:
+        LOGGER.error("daynest.snooze_task: communication error for chore %s: %s", chore_instance_id, err)
+        raise HomeAssistantError(f"Communication error snoozing chore {chore_instance_id}") from err
+    except DaynestApiClientError as err:
+        LOGGER.error("daynest.snooze_task: unexpected error for chore %s: %s", chore_instance_id, err)
+        raise HomeAssistantError(f"Error snoozing chore {chore_instance_id}") from err
+    LOGGER.debug("daynest.snooze_task: chore %s snoozed by %s day(s)", chore_instance_id, days)
+    await entry.runtime_data.coordinator.async_refresh()
+
+
+async def _handle_mark_medication_taken(hass: HomeAssistant, call: ServiceCall) -> None:
+    """Mark a medication dose as taken."""
+    medication_dose_id: int = call.data[ATTR_MEDICATION_DOSE_ID]
+    entry = _get_single_entry(hass, "mark_medication_taken")
+    if entry is None:
+        return
+    try:
+        await entry.runtime_data.client.async_mark_medication_taken(medication_dose_id=medication_dose_id)
+    except DaynestApiClientAuthenticationError as err:
+        LOGGER.error("daynest.mark_medication_taken: authentication error for dose %s", medication_dose_id)
+        raise HomeAssistantError(f"Authentication error marking dose {medication_dose_id} taken") from err
+    except DaynestApiClientCommunicationError as err:
+        LOGGER.error("daynest.mark_medication_taken: communication error for dose %s: %s", medication_dose_id, err)
+        raise HomeAssistantError(f"Communication error marking dose {medication_dose_id} taken") from err
+    except DaynestApiClientError as err:
+        LOGGER.error("daynest.mark_medication_taken: unexpected error for dose %s: %s", medication_dose_id, err)
+        raise HomeAssistantError(f"Error marking dose {medication_dose_id} taken") from err
+    LOGGER.debug("daynest.mark_medication_taken: dose %s marked as taken", medication_dose_id)
+    await entry.runtime_data.coordinator.async_refresh()
+
+
+async def _handle_skip_task(hass: HomeAssistant, call: ServiceCall) -> None:
+    """Skip a chore instance."""
+    chore_instance_id: int = call.data[ATTR_CHORE_INSTANCE_ID]
+    entry = _get_single_entry(hass, "skip_task")
+    if entry is None:
+        return
+    try:
+        await entry.runtime_data.client.async_skip_task(chore_instance_id=chore_instance_id)
+    except DaynestApiClientAuthenticationError as err:
+        LOGGER.error("daynest.skip_task: authentication error for chore %s", chore_instance_id)
+        raise HomeAssistantError(f"Authentication error skipping chore {chore_instance_id}") from err
+    except DaynestApiClientCommunicationError as err:
+        LOGGER.error("daynest.skip_task: communication error for chore %s: %s", chore_instance_id, err)
+        raise HomeAssistantError(f"Communication error skipping chore {chore_instance_id}") from err
+    except DaynestApiClientError as err:
+        LOGGER.error("daynest.skip_task: unexpected error for chore %s: %s", chore_instance_id, err)
+        raise HomeAssistantError(f"Error skipping chore {chore_instance_id}") from err
+    LOGGER.debug("daynest.skip_task: chore %s skipped", chore_instance_id)
+    await entry.runtime_data.coordinator.async_refresh()
+
+
+async def _handle_skip_medication(hass: HomeAssistant, call: ServiceCall) -> None:
+    """Skip a medication dose."""
+    medication_dose_id: int = call.data[ATTR_MEDICATION_DOSE_ID]
+    entry = _get_single_entry(hass, "skip_medication")
+    if entry is None:
+        return
+    try:
+        await entry.runtime_data.client.async_skip_medication(medication_dose_id=medication_dose_id)
+    except DaynestApiClientAuthenticationError as err:
+        LOGGER.error("daynest.skip_medication: authentication error for dose %s", medication_dose_id)
+        raise HomeAssistantError(f"Authentication error skipping dose {medication_dose_id}") from err
+    except DaynestApiClientCommunicationError as err:
+        LOGGER.error("daynest.skip_medication: communication error for dose %s: %s", medication_dose_id, err)
+        raise HomeAssistantError(f"Communication error skipping dose {medication_dose_id}") from err
+    except DaynestApiClientError as err:
+        LOGGER.error("daynest.skip_medication: unexpected error for dose %s: %s", medication_dose_id, err)
+        raise HomeAssistantError(f"Error skipping dose {medication_dose_id}") from err
+    LOGGER.debug("daynest.skip_medication: dose %s skipped", medication_dose_id)
+    await entry.runtime_data.coordinator.async_refresh()
+
+
 async def async_setup_services(hass: HomeAssistant) -> None:
     """Register Daynest Home Assistant services."""
-
-    async def handle_refresh(call: ServiceCall) -> None:
-        """Trigger an immediate coordinator refresh for all Daynest entries."""
-        entries = _get_entries(hass)
-        if not entries:
-            LOGGER.warning("daynest.refresh called but no Daynest entries are loaded")
-            return
-        for entry in entries:
-            LOGGER.debug("Refreshing Daynest coordinator for entry %s", entry.entry_id)
-            await entry.runtime_data.coordinator.async_refresh()
-
-    async def handle_complete_task(call: ServiceCall) -> None:
-        """Mark a chore instance as complete."""
-        task_id: int = call.data[ATTR_TASK_ID]
-        entries = _get_entries(hass)
-        if not entries:
-            LOGGER.warning("daynest.complete_task called but no Daynest entries are loaded")
-            return
-        if len(entries) != 1:
-            LOGGER.warning(
-                "daynest.complete_task: multiple Daynest entries loaded; specify an entry_id to target"
-            )
-            return
-        entry = entries[0]
-        try:
-            await entry.runtime_data.client.async_complete_task(task_id=task_id)
-        except DaynestApiClientAuthenticationError as err:
-            LOGGER.error("daynest.complete_task: authentication error for task %s", task_id)
-            raise HomeAssistantError(f"Authentication error completing task {task_id}") from err
-        except DaynestApiClientCommunicationError as err:
-            LOGGER.error("daynest.complete_task: communication error for task %s: %s", task_id, err)
-            raise HomeAssistantError(f"Communication error completing task {task_id}") from err
-        except DaynestApiClientError as err:
-            LOGGER.error("daynest.complete_task: unexpected error for task %s: %s", task_id, err)
-            raise HomeAssistantError(f"Error completing task {task_id}") from err
-        LOGGER.debug("daynest.complete_task: task %s marked as complete", task_id)
-        await entry.runtime_data.coordinator.async_refresh()
-
-    async def handle_snooze_task(call: ServiceCall) -> None:
-        """Reschedule a chore instance N days into the future."""
-        task_id: int = call.data[ATTR_TASK_ID]
-        days: int = call.data[ATTR_DAYS]
-        entries = _get_entries(hass)
-        if not entries:
-            LOGGER.warning("daynest.snooze_task called but no Daynest entries are loaded")
-            return
-        if len(entries) != 1:
-            LOGGER.warning(
-                "daynest.snooze_task: multiple Daynest entries loaded; specify an entry_id to target"
-            )
-            return
-        entry = entries[0]
-        try:
-            await entry.runtime_data.client.async_snooze_task(task_id=task_id, days=days)
-        except DaynestApiClientAuthenticationError as err:
-            LOGGER.error("daynest.snooze_task: authentication error for task %s", task_id)
-            raise HomeAssistantError(f"Authentication error snoozing task {task_id}") from err
-        except DaynestApiClientCommunicationError as err:
-            LOGGER.error("daynest.snooze_task: communication error for task %s: %s", task_id, err)
-            raise HomeAssistantError(f"Communication error snoozing task {task_id}") from err
-        except DaynestApiClientError as err:
-            LOGGER.error("daynest.snooze_task: unexpected error for task %s: %s", task_id, err)
-            raise HomeAssistantError(f"Error snoozing task {task_id}") from err
-        LOGGER.debug("daynest.snooze_task: task %s snoozed by %s day(s)", task_id, days)
-        await entry.runtime_data.coordinator.async_refresh()
-
-    async def handle_mark_medication_taken(call: ServiceCall) -> None:
-        """Mark a medication dose as taken."""
-        medication_dose_id: int = call.data[ATTR_MEDICATION_DOSE_ID]
-        entries = _get_entries(hass)
-        if not entries:
-            LOGGER.warning("daynest.mark_medication_taken called but no Daynest entries are loaded")
-            return
-        if len(entries) != 1:
-            LOGGER.warning(
-                "daynest.mark_medication_taken: multiple Daynest entries loaded; specify an entry_id to target"
-            )
-            return
-        entry = entries[0]
-        try:
-            await entry.runtime_data.client.async_mark_medication_taken(medication_dose_id=medication_dose_id)
-        except DaynestApiClientAuthenticationError as err:
-            LOGGER.error(
-                "daynest.mark_medication_taken: authentication error for dose %s", medication_dose_id
-            )
-            raise HomeAssistantError(f"Authentication error marking dose {medication_dose_id} taken") from err
-        except DaynestApiClientCommunicationError as err:
-            LOGGER.error(
-                "daynest.mark_medication_taken: communication error for dose %s: %s", medication_dose_id, err
-            )
-            raise HomeAssistantError(f"Communication error marking dose {medication_dose_id} taken") from err
-        except DaynestApiClientError as err:
-            LOGGER.error(
-                "daynest.mark_medication_taken: unexpected error for dose %s: %s", medication_dose_id, err
-            )
-            raise HomeAssistantError(f"Error marking dose {medication_dose_id} taken") from err
-        LOGGER.debug("daynest.mark_medication_taken: dose %s marked as taken", medication_dose_id)
-        await entry.runtime_data.coordinator.async_refresh()
-
-    hass.services.async_register(DOMAIN, SERVICE_REFRESH, handle_refresh)
+    hass.services.async_register(DOMAIN, SERVICE_REFRESH, partial(_handle_refresh, hass))
     hass.services.async_register(
-        DOMAIN, SERVICE_COMPLETE_TASK, handle_complete_task, schema=SERVICE_COMPLETE_TASK_SCHEMA
+        DOMAIN, SERVICE_COMPLETE_TASK, partial(_handle_complete_task, hass), schema=SERVICE_COMPLETE_TASK_SCHEMA
     )
     hass.services.async_register(
-        DOMAIN, SERVICE_SNOOZE_TASK, handle_snooze_task, schema=SERVICE_SNOOZE_TASK_SCHEMA
+        DOMAIN, SERVICE_SNOOZE_TASK, partial(_handle_snooze_task, hass), schema=SERVICE_SNOOZE_TASK_SCHEMA
     )
     hass.services.async_register(
-        DOMAIN, SERVICE_MARK_MEDICATION_TAKEN, handle_mark_medication_taken, schema=SERVICE_MARK_MEDICATION_TAKEN_SCHEMA
+        DOMAIN, SERVICE_MARK_MEDICATION_TAKEN, partial(_handle_mark_medication_taken, hass), schema=SERVICE_MARK_MEDICATION_TAKEN_SCHEMA
+    )
+    hass.services.async_register(
+        DOMAIN, SERVICE_SKIP_TASK, partial(_handle_skip_task, hass), schema=SERVICE_SKIP_TASK_SCHEMA
+    )
+    hass.services.async_register(
+        DOMAIN, SERVICE_SKIP_MEDICATION, partial(_handle_skip_medication, hass), schema=SERVICE_SKIP_MEDICATION_SCHEMA
     )
 
 
@@ -169,15 +223,19 @@ def async_unload_services(hass: HomeAssistant) -> None:
     hass.services.async_remove(DOMAIN, SERVICE_COMPLETE_TASK)
     hass.services.async_remove(DOMAIN, SERVICE_SNOOZE_TASK)
     hass.services.async_remove(DOMAIN, SERVICE_MARK_MEDICATION_TAKEN)
+    hass.services.async_remove(DOMAIN, SERVICE_SKIP_TASK)
+    hass.services.async_remove(DOMAIN, SERVICE_SKIP_MEDICATION)
 
 
 __all__ = [
+    "ATTR_CHORE_INSTANCE_ID",
     "ATTR_DAYS",
     "ATTR_MEDICATION_DOSE_ID",
-    "ATTR_TASK_ID",
     "SERVICE_COMPLETE_TASK",
     "SERVICE_MARK_MEDICATION_TAKEN",
     "SERVICE_REFRESH",
+    "SERVICE_SKIP_MEDICATION",
+    "SERVICE_SKIP_TASK",
     "SERVICE_SNOOZE_TASK",
     "async_setup_services",
     "async_unload_services",

--- a/custom_components/daynest/services.py
+++ b/custom_components/daynest/services.py
@@ -27,10 +27,12 @@ SERVICE_SKIP_MEDICATION = "skip_medication"
 ATTR_CHORE_INSTANCE_ID = "chore_instance_id"
 ATTR_MEDICATION_DOSE_ID = "medication_dose_id"
 ATTR_DAYS = "days"
+ATTR_ENTRY_ID = "entry_id"
 
 SERVICE_COMPLETE_TASK_SCHEMA = vol.Schema(
     {
         vol.Required(ATTR_CHORE_INSTANCE_ID): vol.All(int, vol.Range(min=1)),
+        vol.Optional(ATTR_ENTRY_ID): str,
     }
 )
 
@@ -38,24 +40,28 @@ SERVICE_SNOOZE_TASK_SCHEMA = vol.Schema(
     {
         vol.Required(ATTR_CHORE_INSTANCE_ID): vol.All(int, vol.Range(min=1)),
         vol.Optional(ATTR_DAYS, default=1): vol.All(int, vol.Range(min=1, max=30)),
+        vol.Optional(ATTR_ENTRY_ID): str,
     }
 )
 
 SERVICE_MARK_MEDICATION_TAKEN_SCHEMA = vol.Schema(
     {
         vol.Required(ATTR_MEDICATION_DOSE_ID): vol.All(int, vol.Range(min=1)),
+        vol.Optional(ATTR_ENTRY_ID): str,
     }
 )
 
 SERVICE_SKIP_TASK_SCHEMA = vol.Schema(
     {
         vol.Required(ATTR_CHORE_INSTANCE_ID): vol.All(int, vol.Range(min=1)),
+        vol.Optional(ATTR_ENTRY_ID): str,
     }
 )
 
 SERVICE_SKIP_MEDICATION_SCHEMA = vol.Schema(
     {
         vol.Required(ATTR_MEDICATION_DOSE_ID): vol.All(int, vol.Range(min=1)),
+        vol.Optional(ATTR_ENTRY_ID): str,
     }
 )
 
@@ -65,11 +71,21 @@ def _get_entries(hass: HomeAssistant) -> list[DaynestConfigEntry]:
     return hass.config_entries.async_entries(DOMAIN)  # type: ignore[return-value]
 
 
-def _get_single_entry(hass: HomeAssistant, service_name: str) -> DaynestConfigEntry | None:
-    """Return the single loaded Daynest entry, or None if zero or multiple are loaded."""
+def _get_single_entry(
+    hass: HomeAssistant,
+    service_name: str,
+    entry_id: str | None = None,
+) -> DaynestConfigEntry | None:
+    """Return the matching entry, falling back to single-entry behaviour when entry_id is omitted."""
     entries = _get_entries(hass)
     if not entries:
         LOGGER.warning("daynest.%s called but no Daynest entries are loaded", service_name)
+        return None
+    if entry_id is not None:
+        for entry in entries:
+            if entry.entry_id == entry_id:
+                return entry
+        LOGGER.warning("daynest.%s: entry_id %s not found", service_name, entry_id)
         return None
     if len(entries) != 1:
         LOGGER.warning(
@@ -94,7 +110,7 @@ async def _handle_refresh(hass: HomeAssistant, call: ServiceCall) -> None:
 async def _handle_complete_task(hass: HomeAssistant, call: ServiceCall) -> None:
     """Mark a chore instance as complete."""
     chore_instance_id: int = call.data[ATTR_CHORE_INSTANCE_ID]
-    entry = _get_single_entry(hass, "complete_task")
+    entry = _get_single_entry(hass, "complete_task", call.data.get(ATTR_ENTRY_ID))
     if entry is None:
         return
     try:
@@ -116,7 +132,7 @@ async def _handle_snooze_task(hass: HomeAssistant, call: ServiceCall) -> None:
     """Reschedule a chore instance N days into the future."""
     chore_instance_id: int = call.data[ATTR_CHORE_INSTANCE_ID]
     days: int = call.data[ATTR_DAYS]
-    entry = _get_single_entry(hass, "snooze_task")
+    entry = _get_single_entry(hass, "snooze_task", call.data.get(ATTR_ENTRY_ID))
     if entry is None:
         return
     try:
@@ -137,7 +153,7 @@ async def _handle_snooze_task(hass: HomeAssistant, call: ServiceCall) -> None:
 async def _handle_mark_medication_taken(hass: HomeAssistant, call: ServiceCall) -> None:
     """Mark a medication dose as taken."""
     medication_dose_id: int = call.data[ATTR_MEDICATION_DOSE_ID]
-    entry = _get_single_entry(hass, "mark_medication_taken")
+    entry = _get_single_entry(hass, "mark_medication_taken", call.data.get(ATTR_ENTRY_ID))
     if entry is None:
         return
     try:
@@ -158,7 +174,7 @@ async def _handle_mark_medication_taken(hass: HomeAssistant, call: ServiceCall) 
 async def _handle_skip_task(hass: HomeAssistant, call: ServiceCall) -> None:
     """Skip a chore instance."""
     chore_instance_id: int = call.data[ATTR_CHORE_INSTANCE_ID]
-    entry = _get_single_entry(hass, "skip_task")
+    entry = _get_single_entry(hass, "skip_task", call.data.get(ATTR_ENTRY_ID))
     if entry is None:
         return
     try:
@@ -179,7 +195,7 @@ async def _handle_skip_task(hass: HomeAssistant, call: ServiceCall) -> None:
 async def _handle_skip_medication(hass: HomeAssistant, call: ServiceCall) -> None:
     """Skip a medication dose."""
     medication_dose_id: int = call.data[ATTR_MEDICATION_DOSE_ID]
-    entry = _get_single_entry(hass, "skip_medication")
+    entry = _get_single_entry(hass, "skip_medication", call.data.get(ATTR_ENTRY_ID))
     if entry is None:
         return
     try:
@@ -230,6 +246,7 @@ def async_unload_services(hass: HomeAssistant) -> None:
 __all__ = [
     "ATTR_CHORE_INSTANCE_ID",
     "ATTR_DAYS",
+    "ATTR_ENTRY_ID",
     "ATTR_MEDICATION_DOSE_ID",
     "SERVICE_COMPLETE_TASK",
     "SERVICE_MARK_MEDICATION_TAKEN",

--- a/custom_components/daynest/services.yaml
+++ b/custom_components/daynest/services.yaml
@@ -3,7 +3,7 @@ refresh:
 
 complete_task:
   fields:
-    task_id:
+    chore_instance_id:
       required: true
       selector:
         number:
@@ -12,7 +12,7 @@ complete_task:
 
 snooze_task:
   fields:
-    task_id:
+    chore_instance_id:
       required: true
       selector:
         number:
@@ -28,6 +28,24 @@ snooze_task:
           mode: box
 
 mark_medication_taken:
+  fields:
+    medication_dose_id:
+      required: true
+      selector:
+        number:
+          min: 1
+          mode: box
+
+skip_task:
+  fields:
+    chore_instance_id:
+      required: true
+      selector:
+        number:
+          min: 1
+          mode: box
+
+skip_medication:
   fields:
     medication_dose_id:
       required: true

--- a/custom_components/daynest/translations/en.json
+++ b/custom_components/daynest/translations/en.json
@@ -47,6 +47,9 @@
       },
       "next_medication": {
         "name": "Next Medication"
+      },
+      "routines_open_count": {
+        "name": "Open Routines"
       }
     }
   },
@@ -59,8 +62,8 @@
       "name": "Complete Task",
       "description": "Marks a Daynest chore instance as complete. Requires the integration API key to have the ha:write scope.",
       "fields": {
-        "task_id": {
-          "name": "Task ID",
+        "chore_instance_id": {
+          "name": "Chore Instance ID",
           "description": "The numeric ID of the chore instance to mark as complete. Obtain this ID from the Daynest app or API."
         }
       }
@@ -69,8 +72,8 @@
       "name": "Snooze Task",
       "description": "Reschedules a Daynest chore instance to a later date. Requires the integration API key to have the ha:write scope.",
       "fields": {
-        "task_id": {
-          "name": "Task ID",
+        "chore_instance_id": {
+          "name": "Chore Instance ID",
           "description": "The numeric ID of the chore instance to reschedule. Obtain this ID from the Daynest app or API."
         },
         "days": {
@@ -86,6 +89,26 @@
         "medication_dose_id": {
           "name": "Medication Dose ID",
           "description": "The numeric ID of the medication dose instance to mark as taken. Obtain this ID from the Daynest app or API."
+        }
+      }
+    },
+    "skip_task": {
+      "name": "Skip Task",
+      "description": "Skips a Daynest chore instance. Requires the integration API key to have the ha:write scope.",
+      "fields": {
+        "chore_instance_id": {
+          "name": "Chore Instance ID",
+          "description": "The numeric ID of the chore instance to skip."
+        }
+      }
+    },
+    "skip_medication": {
+      "name": "Skip Medication Dose",
+      "description": "Skips a scheduled medication dose. Requires the integration API key to have the ha:write scope.",
+      "fields": {
+        "medication_dose_id": {
+          "name": "Medication Dose ID",
+          "description": "The numeric ID of the medication dose instance to skip."
         }
       }
     }

--- a/custom_components/tests/test_client.py
+++ b/custom_components/tests/test_client.py
@@ -256,7 +256,7 @@ class TestDaynestApiClientWriteMethods:
         response = _make_mock_response(200, VALID_ACTION_RESPONSE)
         client = _make_post_client(response)
 
-        result = await client.async_complete_task(task_id=42)
+        result = await client.async_complete_task(chore_instance_id=42)
 
         assert result["success"] is True
         assert "42" in result["detail"]
@@ -266,7 +266,7 @@ class TestDaynestApiClientWriteMethods:
         response = _make_mock_response(200, snooze_response)
         client = _make_post_client(response)
 
-        result = await client.async_snooze_task(task_id=10, days=2)
+        result = await client.async_snooze_task(chore_instance_id=10, days=2)
 
         assert result["success"] is True
 
@@ -284,21 +284,21 @@ class TestDaynestApiClientWriteMethods:
         client = _make_post_client(response)
 
         with pytest.raises(DaynestApiClientAuthenticationError):
-            await client.async_complete_task(task_id=1)
+            await client.async_complete_task(chore_instance_id=1)
 
     async def test_post_action_403_raises_authentication_error(self) -> None:
         response = _make_mock_response(403, {})
         client = _make_post_client(response)
 
         with pytest.raises(DaynestApiClientAuthenticationError):
-            await client.async_complete_task(task_id=1)
+            await client.async_complete_task(chore_instance_id=1)
 
     async def test_post_action_500_raises_server_unavailable_error(self) -> None:
         response = _make_mock_response(500, {})
         client = _make_post_client(response)
 
         with pytest.raises(DaynestApiClientServerUnavailableError):
-            await client.async_complete_task(task_id=1)
+            await client.async_complete_task(chore_instance_id=1)
 
     async def test_post_action_timeout_raises_timeout_error(self) -> None:
         session = MagicMock(spec=aiohttp.ClientSession)
@@ -309,7 +309,7 @@ class TestDaynestApiClientWriteMethods:
         client = DaynestApiClient(session=session, base_url="https://api.example", integration_key="key")
 
         with pytest.raises(DaynestApiClientTimeoutError):
-            await client.async_complete_task(task_id=1)
+            await client.async_complete_task(chore_instance_id=1)
 
     async def test_post_action_connection_error_raises_server_unavailable(self) -> None:
         session = MagicMock(spec=aiohttp.ClientSession)
@@ -320,7 +320,7 @@ class TestDaynestApiClientWriteMethods:
         client = DaynestApiClient(session=session, base_url="https://api.example", integration_key="key")
 
         with pytest.raises(DaynestApiClientServerUnavailableError):
-            await client.async_snooze_task(task_id=1)
+            await client.async_snooze_task(chore_instance_id=1)
 
     async def test_post_action_non_dict_response_raises_malformed_error(self) -> None:
         response = _make_mock_response(200, ["not", "a", "dict"])
@@ -339,7 +339,7 @@ class TestDaynestApiClientWriteMethods:
             integration_key="daynest_write_secret",
         )
 
-        await client.async_complete_task(task_id=5)
+        await client.async_complete_task(chore_instance_id=5)
 
         call_kwargs = session.post.call_args[1]
         assert call_kwargs["headers"]["X-Integration-Key"] == "daynest_write_secret"
@@ -350,8 +350,41 @@ class TestDaynestApiClientWriteMethods:
         session.post = MagicMock(return_value=response)
         client = DaynestApiClient(session=session, base_url="https://api.example", integration_key="key")
 
-        await client.async_snooze_task(task_id=3)
+        await client.async_snooze_task(chore_instance_id=3)
 
         call_kwargs = session.post.call_args[1]
         assert call_kwargs["json"]["days"] == 1
+
+    async def test_complete_task_uses_chore_instance_id_payload(self) -> None:
+        response = _make_mock_response(200, VALID_ACTION_RESPONSE)
+        session = MagicMock(spec=aiohttp.ClientSession)
+        session.post = MagicMock(return_value=response)
+        client = DaynestApiClient(session=session, base_url="https://api.example", integration_key="key")
+
+        await client.async_complete_task(chore_instance_id=6)
+
+        call_kwargs = session.post.call_args[1]
+        assert call_kwargs["json"] == {"chore_instance_id": 6}
+
+    async def test_snooze_task_uses_chore_instance_id_payload(self) -> None:
+        response = _make_mock_response(200, VALID_ACTION_RESPONSE)
+        session = MagicMock(spec=aiohttp.ClientSession)
+        session.post = MagicMock(return_value=response)
+        client = DaynestApiClient(session=session, base_url="https://api.example", integration_key="key")
+
+        await client.async_snooze_task(chore_instance_id=7, days=4)
+
+        call_kwargs = session.post.call_args[1]
+        assert call_kwargs["json"] == {"chore_instance_id": 7, "days": 4}
+
+    async def test_skip_task_uses_chore_instance_id_payload(self) -> None:
+        response = _make_mock_response(200, VALID_ACTION_RESPONSE)
+        session = MagicMock(spec=aiohttp.ClientSession)
+        session.post = MagicMock(return_value=response)
+        client = DaynestApiClient(session=session, base_url="https://api.example", integration_key="key")
+
+        await client.async_skip_task(chore_instance_id=8)
+
+        call_kwargs = session.post.call_args[1]
+        assert call_kwargs["json"] == {"chore_instance_id": 8}
 

--- a/custom_components/tests/test_client.py
+++ b/custom_components/tests/test_client.py
@@ -388,3 +388,14 @@ class TestDaynestApiClientWriteMethods:
         call_kwargs = session.post.call_args[1]
         assert call_kwargs["json"] == {"chore_instance_id": 8}
 
+    async def test_skip_medication_uses_medication_dose_id_payload(self) -> None:
+        response = _make_mock_response(200, VALID_ACTION_RESPONSE)
+        session = MagicMock(spec=aiohttp.ClientSession)
+        session.post = MagicMock(return_value=response)
+        client = DaynestApiClient(session=session, base_url="https://api.example", integration_key="key")
+
+        await client.async_skip_medication(medication_dose_id=9)
+
+        call_kwargs = session.post.call_args[1]
+        assert call_kwargs["json"] == {"medication_dose_id": 9}
+

--- a/custom_components/tests/test_services.py
+++ b/custom_components/tests/test_services.py
@@ -12,12 +12,13 @@ from daynest.api.client import (
     DaynestApiClientError,
 )
 from daynest.services import (
+    ATTR_CHORE_INSTANCE_ID,
     ATTR_DAYS,
     ATTR_MEDICATION_DOSE_ID,
-    ATTR_TASK_ID,
     SERVICE_COMPLETE_TASK,
     SERVICE_MARK_MEDICATION_TAKEN,
     SERVICE_REFRESH,
+    SERVICE_SKIP_TASK,
     SERVICE_SNOOZE_TASK,
     async_setup_services,
     async_unload_services,
@@ -125,7 +126,7 @@ class TestHandleCompleteTask:
         await async_setup_services(hass)
         handler = await _get_handler(hass, SERVICE_COMPLETE_TASK)
         with patch("daynest.services.LOGGER") as mock_logger:
-            await handler(_make_service_call(**{ATTR_TASK_ID: 42}))
+            await handler(_make_service_call(**{ATTR_CHORE_INSTANCE_ID: 42}))
         mock_logger.warning.assert_called_once()
 
     async def test_multiple_entries_logs_warning_and_returns(self) -> None:
@@ -134,7 +135,7 @@ class TestHandleCompleteTask:
         await async_setup_services(hass)
         handler = await _get_handler(hass, SERVICE_COMPLETE_TASK)
         with patch("daynest.services.LOGGER") as mock_logger:
-            await handler(_make_service_call(**{ATTR_TASK_ID: 42}))
+            await handler(_make_service_call(**{ATTR_CHORE_INSTANCE_ID: 42}))
         mock_logger.warning.assert_called_once()
         for entry in entries:
             entry.runtime_data.client.async_complete_task.assert_not_awaited()
@@ -145,8 +146,8 @@ class TestHandleCompleteTask:
         hass = _make_hass(entries=[entry])
         await async_setup_services(hass)
         handler = await _get_handler(hass, SERVICE_COMPLETE_TASK)
-        await handler(_make_service_call(**{ATTR_TASK_ID: 7}))
-        client.async_complete_task.assert_awaited_once_with(task_id=7)
+        await handler(_make_service_call(**{ATTR_CHORE_INSTANCE_ID: 7}))
+        client.async_complete_task.assert_awaited_once_with(chore_instance_id=7)
         entry.runtime_data.coordinator.async_refresh.assert_awaited_once()
 
     async def test_authentication_error_raises_homeassistant_error(self) -> None:
@@ -156,8 +157,8 @@ class TestHandleCompleteTask:
         hass = _make_hass(entries=[entry])
         await async_setup_services(hass)
         handler = await _get_handler(hass, SERVICE_COMPLETE_TASK)
-        with pytest.raises(HomeAssistantError, match="Authentication error completing task"):
-            await handler(_make_service_call(**{ATTR_TASK_ID: 7}))
+        with pytest.raises(HomeAssistantError, match="Authentication error completing chore"):
+            await handler(_make_service_call(**{ATTR_CHORE_INSTANCE_ID: 7}))
 
     async def test_communication_error_raises_homeassistant_error(self) -> None:
         client = AsyncMock()
@@ -166,8 +167,8 @@ class TestHandleCompleteTask:
         hass = _make_hass(entries=[entry])
         await async_setup_services(hass)
         handler = await _get_handler(hass, SERVICE_COMPLETE_TASK)
-        with pytest.raises(HomeAssistantError, match="Communication error completing task"):
-            await handler(_make_service_call(**{ATTR_TASK_ID: 7}))
+        with pytest.raises(HomeAssistantError, match="Communication error completing chore"):
+            await handler(_make_service_call(**{ATTR_CHORE_INSTANCE_ID: 7}))
 
     async def test_generic_api_error_raises_homeassistant_error(self) -> None:
         client = AsyncMock()
@@ -176,8 +177,8 @@ class TestHandleCompleteTask:
         hass = _make_hass(entries=[entry])
         await async_setup_services(hass)
         handler = await _get_handler(hass, SERVICE_COMPLETE_TASK)
-        with pytest.raises(HomeAssistantError, match="Error completing task"):
-            await handler(_make_service_call(**{ATTR_TASK_ID: 7}))
+        with pytest.raises(HomeAssistantError, match="Error completing chore"):
+            await handler(_make_service_call(**{ATTR_CHORE_INSTANCE_ID: 7}))
 
     async def test_error_does_not_trigger_coordinator_refresh(self) -> None:
         client = AsyncMock()
@@ -187,7 +188,7 @@ class TestHandleCompleteTask:
         await async_setup_services(hass)
         handler = await _get_handler(hass, SERVICE_COMPLETE_TASK)
         with pytest.raises(HomeAssistantError):
-            await handler(_make_service_call(**{ATTR_TASK_ID: 7}))
+            await handler(_make_service_call(**{ATTR_CHORE_INSTANCE_ID: 7}))
         entry.runtime_data.coordinator.async_refresh.assert_not_awaited()
 
 
@@ -201,7 +202,7 @@ class TestHandleSnoozeTask:
         await async_setup_services(hass)
         handler = await _get_handler(hass, SERVICE_SNOOZE_TASK)
         with patch("daynest.services.LOGGER") as mock_logger:
-            await handler(_make_service_call(**{ATTR_TASK_ID: 1, ATTR_DAYS: 2}))
+            await handler(_make_service_call(**{ATTR_CHORE_INSTANCE_ID: 1, ATTR_DAYS: 2}))
         mock_logger.warning.assert_called_once()
 
     async def test_multiple_entries_logs_warning_and_returns(self) -> None:
@@ -210,7 +211,7 @@ class TestHandleSnoozeTask:
         await async_setup_services(hass)
         handler = await _get_handler(hass, SERVICE_SNOOZE_TASK)
         with patch("daynest.services.LOGGER") as mock_logger:
-            await handler(_make_service_call(**{ATTR_TASK_ID: 1, ATTR_DAYS: 2}))
+            await handler(_make_service_call(**{ATTR_CHORE_INSTANCE_ID: 1, ATTR_DAYS: 2}))
         mock_logger.warning.assert_called_once()
 
     async def test_success_calls_client_with_correct_args(self) -> None:
@@ -219,8 +220,8 @@ class TestHandleSnoozeTask:
         hass = _make_hass(entries=[entry])
         await async_setup_services(hass)
         handler = await _get_handler(hass, SERVICE_SNOOZE_TASK)
-        await handler(_make_service_call(**{ATTR_TASK_ID: 3, ATTR_DAYS: 5}))
-        client.async_snooze_task.assert_awaited_once_with(task_id=3, days=5)
+        await handler(_make_service_call(**{ATTR_CHORE_INSTANCE_ID: 3, ATTR_DAYS: 5}))
+        client.async_snooze_task.assert_awaited_once_with(chore_instance_id=3, days=5)
         entry.runtime_data.coordinator.async_refresh.assert_awaited_once()
 
     async def test_authentication_error_raises_homeassistant_error(self) -> None:
@@ -230,8 +231,8 @@ class TestHandleSnoozeTask:
         hass = _make_hass(entries=[entry])
         await async_setup_services(hass)
         handler = await _get_handler(hass, SERVICE_SNOOZE_TASK)
-        with pytest.raises(HomeAssistantError, match="Authentication error snoozing task"):
-            await handler(_make_service_call(**{ATTR_TASK_ID: 3, ATTR_DAYS: 2}))
+        with pytest.raises(HomeAssistantError, match="Authentication error snoozing chore"):
+            await handler(_make_service_call(**{ATTR_CHORE_INSTANCE_ID: 3, ATTR_DAYS: 2}))
 
     async def test_communication_error_raises_homeassistant_error(self) -> None:
         client = AsyncMock()
@@ -240,8 +241,8 @@ class TestHandleSnoozeTask:
         hass = _make_hass(entries=[entry])
         await async_setup_services(hass)
         handler = await _get_handler(hass, SERVICE_SNOOZE_TASK)
-        with pytest.raises(HomeAssistantError, match="Communication error snoozing task"):
-            await handler(_make_service_call(**{ATTR_TASK_ID: 3, ATTR_DAYS: 2}))
+        with pytest.raises(HomeAssistantError, match="Communication error snoozing chore"):
+            await handler(_make_service_call(**{ATTR_CHORE_INSTANCE_ID: 3, ATTR_DAYS: 2}))
 
     async def test_generic_api_error_raises_homeassistant_error(self) -> None:
         client = AsyncMock()
@@ -250,8 +251,8 @@ class TestHandleSnoozeTask:
         hass = _make_hass(entries=[entry])
         await async_setup_services(hass)
         handler = await _get_handler(hass, SERVICE_SNOOZE_TASK)
-        with pytest.raises(HomeAssistantError, match="Error snoozing task"):
-            await handler(_make_service_call(**{ATTR_TASK_ID: 3, ATTR_DAYS: 2}))
+        with pytest.raises(HomeAssistantError, match="Error snoozing chore"):
+            await handler(_make_service_call(**{ATTR_CHORE_INSTANCE_ID: 3, ATTR_DAYS: 2}))
 
 
 @pytest.mark.unit
@@ -326,3 +327,29 @@ class TestHandleMarkMedicationTaken:
         with pytest.raises(HomeAssistantError):
             await handler(_make_service_call(**{ATTR_MEDICATION_DOSE_ID: 15}))
         entry.runtime_data.coordinator.async_refresh.assert_not_awaited()
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+class TestHandleSkipTask:
+    """Tests for the skip_task service handler."""
+
+    async def test_success_calls_client_with_chore_instance_id(self) -> None:
+        client = AsyncMock()
+        entry = _make_entry(client=client)
+        hass = _make_hass(entries=[entry])
+        await async_setup_services(hass)
+        handler = await _get_handler(hass, SERVICE_SKIP_TASK)
+        await handler(_make_service_call(**{ATTR_CHORE_INSTANCE_ID: 9}))
+        client.async_skip_task.assert_awaited_once_with(chore_instance_id=9)
+        entry.runtime_data.coordinator.async_refresh.assert_awaited_once()
+
+    async def test_authentication_error_raises_homeassistant_error(self) -> None:
+        client = AsyncMock()
+        client.async_skip_task.side_effect = DaynestApiClientAuthenticationError()
+        entry = _make_entry(client=client)
+        hass = _make_hass(entries=[entry])
+        await async_setup_services(hass)
+        handler = await _get_handler(hass, SERVICE_SKIP_TASK)
+        with pytest.raises(HomeAssistantError, match="Authentication error skipping chore"):
+            await handler(_make_service_call(**{ATTR_CHORE_INSTANCE_ID: 9}))

--- a/custom_components/tests/test_services.py
+++ b/custom_components/tests/test_services.py
@@ -18,6 +18,7 @@ from daynest.services import (
     SERVICE_COMPLETE_TASK,
     SERVICE_MARK_MEDICATION_TAKEN,
     SERVICE_REFRESH,
+    SERVICE_SKIP_MEDICATION,
     SERVICE_SKIP_TASK,
     SERVICE_SNOOZE_TASK,
     async_setup_services,
@@ -73,6 +74,8 @@ class TestAsyncSetupServices:
         assert SERVICE_COMPLETE_TASK in hass._registered_services
         assert SERVICE_SNOOZE_TASK in hass._registered_services
         assert SERVICE_MARK_MEDICATION_TAKEN in hass._registered_services
+        assert SERVICE_SKIP_TASK in hass._registered_services
+        assert SERVICE_SKIP_MEDICATION in hass._registered_services
 
     async def test_unload_removes_all_services(self) -> None:
         hass = _make_hass()
@@ -82,6 +85,8 @@ class TestAsyncSetupServices:
         assert SERVICE_COMPLETE_TASK not in hass._registered_services
         assert SERVICE_SNOOZE_TASK not in hass._registered_services
         assert SERVICE_MARK_MEDICATION_TAKEN not in hass._registered_services
+        assert SERVICE_SKIP_TASK not in hass._registered_services
+        assert SERVICE_SKIP_MEDICATION not in hass._registered_services
 
 
 @pytest.mark.unit

--- a/frontend/src/app.css
+++ b/frontend/src/app.css
@@ -91,3 +91,28 @@ main.container {
     padding-right: 0.75rem;
   }
 }
+
+.web-focus-panel {
+  background: linear-gradient(135deg, rgba(13, 110, 253, 0.12), var(--bg-surface-from));
+}
+
+.focus-progress {
+  min-width: 7rem;
+  padding: 0.75rem 1rem;
+  border-radius: 1rem;
+  background: var(--bg-muted);
+  text-align: center;
+}
+
+.focus-progress-value {
+  display: block;
+  font-size: clamp(1.75rem, 4vw, 2.5rem);
+  line-height: 1;
+  font-weight: 800;
+}
+
+.settings-endpoint-list {
+  display: grid;
+  gap: 0.35rem;
+  padding-left: 1rem;
+}

--- a/frontend/src/features/calendar/CalendarPage.tsx
+++ b/frontend/src/features/calendar/CalendarPage.tsx
@@ -74,6 +74,7 @@ export function CalendarPage() {
   const [linkedSource, setLinkedSource] = useState("");
   const [linkedRef, setLinkedRef] = useState("");
   const [editingPlannedItemId, setEditingPlannedItemId] = useState<number | null>(null);
+  const [confirmDeleteId, setConfirmDeleteId] = useState<number | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [canRetry, setCanRetry] = useState(false);
@@ -220,9 +221,7 @@ export function CalendarPage() {
   };
 
   const removePlannedItem = async (itemId: number) => {
-    if (!window.confirm("Delete this planned item?")) {
-      return;
-    }
+    setConfirmDeleteId(null);
     setAddError(null);
     setIsAdding(true);
     setActionStatus(null);
@@ -735,14 +734,35 @@ export function CalendarPage() {
                         >
                           Edit
                         </button>
-                        <button
-                          type="button"
-                          className="btn btn-outline-danger btn-sm"
-                          disabled={isAdding}
-                          onClick={() => void removePlannedItem(item.id)}
-                        >
-                          Delete
-                        </button>
+                        {confirmDeleteId === item.id ? (
+                          <div className="d-flex gap-1">
+                            <button
+                              type="button"
+                              className="btn btn-danger btn-sm"
+                              disabled={isAdding}
+                              onClick={() => void removePlannedItem(item.id)}
+                            >
+                              Confirm
+                            </button>
+                            <button
+                              type="button"
+                              className="btn btn-outline-secondary btn-sm"
+                              disabled={isAdding}
+                              onClick={() => setConfirmDeleteId(null)}
+                            >
+                              Cancel
+                            </button>
+                          </div>
+                        ) : (
+                          <button
+                            type="button"
+                            className="btn btn-outline-danger btn-sm"
+                            disabled={isAdding}
+                            onClick={() => setConfirmDeleteId(item.id)}
+                          >
+                            Delete
+                          </button>
+                        )}
                       </div>
                     </div>
                   </li>

--- a/frontend/src/features/medication/MedicationPage.tsx
+++ b/frontend/src/features/medication/MedicationPage.tsx
@@ -216,12 +216,21 @@ export function MedicationPage() {
               ) : (
                 plans.map((plan) => (
                   <li key={plan.id} className="list-group-item py-2">
-                    <div className="fw-semibold">{plan.name}</div>
-                    <small className="text-muted d-block">
-                      Starts {formatDate(plan.start_date)} • {plan.schedule_time.slice(0, 5)} •
-                      every {plan.every_n_days} day{plan.every_n_days === 1 ? "" : "s"}
-                    </small>
-                    <small className="d-block mt-1">{plan.instructions}</small>
+                    <div className="d-flex justify-content-between align-items-start gap-3">
+                      <div>
+                        <div className="fw-semibold">{plan.name}</div>
+                        <small className="text-muted d-block">
+                          Starts {formatDate(plan.start_date)} • {plan.schedule_time.slice(0, 5)} •
+                          every {plan.every_n_days} day{plan.every_n_days === 1 ? "" : "s"}
+                        </small>
+                        <small className="d-block mt-1">{plan.instructions}</small>
+                      </div>
+                      <span
+                        className={`badge align-self-start ${plan.is_active ? "text-bg-success" : "text-bg-secondary"}`}
+                      >
+                        {plan.is_active ? "Active" : "Inactive"}
+                      </span>
+                    </div>
                   </li>
                 ))
               )}

--- a/frontend/src/features/settings/SettingsPage.tsx
+++ b/frontend/src/features/settings/SettingsPage.tsx
@@ -10,14 +10,57 @@ import {
 const AVAILABLE_SCOPES = [
   {
     key: "ha:read",
-    label: "Home Assistant",
-    description: "Allows Home Assistant summary, entities, and dashboard reads.",
+    label: "Home Assistant dashboard",
+    description: "Allows Home Assistant summary, entity, and dashboard reads.",
+  },
+  {
+    key: "ha:write",
+    label: "Home Assistant actions",
+    description:
+      "Allows Home Assistant services to complete tasks, snooze tasks, and mark medication taken.",
   },
   {
     key: "mcp:read",
     label: "MCP Adapter",
     description: "Allows MCP-compatible reads for Today and Calendar day data.",
   },
+];
+
+const INTEGRATION_PRESETS = [
+  {
+    key: "ha-dashboard",
+    label: "Home Assistant dashboard",
+    name: "Home Assistant",
+    scopes: ["ha:read"],
+    rateLimit: "120",
+    description: "Sensors, dashboard metrics, setup validation, and entity reads.",
+  },
+  {
+    key: "ha-automation",
+    label: "Home Assistant automations",
+    name: "Home Assistant Automations",
+    scopes: ["ha:read", "ha:write"],
+    rateLimit: "120",
+    description: "Everything in dashboard mode plus write services for household automations.",
+  },
+  {
+    key: "mcp-reader",
+    label: "MCP read-only",
+    name: "MCP Adapter",
+    scopes: ["mcp:read"],
+    rateLimit: "60",
+    description: "Least-privilege read access for MCP consumers.",
+  },
+];
+
+const HA_ENDPOINTS = [
+  "GET /api/v1/integrations/home-assistant/summary",
+  "GET /api/v1/integrations/home-assistant/dashboard",
+  "POST /api/v1/integrations/home-assistant/actions/complete-task",
+  "POST /api/v1/integrations/home-assistant/actions/snooze-task",
+  "POST /api/v1/integrations/home-assistant/actions/mark-medication-taken",
+  "POST /api/v1/integrations/home-assistant/actions/skip-task",
+  "POST /api/v1/integrations/home-assistant/actions/skip-medication",
 ];
 
 export function SettingsPage() {
@@ -34,6 +77,8 @@ export function SettingsPage() {
   const [name, setName] = useState("Home Assistant");
   const [rateLimit, setRateLimit] = useState("120");
   const [selectedScopes, setSelectedScopes] = useState<string[]>(["ha:read"]);
+
+  const backendBaseUrl = window.location.origin;
 
   const loadClients = async (signal?: AbortSignal) => {
     setLoading(true);
@@ -67,6 +112,14 @@ export function SettingsPage() {
       current.includes(scope) ? current.filter((item) => item !== scope) : [...current, scope],
     );
     setSubmitError(null);
+  };
+
+  const applyPreset = (preset: (typeof INTEGRATION_PRESETS)[number]) => {
+    setName(preset.name);
+    setRateLimit(preset.rateLimit);
+    setSelectedScopes(preset.scopes);
+    setSubmitError(null);
+    setSuccessMessage(null);
   };
 
   const onCreateClient = async () => {
@@ -158,6 +211,23 @@ export function SettingsPage() {
       <div className="row g-3">
         <div className="col-lg-5">
           <div className="card mb-3">
+            <div className="card-header fw-semibold py-2">Integration presets</div>
+            <div className="card-body d-grid gap-2">
+              {INTEGRATION_PRESETS.map((preset) => (
+                <button
+                  key={preset.key}
+                  type="button"
+                  className="btn btn-outline-primary text-start"
+                  onClick={() => applyPreset(preset)}
+                >
+                  <span className="fw-semibold d-block">{preset.label}</span>
+                  <span className="small text-muted">{preset.description}</span>
+                </button>
+              ))}
+            </div>
+          </div>
+
+          <div className="card mb-3">
             <div className="card-header fw-semibold py-2">Create integration client</div>
             <div className="card-body d-grid gap-3">
               <input
@@ -220,6 +290,39 @@ export function SettingsPage() {
             ) : null}
           </div>
 
+          <div className="card mb-3">
+            <div className="card-header fw-semibold py-2">Home Assistant connection details</div>
+            <div className="card-body">
+              <p className="text-muted small mb-2">
+                Use these values when adding the Daynest custom integration in Home Assistant.
+              </p>
+              <dl className="row small mb-0">
+                <dt className="col-sm-4">Base URL</dt>
+                <dd className="col-sm-8">
+                  <code>{backendBaseUrl}</code>
+                </dd>
+                <dt className="col-sm-4">Header</dt>
+                <dd className="col-sm-8">
+                  <code>X-Integration-Key</code>
+                </dd>
+                <dt className="col-sm-4">Contract</dt>
+                <dd className="col-sm-8">
+                  <code>home-assistant; version=ha.v1</code>
+                </dd>
+              </dl>
+              <details className="mt-3">
+                <summary className="small fw-semibold">Home Assistant endpoints</summary>
+                <ul className="settings-endpoint-list mt-2 mb-0">
+                  {HA_ENDPOINTS.map((endpoint) => (
+                    <li key={endpoint}>
+                      <code>{endpoint}</code>
+                    </li>
+                  ))}
+                </ul>
+              </details>
+            </div>
+          </div>
+
           {createdClient ? (
             <div className="card">
               <div className="card-header fw-semibold py-2">New API key</div>
@@ -262,11 +365,13 @@ export function SettingsPage() {
                           {client.scopes.join(", ")} • {client.rate_limit_per_minute}/min
                         </small>
                         <small className="text-muted d-block mt-1">
-                          {client.scopes.includes("ha:read") ? "Home Assistant ready." : ""}
-                          {client.scopes.includes("ha:read") && client.scopes.includes("mcp:read")
-                            ? " "
-                            : ""}
-                          {client.scopes.includes("mcp:read") ? "MCP adapter ready." : ""}
+                          {[
+                            client.scopes.includes("ha:read") && "Home Assistant dashboard ready.",
+                            client.scopes.includes("ha:write") && "HA actions enabled.",
+                            client.scopes.includes("mcp:read") && "MCP adapter ready.",
+                          ]
+                            .filter(Boolean)
+                            .join(" ")}
                         </small>
                       </div>
                       <span

--- a/frontend/src/features/templates/TemplatesPage.tsx
+++ b/frontend/src/features/templates/TemplatesPage.tsx
@@ -31,6 +31,8 @@ export function TemplatesPage() {
   const [routineDueTime, setRoutineDueTime] = useState("08:00");
   const [routineActive, setRoutineActive] = useState(true);
   const [editingRoutineId, setEditingRoutineId] = useState<number | null>(null);
+  const [confirmDeleteRoutineId, setConfirmDeleteRoutineId] = useState<number | null>(null);
+  const [confirmDeleteChoreId, setConfirmDeleteChoreId] = useState<number | null>(null);
 
   const [choreName, setChoreName] = useState("");
   const [choreDescription, setChoreDescription] = useState("");
@@ -167,9 +169,7 @@ export function TemplatesPage() {
   };
 
   const handleDeleteRoutine = async (routineId: number) => {
-    if (!window.confirm("Delete this routine template?")) {
-      return;
-    }
+    setConfirmDeleteRoutineId(null);
     setIsSubmitting(true);
     setSubmitError(null);
     setSuccessMessage(null);
@@ -186,9 +186,7 @@ export function TemplatesPage() {
   };
 
   const handleDeleteChore = async (choreId: number) => {
-    if (!window.confirm("Delete this chore template?")) {
-      return;
-    }
+    setConfirmDeleteChoreId(null);
     setIsSubmitting(true);
     setSubmitError(null);
     setSuccessMessage(null);
@@ -366,18 +364,40 @@ export function TemplatesPage() {
                             setRoutineEveryNDays(String(routine.every_n_days));
                             setRoutineDueTime(routine.due_time ? routine.due_time.slice(0, 5) : "");
                             setRoutineActive(routine.is_active);
+                            setConfirmDeleteRoutineId(null);
                             setSubmitError(null);
                           }}
                         >
                           Edit
                         </button>
-                        <button
-                          type="button"
-                          className="btn btn-outline-danger btn-sm"
-                          onClick={() => void handleDeleteRoutine(routine.id)}
-                        >
-                          Delete
-                        </button>
+                        {confirmDeleteRoutineId === routine.id ? (
+                          <div className="d-flex gap-1">
+                            <button
+                              type="button"
+                              className="btn btn-danger btn-sm"
+                              disabled={isSubmitting}
+                              onClick={() => void handleDeleteRoutine(routine.id)}
+                            >
+                              Confirm
+                            </button>
+                            <button
+                              type="button"
+                              className="btn btn-outline-secondary btn-sm"
+                              disabled={isSubmitting}
+                              onClick={() => setConfirmDeleteRoutineId(null)}
+                            >
+                              Cancel
+                            </button>
+                          </div>
+                        ) : (
+                          <button
+                            type="button"
+                            className="btn btn-outline-danger btn-sm"
+                            onClick={() => setConfirmDeleteRoutineId(routine.id)}
+                          >
+                            Delete
+                          </button>
+                        )}
                       </div>
                     </div>
                   </li>
@@ -498,18 +518,40 @@ export function TemplatesPage() {
                             setChoreStartDate(chore.start_date);
                             setChoreEveryNDays(String(chore.every_n_days));
                             setChoreActive(chore.is_active);
+                            setConfirmDeleteChoreId(null);
                             setSubmitError(null);
                           }}
                         >
                           Edit
                         </button>
-                        <button
-                          type="button"
-                          className="btn btn-outline-danger btn-sm"
-                          onClick={() => void handleDeleteChore(chore.id)}
-                        >
-                          Delete
-                        </button>
+                        {confirmDeleteChoreId === chore.id ? (
+                          <div className="d-flex gap-1">
+                            <button
+                              type="button"
+                              className="btn btn-danger btn-sm"
+                              disabled={isSubmitting}
+                              onClick={() => void handleDeleteChore(chore.id)}
+                            >
+                              Confirm
+                            </button>
+                            <button
+                              type="button"
+                              className="btn btn-outline-secondary btn-sm"
+                              disabled={isSubmitting}
+                              onClick={() => setConfirmDeleteChoreId(null)}
+                            >
+                              Cancel
+                            </button>
+                          </div>
+                        ) : (
+                          <button
+                            type="button"
+                            className="btn btn-outline-danger btn-sm"
+                            onClick={() => setConfirmDeleteChoreId(chore.id)}
+                          >
+                            Delete
+                          </button>
+                        )}
                       </div>
                     </div>
                   </li>

--- a/frontend/src/features/today/TodayPage.tsx
+++ b/frontend/src/features/today/TodayPage.tsx
@@ -1,7 +1,9 @@
 import { useEffect, useState } from "react";
+import type { FormEvent } from "react";
 import {
   completeRoutineTask,
   completeChore,
+  createPlannedItem,
   deletePlannedItem,
   fetchToday,
   isRetryableApiError,
@@ -55,6 +57,39 @@ type BulkAction = {
   isAvailable: (item: SectionItem) => boolean;
   run: (item: SectionItem) => Promise<unknown>;
 };
+
+type TodaySection = {
+  key: string;
+  heading: string;
+  items: SectionItem[];
+  bulkActions?: BulkAction[];
+};
+
+function isItemActionable(item: SectionItem): boolean {
+  if (item.medicationDoseInstanceId) return item.medicationStatus === "scheduled";
+  if (item.taskInstanceId)
+    return item.taskStatus !== "completed" && item.taskStatus !== "skipped";
+  if (item.choreInstanceId)
+    return item.choreStatus !== "completed" && item.choreStatus !== "skipped";
+  if (item.plannedItem) return !item.plannedItem.is_done;
+  return false;
+}
+
+function isItemCompleted(item: SectionItem): boolean {
+  if (item.medicationDoseInstanceId) return item.medicationStatus === "taken";
+  if (item.taskInstanceId) return item.taskStatus === "completed";
+  if (item.choreInstanceId) return item.choreStatus === "completed";
+  if (item.plannedItem) return item.plannedItem.is_done;
+  return false;
+}
+
+function getActionableCount(items: SectionItem[]): number {
+  return items.filter(isItemActionable).length;
+}
+
+function getCompletedCount(items: SectionItem[]): number {
+  return items.filter(isItemCompleted).length;
+}
 
 function formatSubtitle(...values: Array<string | null | undefined>) {
   return values.filter(Boolean).join(" • ");
@@ -199,11 +234,74 @@ function SummaryCard({
   tone: "primary" | "secondary" | "warning" | "success" | "info" | "danger";
 }) {
   return (
-    <div className="col-6 col-lg-3">
+    <div className="col-6 col-sm-4 col-lg">
       <div className="card h-100 border-0 summary-card shadow-sm">
         <div className="card-body py-3">
           <div className={`summary-pill text-bg-${tone}`}>{label}</div>
           <div className="summary-value mt-2">{value}</div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function WebFocusPanel({ sections }: { sections: TodaySection[] }) {
+  const actionableCount = sections.reduce(
+    (total, section) => total + getActionableCount(section.items),
+    0,
+  );
+  const completedCount = sections.reduce(
+    (total, section) => total + getCompletedCount(section.items),
+    0,
+  );
+  const totalTrackedCount = actionableCount + completedCount;
+  const completionPercent =
+    totalTrackedCount > 0 ? Math.round((completedCount / totalTrackedCount) * 100) : 0;
+  const nextSection = sections.find((section) => getActionableCount(section.items) > 0);
+  const nextItem = nextSection?.items.find(isItemActionable);
+
+  return (
+    <div className="card border-0 shadow-sm mb-3 web-focus-panel">
+      <div className="card-body">
+        <div className="d-flex flex-column flex-lg-row justify-content-between gap-3">
+          <div>
+            <div className="text-uppercase text-muted small fw-semibold">Today's focus</div>
+            <h3 className="h5 mb-1">{nextItem ? nextItem.title : "All clear for now"}</h3>
+            <p className="text-muted mb-0">
+              {nextItem
+                ? `${nextSection?.heading ?? "Today"} is the next section that needs attention.`
+                : "No open actions remain for today."}
+            </p>
+          </div>
+          <div className="focus-progress" aria-label={`${completionPercent}% complete`}>
+            <span className="focus-progress-value">{completionPercent}%</span>
+            <span className="text-muted small">complete</span>
+          </div>
+        </div>
+        <div
+          className="progress my-3"
+          role="progressbar"
+          aria-label="Today completion"
+          aria-valuenow={completionPercent}
+          aria-valuemin={0}
+          aria-valuemax={100}
+        >
+          <div className="progress-bar" style={{ width: `${completionPercent}%` }} />
+        </div>
+        <div className="d-flex gap-2 flex-wrap">
+          {sections.map((section) => {
+            const actionable = getActionableCount(section.items);
+            return (
+              <a
+                key={section.key}
+                className={`btn btn-sm ${actionable > 0 ? "btn-outline-primary" : "btn-outline-secondary"}`}
+                href={`#${section.key}`}
+              >
+                {section.heading}
+                <span className="badge text-bg-light ms-2">{actionable}</span>
+              </a>
+            );
+          })}
         </div>
       </div>
     </div>
@@ -419,11 +517,13 @@ function PlannedItemActions({
 }
 
 function SectionCard({
+  sectionId,
   heading,
   items,
   onRefresh,
   bulkActions,
 }: {
+  sectionId: string;
   heading: string;
   items: SectionItem[];
   onRefresh: () => Promise<void>;
@@ -499,7 +599,7 @@ function SectionCard({
   };
 
   return (
-    <div className="card mb-3">
+    <div className="card mb-3" id={sectionId}>
       <div className="card-header py-2">
         <div className="d-flex flex-column gap-2">
           <div className="d-flex justify-content-between align-items-center gap-2 flex-wrap">
@@ -605,6 +705,77 @@ function SectionCard({
   );
 }
 
+function QuickAddPlanned({ onRefresh }: { onRefresh: () => Promise<void> }) {
+  const [isOpen, setIsOpen] = useState(false);
+  const [title, setTitle] = useState("");
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [addError, setAddError] = useState<string | null>(null);
+
+  const todayDate = toIsoDate(dayjs());
+
+  const onSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!title.trim()) return;
+    setIsSubmitting(true);
+    setAddError(null);
+    try {
+      await createPlannedItem({ title: title.trim(), planned_for: todayDate });
+      setTitle("");
+      setIsOpen(false);
+      await onRefresh();
+    } catch (err) {
+      setAddError(err instanceof Error ? err.message : "Failed to add item.");
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  if (!isOpen) {
+    return (
+      <button
+        type="button"
+        className="btn btn-outline-secondary btn-sm"
+        onClick={() => setIsOpen(true)}
+      >
+        + Quick add
+      </button>
+    );
+  }
+
+  return (
+    <form className="d-flex gap-2 align-items-start flex-wrap" onSubmit={(e) => void onSubmit(e)}>
+      <input
+        className="form-control form-control-sm flex-grow-1"
+        style={{ minWidth: "12rem" }}
+        value={title}
+        autoFocus
+        placeholder="Plan title for today…"
+        disabled={isSubmitting}
+        onChange={(e) => {
+          setTitle(e.target.value);
+          setAddError(null);
+        }}
+      />
+      <button type="submit" className="btn btn-primary btn-sm" disabled={isSubmitting || !title.trim()}>
+        {isSubmitting ? "Adding…" : "Add"}
+      </button>
+      <button
+        type="button"
+        className="btn btn-outline-secondary btn-sm"
+        disabled={isSubmitting}
+        onClick={() => {
+          setIsOpen(false);
+          setTitle("");
+          setAddError(null);
+        }}
+      >
+        Cancel
+      </button>
+      {addError ? <small className="w-100 text-danger">{addError}</small> : null}
+    </form>
+  );
+}
+
 export function TodayPage() {
   const [today, setToday] = useState<TodayPayload | null>(null);
   const [isLoading, setIsLoading] = useState(true);
@@ -657,20 +828,14 @@ export function TodayPage() {
       key: "routine-done",
       label: "Bulk Done",
       buttonClassName: "btn-success",
-      isAvailable: (item) =>
-        Boolean(
-          item.taskInstanceId && item.taskStatus !== "completed" && item.taskStatus !== "skipped",
-        ),
+      isAvailable: (item) => Boolean(item.taskInstanceId && isItemActionable(item)),
       run: (item) => completeRoutineTask(item.taskInstanceId as number),
     },
     {
       key: "routine-skip",
       label: "Bulk Skip",
       buttonClassName: "btn-outline-secondary",
-      isAvailable: (item) =>
-        Boolean(
-          item.taskInstanceId && item.taskStatus !== "completed" && item.taskStatus !== "skipped",
-        ),
+      isAvailable: (item) => Boolean(item.taskInstanceId && isItemActionable(item)),
       run: (item) => skipRoutineTask(item.taskInstanceId as number),
     },
   ];
@@ -679,24 +844,14 @@ export function TodayPage() {
       key: "chore-done",
       label: "Bulk Done",
       buttonClassName: "btn-success",
-      isAvailable: (item) =>
-        Boolean(
-          item.choreInstanceId &&
-          item.choreStatus !== "completed" &&
-          item.choreStatus !== "skipped",
-        ),
+      isAvailable: (item) => Boolean(item.choreInstanceId && isItemActionable(item)),
       run: (item) => completeChore(item.choreInstanceId as number),
     },
     {
       key: "chore-skip",
       label: "Bulk Skip",
       buttonClassName: "btn-outline-secondary",
-      isAvailable: (item) =>
-        Boolean(
-          item.choreInstanceId &&
-          item.choreStatus !== "completed" &&
-          item.choreStatus !== "skipped",
-        ),
+      isAvailable: (item) => Boolean(item.choreInstanceId && isItemActionable(item)),
       run: (item) => skipChore(item.choreInstanceId as number),
     },
   ];
@@ -705,7 +860,7 @@ export function TodayPage() {
       key: "planned-done",
       label: "Bulk Done",
       buttonClassName: "btn-success",
-      isAvailable: (item) => Boolean(item.plannedItem && !item.plannedItem.is_done),
+      isAvailable: (item) => Boolean(item.plannedItem && isItemActionable(item)),
       run: (item) =>
         updatePlannedItem(item.plannedItem!.id, buildPlannedItemPayload(item.plannedItem!, true)),
     },
@@ -713,19 +868,65 @@ export function TodayPage() {
       key: "planned-undo",
       label: "Bulk Undo",
       buttonClassName: "btn-outline-success",
-      isAvailable: (item) => Boolean(item.plannedItem?.is_done),
+      isAvailable: (item) => Boolean(item.plannedItem && isItemCompleted(item)),
       run: (item) =>
         updatePlannedItem(item.plannedItem!.id, buildPlannedItemPayload(item.plannedItem!, false)),
     },
   ];
 
+  const sections: TodaySection[] = today
+    ? [
+        {
+          key: "medication-today",
+          heading: "Medication Today",
+          items: buildMedicationItems(today.medication),
+        },
+        {
+          key: "medication-history",
+          heading: "Medication History",
+          items: buildMedicationHistoryItems(today.medication_history),
+        },
+        {
+          key: "routines",
+          heading: "Routines",
+          items: buildRoutineItems(today.routines),
+          bulkActions: routineBulkActions,
+        },
+        {
+          key: "overdue",
+          heading: "Overdue",
+          items: buildOverdueItems(today.overdue),
+          bulkActions: choreBulkActions,
+        },
+        {
+          key: "due-today",
+          heading: "Due Today",
+          items: buildDueTodayItems(today.due_today),
+          bulkActions: choreBulkActions,
+        },
+        {
+          key: "upcoming",
+          heading: "Upcoming",
+          items: buildUpcomingItems(today.upcoming),
+          bulkActions: choreBulkActions,
+        },
+        {
+          key: "planned",
+          heading: "Planned",
+          items: buildPlannedItems(today.planned),
+          bulkActions: plannedBulkActions,
+        },
+      ]
+    : [];
+
   return (
     <section>
       <div className="d-flex flex-column flex-md-row justify-content-between align-items-start align-items-md-center gap-2 mb-2">
         <h2 className="h4 mb-0">Today</h2>
-        <div className="d-flex gap-2 w-100 w-md-auto">
+        <div className="d-flex gap-2 align-items-start flex-wrap w-100 w-md-auto">
+          <QuickAddPlanned onRefresh={loadToday} />
           <button
-            className="btn btn-outline-primary btn-sm flex-grow-1 flex-md-grow-0"
+            className="btn btn-outline-primary btn-sm flex-md-grow-0"
             type="button"
             disabled={isLoading}
             onClick={() => void loadToday()}
@@ -735,7 +936,7 @@ export function TodayPage() {
         </div>
       </div>
       <p className="text-muted mb-3">
-        Medication, routines, chores, and planned tasks with fast mobile-friendly actions.
+        Medication, routines, chores, and planned tasks — everything due or active today.
       </p>
 
       {isLoading ? <div className="alert alert-info py-2">Loading today...</div> : null}
@@ -766,46 +967,17 @@ export function TodayPage() {
             <SummaryCard label="Open Plans" value={openPlannedCount} tone="primary" />
             <SummaryCard label="Open Routines" value={routineOpenCount} tone="secondary" />
           </div>
-          <SectionCard
-            heading="Medication Today"
-            items={buildMedicationItems(today.medication)}
-            onRefresh={loadToday}
-          />
-          <SectionCard
-            heading="Medication History"
-            items={buildMedicationHistoryItems(today.medication_history)}
-            onRefresh={loadToday}
-          />
-          <SectionCard
-            heading="Routines"
-            items={buildRoutineItems(today.routines)}
-            onRefresh={loadToday}
-            bulkActions={routineBulkActions}
-          />
-          <SectionCard
-            heading="Overdue"
-            items={buildOverdueItems(today.overdue)}
-            onRefresh={loadToday}
-            bulkActions={choreBulkActions}
-          />
-          <SectionCard
-            heading="Due Today"
-            items={buildDueTodayItems(today.due_today)}
-            onRefresh={loadToday}
-            bulkActions={choreBulkActions}
-          />
-          <SectionCard
-            heading="Upcoming"
-            items={buildUpcomingItems(today.upcoming)}
-            onRefresh={loadToday}
-            bulkActions={choreBulkActions}
-          />
-          <SectionCard
-            heading="Planned"
-            items={buildPlannedItems(today.planned)}
-            onRefresh={loadToday}
-            bulkActions={plannedBulkActions}
-          />
+          <WebFocusPanel sections={sections} />
+          {sections.map((section) => (
+            <SectionCard
+              key={section.key}
+              sectionId={section.key}
+              heading={section.heading}
+              items={section.items}
+              onRefresh={loadToday}
+              bulkActions={section.bulkActions}
+            />
+          ))}
         </>
       ) : null}
     </section>

--- a/frontend/tests/features/settings/SettingsPage.test.tsx
+++ b/frontend/tests/features/settings/SettingsPage.test.tsx
@@ -1,0 +1,59 @@
+// @vitest-environment jsdom
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { SettingsPage } from "@/features/settings/SettingsPage";
+
+const apiMock = vi.hoisted(() => ({
+  createIntegrationClient: vi.fn(),
+  listIntegrationClients: vi.fn(),
+}));
+
+vi.mock("@/lib/api/today", () => ({
+  createIntegrationClient: apiMock.createIntegrationClient,
+  isRetryableApiError: () => false,
+  listIntegrationClients: apiMock.listIntegrationClients,
+}));
+
+describe("SettingsPage", () => {
+  beforeEach(() => {
+    apiMock.createIntegrationClient.mockReset();
+    apiMock.listIntegrationClients.mockReset();
+    apiMock.listIntegrationClients.mockResolvedValue([]);
+    apiMock.createIntegrationClient.mockResolvedValue({
+      id: 1,
+      name: "Home Assistant Automations",
+      scopes: ["ha:read", "ha:write"],
+      rate_limit_per_minute: 120,
+      is_active: true,
+      api_key: "daynest_test_key",
+    });
+  });
+
+  it("shows Home Assistant setup details and the action scope", async () => {
+    render(<SettingsPage />);
+
+    expect(await screen.findByText("Home Assistant connection details")).toBeInTheDocument();
+    expect(screen.getByText("home-assistant; version=ha.v1")).toBeInTheDocument();
+    expect(screen.getByText("X-Integration-Key")).toBeInTheDocument();
+    expect(screen.getByLabelText(/home assistant actions/i)).toBeInTheDocument();
+  });
+
+  it("applies the Home Assistant automation preset when creating a client", async () => {
+    const user = userEvent.setup();
+    render(<SettingsPage />);
+
+    await screen.findByText("Integration presets");
+    await user.click(screen.getByRole("button", { name: /home assistant automations/i }));
+    await user.click(screen.getByRole("button", { name: /^create client$/i }));
+
+    await waitFor(() => {
+      expect(apiMock.createIntegrationClient).toHaveBeenCalledWith({
+        name: "Home Assistant Automations",
+        scopes: ["ha:read", "ha:write"],
+        rate_limit_per_minute: 120,
+      });
+    });
+    expect(await screen.findByText("daynest_test_key")).toBeInTheDocument();
+  });
+});

--- a/frontend/tests/features/today/TodayPage.test.tsx
+++ b/frontend/tests/features/today/TodayPage.test.tsx
@@ -1,0 +1,115 @@
+// @vitest-environment jsdom
+import { render, screen, within } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { TodayPage } from "@/features/today/TodayPage";
+
+const todayApiMock = vi.hoisted(() => ({
+  fetchToday: vi.fn(),
+  mutation: vi.fn().mockResolvedValue({}),
+}));
+
+vi.mock("@/lib/api/today", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/api/today")>("@/lib/api/today");
+  return {
+    ...actual,
+    completeRoutineTask: todayApiMock.mutation,
+    completeChore: todayApiMock.mutation,
+    deletePlannedItem: todayApiMock.mutation,
+    fetchToday: todayApiMock.fetchToday,
+    rescheduleChore: todayApiMock.mutation,
+    skipRoutineTask: todayApiMock.mutation,
+    skipChore: todayApiMock.mutation,
+    skipMedicationDose: todayApiMock.mutation,
+    startRoutineTask: todayApiMock.mutation,
+    takeMedicationDose: todayApiMock.mutation,
+    updatePlannedItem: todayApiMock.mutation,
+  };
+});
+
+const todayPayload = {
+  medication: [
+    {
+      medication_dose_instance_id: 1,
+      medication_plan_id: 10,
+      name: "Morning vitamin",
+      instructions: "With breakfast",
+      scheduled_at: "2026-05-15T08:00:00Z",
+      status: "scheduled",
+    },
+    {
+      medication_dose_instance_id: 2,
+      medication_plan_id: 11,
+      name: "Evening magnesium",
+      instructions: "After dinner",
+      scheduled_at: "2026-05-15T20:00:00Z",
+      status: "taken",
+    },
+  ],
+  medication_history: [],
+  routines: [
+    {
+      task_instance_id: 3,
+      routine_template_id: 30,
+      title: "Pack lunch",
+      status: "completed",
+      scheduled_date: "2026-05-15",
+      due_at: null,
+    },
+  ],
+  overdue: [],
+  due_today: [
+    {
+      chore_instance_id: 4,
+      chore_template_id: 40,
+      title: "Water plants",
+      status: "pending",
+      scheduled_date: "2026-05-15",
+    },
+  ],
+  upcoming: [],
+  planned: [
+    {
+      id: 5,
+      title: "Order groceries",
+      planned_for: "2026-05-15",
+      notes: null,
+      module_key: "shopping_list",
+      recurrence_hint: null,
+      linked_source: null,
+      linked_ref: null,
+      is_done: false,
+    },
+  ],
+  day_items: [],
+} satisfies Awaited<ReturnType<typeof import("@/lib/api/today").fetchToday>>;
+
+describe("TodayPage", () => {
+  beforeEach(() => {
+    todayApiMock.fetchToday.mockReset();
+    todayApiMock.fetchToday.mockResolvedValue(todayPayload);
+  });
+
+  it("shows the web focus panel with the next actionable item and progress", async () => {
+    render(<TodayPage />);
+
+    expect(await screen.findByText("Today's focus")).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Morning vitamin" })).toBeInTheDocument();
+    expect(screen.getByLabelText("40% complete")).toBeInTheDocument();
+    expect(screen.getByRole("progressbar", { name: "Today completion" })).toHaveAttribute(
+      "aria-valuenow",
+      "40",
+    );
+  });
+
+  it("renders quick-jump counts for each today section", async () => {
+    render(<TodayPage />);
+
+    const medicationJump = await screen.findByRole("link", { name: /medication today/i });
+    expect(medicationJump).toHaveAttribute("href", "#medication-today");
+    expect(within(medicationJump).getByText("1")).toBeInTheDocument();
+
+    const dueTodayJump = screen.getByRole("link", { name: /due today/i });
+    expect(dueTodayJump).toHaveAttribute("href", "#due-today");
+    expect(within(dueTodayJump).getByText("1")).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
### Motivation
- Surface the same top-level product areas on Android as the web app so feature parity is clearer and navigation is consistent across platforms.
- Provide a shared native navigation scaffold and parity screens so non‑Today areas can be iterated on quickly against the shared backend contracts.

### Description
- Add new destination constants and a top‑level destinations list by extending `DaynestDestination` and adding `daynestTopLevelDestinations` for Today, Calendar, Medication, Templates, and Settings.
- Add a reusable bottom navigation scaffold `DaynestNavigationScaffold` and a parity layout `DaynestParityRoute` to host module capability cards for native routes.
- Add native parity routes `CalendarRoute`, `MedicationRoute`, `TemplatesRoute`, and `SettingsRoute`, and wire them into the app graph in `DaynestApp` with a `navigateTopLevel` helper that preserves state.
- Update `HomeRoute` to use the shared scaffold, add localized strings for the new destinations, and document the current Android parity state in `android/README.md`.

### Testing
- Ran `npm test` which completed successfully with all frontend tests passing (22 tests passed).
- Ran `npm run build` which produced a successful frontend build artifact via `vite`.
- Validated Android string resources parse with a Python XML parse (`xml.etree.ElementTree`) which returned OK.
- Attempted `./gradlew testDebugUnitTest ktlintCheck` but the job was blocked because the Android SDK location is not configured in the environment (no `ANDROID_HOME` / `local.properties`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a06f8f48b5c832e93f97f6222182b04)