### PR TITLE
feat(android): implement full feature parity across all screens

### DIFF
--- a/android/app/src/androidTest/java/com/daynest/android/app/DaynestNavigationTest.kt
+++ b/android/app/src/androidTest/java/com/daynest/android/app/DaynestNavigationTest.kt
@@ -19,9 +19,21 @@ import com.daynest.android.data.auth.AuthApi
 import com.daynest.android.data.auth.AuthRepository
 import com.daynest.android.data.auth.AuthSessionDto
 import com.daynest.android.data.auth.SignInRequestDto
+import com.daynest.android.core.database.today.TodaySummaryDao
+import com.daynest.android.core.database.today.TodaySummaryEntity
+import com.daynest.android.data.auth.RefreshRequestDto
+import com.daynest.android.data.today.ChoreMutationDto
+import com.daynest.android.data.today.DoseMutationDto
+import com.daynest.android.data.today.PlannedItemCreateDto
+import com.daynest.android.data.today.PlannedItemUpdateDto
+import com.daynest.android.data.today.PlannedTodayItemDto
+import com.daynest.android.data.today.TaskMutationDto
+import com.daynest.android.data.today.TodayActionsApi
 import com.daynest.android.data.today.TodayApi
 import com.daynest.android.data.today.TodayRepository
 import com.daynest.android.data.today.TodayResponseDto
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
 import com.daynest.android.feature.auth.AuthRoute
 import com.daynest.android.feature.auth.AuthUiEvent
 import com.daynest.android.feature.auth.AuthViewModel
@@ -237,6 +249,26 @@ private fun makeHomeViewModel(): HomeViewModel =
                     object : TodayApi {
                         override suspend fun getToday(): TodayResponseDto = TodayResponseDto()
                     },
+                todayActionsApi =
+                    object : TodayActionsApi {
+                        override suspend fun completeChore(id: Int): ChoreMutationDto = ChoreMutationDto(id, "completed")
+                        override suspend fun skipChore(id: Int): ChoreMutationDto = ChoreMutationDto(id, "skipped")
+                        override suspend fun completeTask(id: Int): TaskMutationDto = TaskMutationDto(id, "completed")
+                        override suspend fun skipTask(id: Int): TaskMutationDto = TaskMutationDto(id, "skipped")
+                        override suspend fun startTask(id: Int): TaskMutationDto = TaskMutationDto(id, "in_progress")
+                        override suspend fun takeDose(id: Int): DoseMutationDto = DoseMutationDto(id, "taken")
+                        override suspend fun skipDose(id: Int): DoseMutationDto = DoseMutationDto(id, "skipped")
+                        override suspend fun updatePlannedItem(id: Int, request: PlannedItemUpdateDto): PlannedTodayItemDto = PlannedTodayItemDto(id, request.title, request.isDone)
+                        override suspend fun deletePlannedItem(id: Int) = Unit
+                        override suspend fun createPlannedItem(request: PlannedItemCreateDto): PlannedTodayItemDto = PlannedTodayItemDto(0, request.title, false)
+                    },
+                todaySummaryDao =
+                    object : TodaySummaryDao {
+                        private val flow = MutableStateFlow<TodaySummaryEntity?>(null)
+                        override fun observe(): Flow<TodaySummaryEntity?> = flow
+                        override suspend fun upsert(entity: TodaySummaryEntity) { flow.value = entity }
+                        override suspend fun clear() { flow.value = null }
+                    },
             ),
     )
 
@@ -247,15 +279,22 @@ private class FakeNavAuthApi(
     override suspend fun signIn(request: SignInRequestDto): AuthSessionDto = signInResult.getOrThrow()
 
     override suspend fun restoreSession(): AuthSessionDto = restoreResult.getOrThrow()
+
+    override suspend fun refresh(request: RefreshRequestDto): AuthSessionDto =
+        throw UnsupportedOperationException("refresh not expected")
 }
 
 private class FakeNavTokenStorage(
     initialToken: String?,
 ) : SecureTokenStorage {
     private var storedToken: String? = initialToken
+    private var storedRefreshToken: String? = null
 
     override val cachedToken: String?
         get() = storedToken
+
+    override val cachedRefreshToken: String?
+        get() = storedRefreshToken
 
     override suspend fun getToken(): String? = storedToken
 
@@ -265,5 +304,15 @@ private class FakeNavTokenStorage(
 
     override suspend fun clearToken() {
         storedToken = null
+    }
+
+    override suspend fun getRefreshToken(): String? = storedRefreshToken
+
+    override suspend fun saveRefreshToken(token: String) {
+        storedRefreshToken = token
+    }
+
+    override suspend fun clearRefreshToken() {
+        storedRefreshToken = null
     }
 }

--- a/android/app/src/androidTest/java/com/daynest/android/app/DaynestNavigationTest.kt
+++ b/android/app/src/androidTest/java/com/daynest/android/app/DaynestNavigationTest.kt
@@ -251,16 +251,22 @@ private fun makeHomeViewModel(): HomeViewModel =
                     },
                 todayActionsApi =
                     object : TodayActionsApi {
-                        override suspend fun completeChore(id: Int): ChoreMutationDto = ChoreMutationDto(id, "completed")
+                        override suspend fun completeChore(id: Int): ChoreMutationDto =
+                            ChoreMutationDto(id, "completed")
                         override suspend fun skipChore(id: Int): ChoreMutationDto = ChoreMutationDto(id, "skipped")
                         override suspend fun completeTask(id: Int): TaskMutationDto = TaskMutationDto(id, "completed")
                         override suspend fun skipTask(id: Int): TaskMutationDto = TaskMutationDto(id, "skipped")
                         override suspend fun startTask(id: Int): TaskMutationDto = TaskMutationDto(id, "in_progress")
                         override suspend fun takeDose(id: Int): DoseMutationDto = DoseMutationDto(id, "taken")
                         override suspend fun skipDose(id: Int): DoseMutationDto = DoseMutationDto(id, "skipped")
-                        override suspend fun updatePlannedItem(id: Int, request: PlannedItemUpdateDto): PlannedTodayItemDto = PlannedTodayItemDto(id, request.title, request.isDone)
+                        override suspend fun updatePlannedItem(
+                            id: Int,
+                            request: PlannedItemUpdateDto,
+                        ): PlannedTodayItemDto = PlannedTodayItemDto(id, request.title, request.isDone)
                         override suspend fun deletePlannedItem(id: Int) = Unit
-                        override suspend fun createPlannedItem(request: PlannedItemCreateDto): PlannedTodayItemDto = PlannedTodayItemDto(0, request.title, false)
+                        override suspend fun createPlannedItem(
+                            request: PlannedItemCreateDto,
+                        ): PlannedTodayItemDto = PlannedTodayItemDto(0, request.title, false)
                     },
                 todaySummaryDao =
                     object : TodaySummaryDao {
@@ -273,8 +279,10 @@ private fun makeHomeViewModel(): HomeViewModel =
     )
 
 private class FakeNavAuthApi(
-    private val signInResult: Result<AuthSessionDto> = Result.failure(UnsupportedOperationException("signIn not expected")),
-    private val restoreResult: Result<AuthSessionDto> = Result.failure(UnsupportedOperationException("restoreSession not expected")),
+    private val signInResult: Result<AuthSessionDto> =
+        Result.failure(UnsupportedOperationException("signIn not expected")),
+    private val restoreResult: Result<AuthSessionDto> =
+        Result.failure(UnsupportedOperationException("restoreSession not expected")),
 ) : AuthApi {
     override suspend fun signIn(request: SignInRequestDto): AuthSessionDto = signInResult.getOrThrow()
 

--- a/android/app/src/androidTest/java/com/daynest/android/app/DaynestNavigationTest.kt
+++ b/android/app/src/androidTest/java/com/daynest/android/app/DaynestNavigationTest.kt
@@ -251,29 +251,43 @@ private fun makeHomeViewModel(): HomeViewModel =
                     },
                 todayActionsApi =
                     object : TodayActionsApi {
-                        override suspend fun completeChore(id: Int): ChoreMutationDto =
-                            ChoreMutationDto(id, "completed")
+                        override suspend fun completeChore(id: Int): ChoreMutationDto = ChoreMutationDto(id, "completed")
+
                         override suspend fun skipChore(id: Int): ChoreMutationDto = ChoreMutationDto(id, "skipped")
+
                         override suspend fun completeTask(id: Int): TaskMutationDto = TaskMutationDto(id, "completed")
+
                         override suspend fun skipTask(id: Int): TaskMutationDto = TaskMutationDto(id, "skipped")
+
                         override suspend fun startTask(id: Int): TaskMutationDto = TaskMutationDto(id, "in_progress")
+
                         override suspend fun takeDose(id: Int): DoseMutationDto = DoseMutationDto(id, "taken")
+
                         override suspend fun skipDose(id: Int): DoseMutationDto = DoseMutationDto(id, "skipped")
+
                         override suspend fun updatePlannedItem(
                             id: Int,
                             request: PlannedItemUpdateDto,
                         ): PlannedTodayItemDto = PlannedTodayItemDto(id, request.title, request.isDone)
+
                         override suspend fun deletePlannedItem(id: Int) = Unit
-                        override suspend fun createPlannedItem(
-                            request: PlannedItemCreateDto,
-                        ): PlannedTodayItemDto = PlannedTodayItemDto(0, request.title, false)
+
+                        override suspend fun createPlannedItem(request: PlannedItemCreateDto): PlannedTodayItemDto =
+                            PlannedTodayItemDto(0, request.title, false)
                     },
                 todaySummaryDao =
                     object : TodaySummaryDao {
                         private val flow = MutableStateFlow<TodaySummaryEntity?>(null)
+
                         override fun observe(): Flow<TodaySummaryEntity?> = flow
-                        override suspend fun upsert(entity: TodaySummaryEntity) { flow.value = entity }
-                        override suspend fun clear() { flow.value = null }
+
+                        override suspend fun upsert(entity: TodaySummaryEntity) {
+                            flow.value = entity
+                        }
+
+                        override suspend fun clear() {
+                            flow.value = null
+                        }
                     },
             ),
     )
@@ -288,8 +302,7 @@ private class FakeNavAuthApi(
 
     override suspend fun restoreSession(): AuthSessionDto = restoreResult.getOrThrow()
 
-    override suspend fun refresh(request: RefreshRequestDto): AuthSessionDto =
-        throw UnsupportedOperationException("refresh not expected")
+    override suspend fun refresh(request: RefreshRequestDto): AuthSessionDto = throw UnsupportedOperationException("refresh not expected")
 }
 
 private class FakeNavTokenStorage(

--- a/android/app/src/androidTest/java/com/daynest/android/app/DaynestNavigationTest.kt
+++ b/android/app/src/androidTest/java/com/daynest/android/app/DaynestNavigationTest.kt
@@ -14,14 +14,14 @@ import androidx.navigation.compose.rememberNavController
 import com.daynest.android.app.navigation.DaynestDestination
 import com.daynest.android.app.session.SessionGateRoute
 import com.daynest.android.app.session.SessionGateViewModel
+import com.daynest.android.core.database.today.TodaySummaryDao
+import com.daynest.android.core.database.today.TodaySummaryEntity
 import com.daynest.android.core.storage.SecureTokenStorage
 import com.daynest.android.data.auth.AuthApi
 import com.daynest.android.data.auth.AuthRepository
 import com.daynest.android.data.auth.AuthSessionDto
-import com.daynest.android.data.auth.SignInRequestDto
-import com.daynest.android.core.database.today.TodaySummaryDao
-import com.daynest.android.core.database.today.TodaySummaryEntity
 import com.daynest.android.data.auth.RefreshRequestDto
+import com.daynest.android.data.auth.SignInRequestDto
 import com.daynest.android.data.today.ChoreMutationDto
 import com.daynest.android.data.today.DoseMutationDto
 import com.daynest.android.data.today.PlannedItemCreateDto
@@ -32,8 +32,6 @@ import com.daynest.android.data.today.TodayActionsApi
 import com.daynest.android.data.today.TodayApi
 import com.daynest.android.data.today.TodayRepository
 import com.daynest.android.data.today.TodayResponseDto
-import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.MutableStateFlow
 import com.daynest.android.feature.auth.AuthRoute
 import com.daynest.android.feature.auth.AuthUiEvent
 import com.daynest.android.feature.auth.AuthViewModel
@@ -44,6 +42,8 @@ import com.daynest.android.feature.medication.MedicationRoute
 import com.daynest.android.feature.settings.SettingsRoute
 import com.daynest.android.feature.templates.TemplatesRoute
 import com.daynest.android.ui.theme.DaynestTheme
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
 import org.junit.Assert.assertEquals
 import org.junit.Rule
 import org.junit.Test

--- a/android/app/src/androidTest/java/com/daynest/android/feature/home/HomeScreenTest.kt
+++ b/android/app/src/androidTest/java/com/daynest/android/feature/home/HomeScreenTest.kt
@@ -22,6 +22,8 @@ class HomeScreenTest {
             }
         }
 
-        composeTestRule.onNode(hasProgressBarRangeInfo(androidx.compose.ui.semantics.ProgressBarRangeInfo.Indeterminate)).assertExists()
+        composeTestRule
+            .onNode(hasProgressBarRangeInfo(androidx.compose.ui.semantics.ProgressBarRangeInfo.Indeterminate))
+            .assertExists()
     }
 }

--- a/android/app/src/main/java/com/daynest/android/app/DaynestApp.kt
+++ b/android/app/src/main/java/com/daynest/android/app/DaynestApp.kt
@@ -66,7 +66,15 @@ fun DaynestApp() {
                 TemplatesRoute(onNavigate = navController::navigateTopLevel)
             }
             composable(route = DaynestDestination.SETTINGS) {
-                SettingsRoute(onNavigate = navController::navigateTopLevel)
+                SettingsRoute(
+                    onNavigate = navController::navigateTopLevel,
+                    onSignedOut = {
+                        navController.navigate(DaynestDestination.AUTH) {
+                            popUpTo(navController.graph.findStartDestination().id) { inclusive = true }
+                            launchSingleTop = true
+                        }
+                    },
+                )
             }
         }
     }

--- a/android/app/src/main/java/com/daynest/android/core/di/NetworkDiModule.kt
+++ b/android/app/src/main/java/com/daynest/android/core/di/NetworkDiModule.kt
@@ -7,6 +7,11 @@ import com.daynest.android.core.network.CertificatePinnerProvider
 import com.daynest.android.core.network.JsonSerializer
 import com.daynest.android.core.network.TokenAuthenticator
 import com.daynest.android.data.auth.AuthApi
+import com.daynest.android.data.calendar.CalendarApi
+import com.daynest.android.data.medication.MedicationApi
+import com.daynest.android.data.settings.SettingsApi
+import com.daynest.android.data.templates.TemplatesApi
+import com.daynest.android.data.today.TodayActionsApi
 import com.daynest.android.data.today.TodayApi
 import dagger.Module
 import dagger.Provides
@@ -73,5 +78,25 @@ object NetworkDiModule {
 
     @Provides
     @Singleton
+    fun provideTodayActionsApi(retrofit: Retrofit): TodayActionsApi = retrofit.create(TodayActionsApi::class.java)
+
+    @Provides
+    @Singleton
     fun provideAuthApi(retrofit: Retrofit): AuthApi = retrofit.create(AuthApi::class.java)
+
+    @Provides
+    @Singleton
+    fun provideCalendarApi(retrofit: Retrofit): CalendarApi = retrofit.create(CalendarApi::class.java)
+
+    @Provides
+    @Singleton
+    fun provideMedicationApi(retrofit: Retrofit): MedicationApi = retrofit.create(MedicationApi::class.java)
+
+    @Provides
+    @Singleton
+    fun provideTemplatesApi(retrofit: Retrofit): TemplatesApi = retrofit.create(TemplatesApi::class.java)
+
+    @Provides
+    @Singleton
+    fun provideSettingsApi(retrofit: Retrofit): SettingsApi = retrofit.create(SettingsApi::class.java)
 }

--- a/android/app/src/main/java/com/daynest/android/data/calendar/CalendarApi.kt
+++ b/android/app/src/main/java/com/daynest/android/data/calendar/CalendarApi.kt
@@ -1,0 +1,59 @@
+package com.daynest.android.data.calendar
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import retrofit2.http.GET
+import retrofit2.http.Query
+
+interface CalendarApi {
+    @GET("api/v1/calendar/month")
+    suspend fun getMonth(
+        @Query("year") year: Int,
+        @Query("month") month: Int,
+    ): CalendarMonthDto
+
+    @GET("api/v1/calendar/day")
+    suspend fun getDay(
+        @Query("date") date: String,
+    ): CalendarDayDto
+}
+
+@Serializable
+data class CalendarMonthDto(
+    val year: Int,
+    val month: Int,
+    val days: List<CalendarDaySummaryDto>,
+)
+
+@Serializable
+data class CalendarDaySummaryDto(
+    val date: String,
+    val total: Int,
+    val routines: Int,
+    val chores: Int,
+    val medications: Int,
+    val planned: Int,
+)
+
+@Serializable
+data class CalendarDayDto(
+    val date: String,
+    val items: List<UnifiedDayItemDto>,
+)
+
+@Serializable
+data class UnifiedDayItemDto(
+    @SerialName("item_type")
+    val itemType: String,
+    @SerialName("item_id")
+    val itemId: Int,
+    val title: String,
+    val status: String,
+    @SerialName("scheduled_at")
+    val scheduledAt: String? = null,
+    @SerialName("scheduled_date")
+    val scheduledDate: String? = null,
+    val detail: String? = null,
+    @SerialName("module_key")
+    val moduleKey: String? = null,
+)

--- a/android/app/src/main/java/com/daynest/android/data/calendar/CalendarRepository.kt
+++ b/android/app/src/main/java/com/daynest/android/data/calendar/CalendarRepository.kt
@@ -1,0 +1,35 @@
+package com.daynest.android.data.calendar
+
+import kotlinx.coroutines.CancellationException
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class CalendarRepository
+    @Inject
+    constructor(
+        private val calendarApi: CalendarApi,
+    ) {
+        @Suppress("TooGenericExceptionCaught")
+        suspend fun getMonth(
+            year: Int,
+            month: Int,
+        ): Result<CalendarMonthDto> =
+            try {
+                Result.success(calendarApi.getMonth(year, month))
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                Result.failure(e)
+            }
+
+        @Suppress("TooGenericExceptionCaught")
+        suspend fun getDay(date: String): Result<CalendarDayDto> =
+            try {
+                Result.success(calendarApi.getDay(date))
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                Result.failure(e)
+            }
+    }

--- a/android/app/src/main/java/com/daynest/android/data/medication/MedicationApi.kt
+++ b/android/app/src/main/java/com/daynest/android/data/medication/MedicationApi.kt
@@ -1,0 +1,63 @@
+package com.daynest.android.data.medication
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import retrofit2.http.Body
+import retrofit2.http.GET
+import retrofit2.http.POST
+
+interface MedicationApi {
+    @GET("api/v1/medications")
+    suspend fun listPlans(): List<MedicationPlanDto>
+
+    @POST("api/v1/medications")
+    suspend fun createPlan(
+        @Body request: MedicationPlanInputDto,
+    ): MedicationPlanDto
+
+    @GET("api/v1/medication-doses/history")
+    suspend fun getHistory(): MedicationHistoryResponseDto
+}
+
+@Serializable
+data class MedicationPlanDto(
+    val id: Int,
+    val name: String,
+    val instructions: String,
+    @SerialName("start_date")
+    val startDate: String,
+    @SerialName("schedule_time")
+    val scheduleTime: String,
+    @SerialName("every_n_days")
+    val everyNDays: Int,
+    @SerialName("is_active")
+    val isActive: Boolean,
+)
+
+@Serializable
+data class MedicationPlanInputDto(
+    val name: String,
+    val instructions: String,
+    @SerialName("start_date")
+    val startDate: String,
+    @SerialName("schedule_time")
+    val scheduleTime: String,
+    @SerialName("every_n_days")
+    val everyNDays: Int,
+)
+
+@Serializable
+data class MedicationHistoryResponseDto(
+    val history: List<MedicationHistoryItemDto>,
+)
+
+@Serializable
+data class MedicationHistoryItemDto(
+    @SerialName("medication_dose_instance_id")
+    val medicationDoseInstanceId: Int,
+    val name: String,
+    val instructions: String = "",
+    @SerialName("scheduled_at")
+    val scheduledAt: String = "",
+    val status: String,
+)

--- a/android/app/src/main/java/com/daynest/android/data/medication/MedicationRepository.kt
+++ b/android/app/src/main/java/com/daynest/android/data/medication/MedicationRepository.kt
@@ -1,0 +1,42 @@
+package com.daynest.android.data.medication
+
+import kotlinx.coroutines.CancellationException
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class MedicationRepository
+    @Inject
+    constructor(
+        private val medicationApi: MedicationApi,
+    ) {
+        @Suppress("TooGenericExceptionCaught")
+        suspend fun listPlans(): Result<List<MedicationPlanDto>> =
+            try {
+                Result.success(medicationApi.listPlans())
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                Result.failure(e)
+            }
+
+        @Suppress("TooGenericExceptionCaught")
+        suspend fun createPlan(request: MedicationPlanInputDto): Result<MedicationPlanDto> =
+            try {
+                Result.success(medicationApi.createPlan(request))
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                Result.failure(e)
+            }
+
+        @Suppress("TooGenericExceptionCaught")
+        suspend fun getHistory(): Result<List<MedicationHistoryItemDto>> =
+            try {
+                Result.success(medicationApi.getHistory().history)
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                Result.failure(e)
+            }
+    }

--- a/android/app/src/main/java/com/daynest/android/data/settings/SettingsApi.kt
+++ b/android/app/src/main/java/com/daynest/android/data/settings/SettingsApi.kt
@@ -1,0 +1,49 @@
+package com.daynest.android.data.settings
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import retrofit2.http.Body
+import retrofit2.http.GET
+import retrofit2.http.POST
+
+interface SettingsApi {
+    @GET("api/v1/integrations/clients")
+    suspend fun listClients(): List<IntegrationClientDto>
+
+    @POST("api/v1/integrations/clients")
+    suspend fun createClient(
+        @Body request: IntegrationClientInputDto,
+    ): IntegrationClientCreateResponseDto
+}
+
+@Serializable
+data class IntegrationClientDto(
+    val id: Int,
+    val name: String,
+    val scopes: List<String>,
+    @SerialName("rate_limit_per_minute")
+    val rateLimitPerMinute: Int,
+    @SerialName("is_active")
+    val isActive: Boolean,
+)
+
+@Serializable
+data class IntegrationClientInputDto(
+    val name: String,
+    val scopes: List<String>,
+    @SerialName("rate_limit_per_minute")
+    val rateLimitPerMinute: Int,
+)
+
+@Serializable
+data class IntegrationClientCreateResponseDto(
+    val id: Int,
+    val name: String,
+    val scopes: List<String>,
+    @SerialName("rate_limit_per_minute")
+    val rateLimitPerMinute: Int,
+    @SerialName("is_active")
+    val isActive: Boolean,
+    @SerialName("api_key")
+    val apiKey: String,
+)

--- a/android/app/src/main/java/com/daynest/android/data/settings/SettingsRepository.kt
+++ b/android/app/src/main/java/com/daynest/android/data/settings/SettingsRepository.kt
@@ -1,0 +1,32 @@
+package com.daynest.android.data.settings
+
+import kotlinx.coroutines.CancellationException
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class SettingsRepository
+    @Inject
+    constructor(
+        private val settingsApi: SettingsApi,
+    ) {
+        @Suppress("TooGenericExceptionCaught")
+        suspend fun listClients(): Result<List<IntegrationClientDto>> =
+            try {
+                Result.success(settingsApi.listClients())
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                Result.failure(e)
+            }
+
+        @Suppress("TooGenericExceptionCaught")
+        suspend fun createClient(request: IntegrationClientInputDto): Result<IntegrationClientCreateResponseDto> =
+            try {
+                Result.success(settingsApi.createClient(request))
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                Result.failure(e)
+            }
+    }

--- a/android/app/src/main/java/com/daynest/android/data/templates/TemplatesApi.kt
+++ b/android/app/src/main/java/com/daynest/android/data/templates/TemplatesApi.kt
@@ -1,0 +1,108 @@
+package com.daynest.android.data.templates
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import retrofit2.http.Body
+import retrofit2.http.DELETE
+import retrofit2.http.GET
+import retrofit2.http.POST
+import retrofit2.http.PUT
+import retrofit2.http.Path
+
+interface TemplatesApi {
+    @GET("api/v1/routines")
+    suspend fun listRoutines(): List<RoutineTemplateDto>
+
+    @POST("api/v1/routines")
+    suspend fun createRoutine(
+        @Body request: RoutineTemplateInputDto,
+    ): RoutineTemplateDto
+
+    @PUT("api/v1/routines/{id}")
+    suspend fun updateRoutine(
+        @Path("id") id: Int,
+        @Body request: RoutineTemplateInputDto,
+    ): RoutineTemplateDto
+
+    @DELETE("api/v1/routines/{id}")
+    suspend fun deleteRoutine(
+        @Path("id") id: Int,
+    )
+
+    @GET("api/v1/chore-templates")
+    suspend fun listChores(): List<ChoreTemplateDto>
+
+    @POST("api/v1/chore-templates")
+    suspend fun createChore(
+        @Body request: ChoreTemplateInputDto,
+    ): ChoreTemplateDto
+
+    @PUT("api/v1/chore-templates/{id}")
+    suspend fun updateChore(
+        @Path("id") id: Int,
+        @Body request: ChoreTemplateInputDto,
+    ): ChoreTemplateDto
+
+    @DELETE("api/v1/chore-templates/{id}")
+    suspend fun deleteChore(
+        @Path("id") id: Int,
+    )
+}
+
+@Serializable
+data class RoutineTemplateDto(
+    val id: Int,
+    val name: String,
+    val description: String? = null,
+    @SerialName("start_date")
+    val startDate: String,
+    @SerialName("every_n_days")
+    val everyNDays: Int,
+    @SerialName("due_time")
+    val dueTime: String? = null,
+    @SerialName("is_active")
+    val isActive: Boolean,
+    @SerialName("created_at")
+    val createdAt: String,
+)
+
+@Serializable
+data class RoutineTemplateInputDto(
+    val name: String,
+    val description: String? = null,
+    @SerialName("start_date")
+    val startDate: String,
+    @SerialName("every_n_days")
+    val everyNDays: Int,
+    @SerialName("due_time")
+    val dueTime: String? = null,
+    @SerialName("is_active")
+    val isActive: Boolean,
+)
+
+@Serializable
+data class ChoreTemplateDto(
+    val id: Int,
+    val name: String,
+    val description: String? = null,
+    @SerialName("start_date")
+    val startDate: String,
+    @SerialName("every_n_days")
+    val everyNDays: Int,
+    @SerialName("is_active")
+    val isActive: Boolean,
+    @SerialName("created_at")
+    val createdAt: String,
+)
+
+@Serializable
+data class ChoreTemplateInputDto(
+    val name: String,
+    val description: String? = null,
+    @SerialName("start_date")
+    val startDate: String,
+    @SerialName("every_n_days")
+    val everyNDays: Int,
+    @SerialName("is_active")
+    val isActive: Boolean,
+)

--- a/android/app/src/main/java/com/daynest/android/data/templates/TemplatesRepository.kt
+++ b/android/app/src/main/java/com/daynest/android/data/templates/TemplatesRepository.kt
@@ -1,0 +1,74 @@
+package com.daynest.android.data.templates
+
+import kotlinx.coroutines.CancellationException
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class TemplatesRepository
+    @Inject
+    constructor(
+        private val templatesApi: TemplatesApi,
+    ) {
+        @Suppress("TooGenericExceptionCaught")
+        suspend fun listRoutines(): Result<List<RoutineTemplateDto>> =
+            try {
+                Result.success(templatesApi.listRoutines())
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                Result.failure(e)
+            }
+
+        @Suppress("TooGenericExceptionCaught")
+        suspend fun createRoutine(request: RoutineTemplateInputDto): Result<RoutineTemplateDto> =
+            try {
+                Result.success(templatesApi.createRoutine(request))
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                Result.failure(e)
+            }
+
+        @Suppress("TooGenericExceptionCaught")
+        suspend fun deleteRoutine(id: Int): Result<Unit> =
+            try {
+                templatesApi.deleteRoutine(id)
+                Result.success(Unit)
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                Result.failure(e)
+            }
+
+        @Suppress("TooGenericExceptionCaught")
+        suspend fun listChores(): Result<List<ChoreTemplateDto>> =
+            try {
+                Result.success(templatesApi.listChores())
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                Result.failure(e)
+            }
+
+        @Suppress("TooGenericExceptionCaught")
+        suspend fun createChore(request: ChoreTemplateInputDto): Result<ChoreTemplateDto> =
+            try {
+                Result.success(templatesApi.createChore(request))
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                Result.failure(e)
+            }
+
+        @Suppress("TooGenericExceptionCaught")
+        suspend fun deleteChore(id: Int): Result<Unit> =
+            try {
+                templatesApi.deleteChore(id)
+                Result.success(Unit)
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                Result.failure(e)
+            }
+    }

--- a/android/app/src/main/java/com/daynest/android/data/today/TodayActionsApi.kt
+++ b/android/app/src/main/java/com/daynest/android/data/today/TodayActionsApi.kt
@@ -1,0 +1,91 @@
+package com.daynest.android.data.today
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import retrofit2.http.Body
+import retrofit2.http.DELETE
+import retrofit2.http.POST
+import retrofit2.http.PUT
+import retrofit2.http.Path
+
+interface TodayActionsApi {
+    @POST("api/v1/chores/{id}/complete")
+    suspend fun completeChore(@Path("id") id: Int): ChoreMutationDto
+
+    @POST("api/v1/chores/{id}/skip")
+    suspend fun skipChore(@Path("id") id: Int): ChoreMutationDto
+
+    @POST("api/v1/tasks/{id}/complete")
+    suspend fun completeTask(@Path("id") id: Int): TaskMutationDto
+
+    @POST("api/v1/tasks/{id}/skip")
+    suspend fun skipTask(@Path("id") id: Int): TaskMutationDto
+
+    @POST("api/v1/tasks/{id}/start")
+    suspend fun startTask(@Path("id") id: Int): TaskMutationDto
+
+    @POST("api/v1/medication-doses/{id}/take")
+    suspend fun takeDose(@Path("id") id: Int): DoseMutationDto
+
+    @POST("api/v1/medication-doses/{id}/skip")
+    suspend fun skipDose(@Path("id") id: Int): DoseMutationDto
+
+    @PUT("api/v1/planned-items/{id}")
+    suspend fun updatePlannedItem(
+        @Path("id") id: Int,
+        @Body request: PlannedItemUpdateDto,
+    ): PlannedTodayItemDto
+
+    @DELETE("api/v1/planned-items/{id}")
+    suspend fun deletePlannedItem(@Path("id") id: Int)
+
+    @POST("api/v1/planned-items")
+    suspend fun createPlannedItem(@Body request: PlannedItemCreateDto): PlannedTodayItemDto
+}
+
+@Serializable
+data class ChoreMutationDto(
+    @SerialName("chore_instance_id")
+    val choreInstanceId: Int,
+    val status: String,
+)
+
+@Serializable
+data class TaskMutationDto(
+    @SerialName("task_instance_id")
+    val taskInstanceId: Int,
+    val status: String,
+)
+
+@Serializable
+data class DoseMutationDto(
+    @SerialName("medication_dose_instance_id")
+    val medicationDoseInstanceId: Int,
+    val status: String,
+)
+
+@Serializable
+data class PlannedItemUpdateDto(
+    val title: String,
+    @SerialName("planned_for")
+    val plannedFor: String,
+    @SerialName("is_done")
+    val isDone: Boolean,
+    val notes: String? = null,
+    @SerialName("module_key")
+    val moduleKey: String? = null,
+    @SerialName("recurrence_hint")
+    val recurrenceHint: String? = null,
+)
+
+@Serializable
+data class PlannedItemCreateDto(
+    val title: String,
+    @SerialName("planned_for")
+    val plannedFor: String,
+    val notes: String? = null,
+    @SerialName("module_key")
+    val moduleKey: String? = null,
+    @SerialName("recurrence_hint")
+    val recurrenceHint: String? = null,
+)

--- a/android/app/src/main/java/com/daynest/android/data/today/TodayActionsApi.kt
+++ b/android/app/src/main/java/com/daynest/android/data/today/TodayActionsApi.kt
@@ -10,25 +10,39 @@ import retrofit2.http.Path
 
 interface TodayActionsApi {
     @POST("api/v1/chores/{id}/complete")
-    suspend fun completeChore(@Path("id") id: Int): ChoreMutationDto
+    suspend fun completeChore(
+        @Path("id") id: Int,
+    ): ChoreMutationDto
 
     @POST("api/v1/chores/{id}/skip")
-    suspend fun skipChore(@Path("id") id: Int): ChoreMutationDto
+    suspend fun skipChore(
+        @Path("id") id: Int,
+    ): ChoreMutationDto
 
     @POST("api/v1/tasks/{id}/complete")
-    suspend fun completeTask(@Path("id") id: Int): TaskMutationDto
+    suspend fun completeTask(
+        @Path("id") id: Int,
+    ): TaskMutationDto
 
     @POST("api/v1/tasks/{id}/skip")
-    suspend fun skipTask(@Path("id") id: Int): TaskMutationDto
+    suspend fun skipTask(
+        @Path("id") id: Int,
+    ): TaskMutationDto
 
     @POST("api/v1/tasks/{id}/start")
-    suspend fun startTask(@Path("id") id: Int): TaskMutationDto
+    suspend fun startTask(
+        @Path("id") id: Int,
+    ): TaskMutationDto
 
     @POST("api/v1/medication-doses/{id}/take")
-    suspend fun takeDose(@Path("id") id: Int): DoseMutationDto
+    suspend fun takeDose(
+        @Path("id") id: Int,
+    ): DoseMutationDto
 
     @POST("api/v1/medication-doses/{id}/skip")
-    suspend fun skipDose(@Path("id") id: Int): DoseMutationDto
+    suspend fun skipDose(
+        @Path("id") id: Int,
+    ): DoseMutationDto
 
     @PUT("api/v1/planned-items/{id}")
     suspend fun updatePlannedItem(
@@ -37,10 +51,14 @@ interface TodayActionsApi {
     ): PlannedTodayItemDto
 
     @DELETE("api/v1/planned-items/{id}")
-    suspend fun deletePlannedItem(@Path("id") id: Int)
+    suspend fun deletePlannedItem(
+        @Path("id") id: Int,
+    )
 
     @POST("api/v1/planned-items")
-    suspend fun createPlannedItem(@Body request: PlannedItemCreateDto): PlannedTodayItemDto
+    suspend fun createPlannedItem(
+        @Body request: PlannedItemCreateDto,
+    ): PlannedTodayItemDto
 }
 
 @Serializable

--- a/android/app/src/main/java/com/daynest/android/data/today/TodayApi.kt
+++ b/android/app/src/main/java/com/daynest/android/data/today/TodayApi.kt
@@ -28,6 +28,10 @@ data class MedicationTodayItemDto(
     @SerialName("medication_dose_instance_id")
     val medicationDoseInstanceId: Int,
     val name: String,
+    val instructions: String = "",
+    @SerialName("scheduled_at")
+    val scheduledAt: String = "",
+    val status: String = "scheduled",
 )
 
 @Serializable
@@ -35,6 +39,10 @@ data class MedicationHistoryItemDto(
     @SerialName("medication_dose_instance_id")
     val medicationDoseInstanceId: Int,
     val name: String,
+    val instructions: String = "",
+    @SerialName("scheduled_at")
+    val scheduledAt: String = "",
+    val status: String = "taken",
 )
 
 @Serializable
@@ -42,6 +50,9 @@ data class RoutineTodayItemDto(
     @SerialName("task_instance_id")
     val taskInstanceId: Int,
     val title: String,
+    val status: String = "pending",
+    @SerialName("scheduled_date")
+    val scheduledDate: String = "",
 )
 
 @Serializable
@@ -49,6 +60,9 @@ data class OverdueTodayItemDto(
     @SerialName("chore_instance_id")
     val choreInstanceId: Int,
     val title: String,
+    val status: String = "pending",
+    @SerialName("overdue_since")
+    val overdueSince: String = "",
 )
 
 @Serializable
@@ -56,6 +70,9 @@ data class DueTodayItemDto(
     @SerialName("chore_instance_id")
     val choreInstanceId: Int,
     val title: String,
+    val status: String = "pending",
+    @SerialName("scheduled_date")
+    val scheduledDate: String = "",
 )
 
 @Serializable
@@ -63,6 +80,8 @@ data class UpcomingTodayItemDto(
     @SerialName("chore_instance_id")
     val choreInstanceId: Int,
     val title: String,
+    @SerialName("scheduled_date")
+    val scheduledDate: String = "",
 )
 
 @Serializable
@@ -71,4 +90,11 @@ data class PlannedTodayItemDto(
     val title: String,
     @SerialName("is_done")
     val isDone: Boolean,
+    @SerialName("planned_for")
+    val plannedFor: String = "",
+    val notes: String? = null,
+    @SerialName("module_key")
+    val moduleKey: String? = null,
+    @SerialName("recurrence_hint")
+    val recurrenceHint: String? = null,
 )

--- a/android/app/src/main/java/com/daynest/android/data/today/TodayRepository.kt
+++ b/android/app/src/main/java/com/daynest/android/data/today/TodayRepository.kt
@@ -12,6 +12,7 @@ import javax.inject.Inject
 import javax.inject.Singleton
 
 @Singleton
+@Suppress("TooManyFunctions")
 class TodayRepository
     @Inject
     constructor(
@@ -19,17 +20,17 @@ class TodayRepository
         private val todayActionsApi: TodayActionsApi,
         private val todaySummaryDao: TodaySummaryDao,
     ) {
-        private val _todayResponse = MutableStateFlow<TodayResponseDto?>(null)
+        private val todayResponseFlow = MutableStateFlow<TodayResponseDto?>(null)
 
         fun observeTodaySummary(): Flow<TodaySummary?> = todaySummaryDao.observe().map { entity -> entity?.toDomain() }
 
-        fun observeTodayResponse(): Flow<TodayResponseDto?> = _todayResponse.asStateFlow()
+        fun observeTodayResponse(): Flow<TodayResponseDto?> = todayResponseFlow.asStateFlow()
 
         @Suppress("TooGenericExceptionCaught")
         suspend fun refresh(): Result<Unit> =
             try {
                 val today = todayApi.getToday()
-                _todayResponse.value = today
+                todayResponseFlow.value = today
                 val entity =
                     TodaySummaryEntity(
                         id = 0,
@@ -51,7 +52,7 @@ class TodayRepository
         suspend fun completeChore(choreInstanceId: Int): Result<ChoreMutationDto> =
             runCatching { todayActionsApi.completeChore(choreInstanceId) }
 
-        @Suppress("TooGenericExceptionCaught")
+        @Suppress("TooGenericExceptionCaught", "ktlint:standard:function-signature")
         suspend fun skipChore(choreInstanceId: Int): Result<ChoreMutationDto> =
             runCatching { todayActionsApi.skipChore(choreInstanceId) }
 
@@ -59,15 +60,15 @@ class TodayRepository
         suspend fun completeTask(taskInstanceId: Int): Result<TaskMutationDto> =
             runCatching { todayActionsApi.completeTask(taskInstanceId) }
 
-        @Suppress("TooGenericExceptionCaught")
+        @Suppress("TooGenericExceptionCaught", "ktlint:standard:function-signature")
         suspend fun skipTask(taskInstanceId: Int): Result<TaskMutationDto> =
             runCatching { todayActionsApi.skipTask(taskInstanceId) }
 
-        @Suppress("TooGenericExceptionCaught")
+        @Suppress("TooGenericExceptionCaught", "ktlint:standard:function-signature")
         suspend fun takeDose(doseInstanceId: Int): Result<DoseMutationDto> =
             runCatching { todayActionsApi.takeDose(doseInstanceId) }
 
-        @Suppress("TooGenericExceptionCaught")
+        @Suppress("TooGenericExceptionCaught", "ktlint:standard:function-signature")
         suspend fun skipDose(doseInstanceId: Int): Result<DoseMutationDto> =
             runCatching { todayActionsApi.skipDose(doseInstanceId) }
 
@@ -92,8 +93,7 @@ class TodayRepository
             }
 
         @Suppress("TooGenericExceptionCaught")
-        suspend fun deletePlannedItem(id: Int): Result<Unit> =
-            runCatching { todayActionsApi.deletePlannedItem(id) }
+        suspend fun deletePlannedItem(id: Int): Result<Unit> = runCatching { todayActionsApi.deletePlannedItem(id) }
 
         @Suppress("TooGenericExceptionCaught")
         suspend fun createPlannedItem(request: PlannedItemCreateDto): Result<PlannedTodayItemDto> =

--- a/android/app/src/main/java/com/daynest/android/data/today/TodayRepository.kt
+++ b/android/app/src/main/java/com/daynest/android/data/today/TodayRepository.kt
@@ -5,6 +5,8 @@ import com.daynest.android.core.database.today.TodaySummaryEntity
 import com.daynest.android.core.model.TodaySummary
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.map
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -14,14 +16,20 @@ class TodayRepository
     @Inject
     constructor(
         private val todayApi: TodayApi,
+        private val todayActionsApi: TodayActionsApi,
         private val todaySummaryDao: TodaySummaryDao,
     ) {
+        private val _todayResponse = MutableStateFlow<TodayResponseDto?>(null)
+
         fun observeTodaySummary(): Flow<TodaySummary?> = todaySummaryDao.observe().map { entity -> entity?.toDomain() }
+
+        fun observeTodayResponse(): Flow<TodayResponseDto?> = _todayResponse.asStateFlow()
 
         @Suppress("TooGenericExceptionCaught")
         suspend fun refresh(): Result<Unit> =
             try {
                 val today = todayApi.getToday()
+                _todayResponse.value = today
                 val entity =
                     TodaySummaryEntity(
                         id = 0,
@@ -38,6 +46,58 @@ class TodayRepository
             } catch (e: Exception) {
                 Result.failure(e)
             }
+
+        @Suppress("TooGenericExceptionCaught")
+        suspend fun completeChore(choreInstanceId: Int): Result<ChoreMutationDto> =
+            runCatching { todayActionsApi.completeChore(choreInstanceId) }
+
+        @Suppress("TooGenericExceptionCaught")
+        suspend fun skipChore(choreInstanceId: Int): Result<ChoreMutationDto> =
+            runCatching { todayActionsApi.skipChore(choreInstanceId) }
+
+        @Suppress("TooGenericExceptionCaught")
+        suspend fun completeTask(taskInstanceId: Int): Result<TaskMutationDto> =
+            runCatching { todayActionsApi.completeTask(taskInstanceId) }
+
+        @Suppress("TooGenericExceptionCaught")
+        suspend fun skipTask(taskInstanceId: Int): Result<TaskMutationDto> =
+            runCatching { todayActionsApi.skipTask(taskInstanceId) }
+
+        @Suppress("TooGenericExceptionCaught")
+        suspend fun takeDose(doseInstanceId: Int): Result<DoseMutationDto> =
+            runCatching { todayActionsApi.takeDose(doseInstanceId) }
+
+        @Suppress("TooGenericExceptionCaught")
+        suspend fun skipDose(doseInstanceId: Int): Result<DoseMutationDto> =
+            runCatching { todayActionsApi.skipDose(doseInstanceId) }
+
+        @Suppress("TooGenericExceptionCaught")
+        suspend fun markPlannedDone(
+            id: Int,
+            item: PlannedTodayItemDto,
+            isDone: Boolean,
+        ): Result<PlannedTodayItemDto> =
+            runCatching {
+                todayActionsApi.updatePlannedItem(
+                    id,
+                    PlannedItemUpdateDto(
+                        title = item.title,
+                        plannedFor = item.plannedFor,
+                        isDone = isDone,
+                        notes = item.notes,
+                        moduleKey = item.moduleKey,
+                        recurrenceHint = item.recurrenceHint,
+                    ),
+                )
+            }
+
+        @Suppress("TooGenericExceptionCaught")
+        suspend fun deletePlannedItem(id: Int): Result<Unit> =
+            runCatching { todayActionsApi.deletePlannedItem(id) }
+
+        @Suppress("TooGenericExceptionCaught")
+        suspend fun createPlannedItem(request: PlannedItemCreateDto): Result<PlannedTodayItemDto> =
+            runCatching { todayActionsApi.createPlannedItem(request) }
 
         private fun TodaySummaryEntity.toDomain() =
             TodaySummary(

--- a/android/app/src/main/java/com/daynest/android/feature/calendar/CalendarRoute.kt
+++ b/android/app/src/main/java/com/daynest/android/feature/calendar/CalendarRoute.kt
@@ -2,24 +2,444 @@
 
 package com.daynest.android.feature.calendar
 
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.automirrored.filled.ArrowForward
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.daynest.android.R
 import com.daynest.android.app.navigation.DaynestDestination
-import com.daynest.android.app.navigation.DaynestParityRoute
+import com.daynest.android.app.navigation.DaynestNavigationScaffold
+import com.daynest.android.data.calendar.CalendarDaySummaryDto
+import com.daynest.android.data.calendar.UnifiedDayItemDto
+import java.time.LocalDate
+import java.time.format.TextStyle
+import java.util.Locale
 
 @Composable
-fun CalendarRoute(onNavigate: (String) -> Unit = {}) {
-    DaynestParityRoute(
+fun CalendarRoute(
+    onNavigate: (String) -> Unit = {},
+    viewModel: CalendarViewModel = hiltViewModel(),
+) {
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    CalendarScreen(
+        uiState = uiState,
+        onEvent = viewModel::onEvent,
+        onNavigate = onNavigate,
+    )
+}
+
+@Composable
+private fun CalendarScreen(
+    uiState: CalendarUiState,
+    onEvent: (CalendarUiEvent) -> Unit,
+    onNavigate: (String) -> Unit,
+) {
+    DaynestNavigationScaffold(
         currentRoute = DaynestDestination.CALENDAR,
         onNavigate = onNavigate,
-        titleRes = R.string.calendar_title,
-        subtitleRes = R.string.calendar_subtitle,
-        capabilityResIds =
-            listOf(
-                R.string.calendar_capability_month,
-                R.string.calendar_capability_day,
-                R.string.calendar_capability_planned,
-                R.string.calendar_capability_backup,
-            ),
+    ) { innerPadding ->
+        when (val state = uiState) {
+            CalendarUiState.Loading -> {
+                Box(
+                    modifier =
+                        Modifier
+                            .fillMaxSize()
+                            .padding(innerPadding),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    CircularProgressIndicator()
+                }
+            }
+
+            is CalendarUiState.Error -> {
+                Column(
+                    modifier =
+                        Modifier
+                            .fillMaxSize()
+                            .padding(innerPadding)
+                            .padding(24.dp),
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                    verticalArrangement = Arrangement.Center,
+                ) {
+                    Text(
+                        text = stringResource(id = R.string.calendar_error),
+                        style = MaterialTheme.typography.bodyLarge,
+                    )
+                    Button(
+                        onClick = { onEvent(CalendarUiEvent.RetryClicked) },
+                        modifier = Modifier.padding(top = 16.dp),
+                    ) {
+                        Text(text = stringResource(id = R.string.home_retry))
+                    }
+                }
+            }
+
+            is CalendarUiState.Content -> {
+                CalendarContent(
+                    state = state,
+                    onEvent = onEvent,
+                    modifier = Modifier.padding(innerPadding),
+                )
+            }
+        }
+    }
+}
+
+@Composable
+@Suppress("LongMethod", "CyclomaticComplexMethod")
+private fun CalendarContent(
+    state: CalendarUiState.Content,
+    onEvent: (CalendarUiEvent) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    var showAddDialog by remember(state.selectedDate) { mutableStateOf(false) }
+
+    LazyColumn(
+        modifier = modifier.fillMaxSize(),
+        contentPadding = PaddingValues(16.dp),
+        verticalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        item {
+            MonthHeader(
+                displayMonth = state.displayMonth,
+                onPrevious = { onEvent(CalendarUiEvent.PreviousMonthClicked) },
+                onNext = { onEvent(CalendarUiEvent.NextMonthClicked) },
+            )
+        }
+
+        item {
+            MonthGrid(
+                displayMonth = state.displayMonth,
+                days = state.days,
+                selectedDate = state.selectedDate,
+                onDayClick = { date ->
+                    if (state.selectedDate == date) {
+                        onEvent(CalendarUiEvent.DayDeselected)
+                    } else {
+                        onEvent(CalendarUiEvent.DaySelected(date))
+                    }
+                },
+            )
+        }
+
+        if (state.selectedDate != null) {
+            item {
+                Spacer(modifier = Modifier.height(8.dp))
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    Text(
+                        text = stringResource(id = R.string.calendar_day_detail_header, state.selectedDate),
+                        style = MaterialTheme.typography.titleMedium,
+                        modifier = Modifier.weight(1f),
+                    )
+                    TextButton(onClick = { showAddDialog = true }) {
+                        Text(text = stringResource(id = R.string.calendar_add_planned))
+                    }
+                }
+            }
+
+            if (state.isLoadingDay) {
+                item {
+                    Box(modifier = Modifier.fillMaxWidth(), contentAlignment = Alignment.Center) {
+                        CircularProgressIndicator(modifier = Modifier.size(24.dp))
+                    }
+                }
+            } else if (state.dayItems.isEmpty()) {
+                item {
+                    Text(
+                        text = stringResource(id = R.string.calendar_day_empty),
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.outline,
+                    )
+                }
+            } else {
+                items(state.dayItems, key = { "${it.itemType}_${it.itemId}" }) { item ->
+                    DayItemCard(
+                        item = item,
+                        onDelete =
+                            if (item.itemType == "planned") {
+                                { onEvent(CalendarUiEvent.DeletePlannedItem(item.itemId, state.selectedDate)) }
+                            } else {
+                                null
+                            },
+                    )
+                }
+            }
+        }
+    }
+
+    if (showAddDialog && state.selectedDate != null) {
+        AddPlannedItemDialog(
+            onConfirm = { title ->
+                onEvent(CalendarUiEvent.AddPlannedItem(title, state.selectedDate))
+                showAddDialog = false
+            },
+            onDismiss = { showAddDialog = false },
+        )
+    }
+}
+
+@Composable
+private fun MonthHeader(
+    displayMonth: LocalDate,
+    onPrevious: () -> Unit,
+    onNext: () -> Unit,
+) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.SpaceBetween,
+    ) {
+        IconButton(onClick = onPrevious) {
+            Icon(
+                imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                contentDescription = stringResource(id = R.string.calendar_prev_month),
+            )
+        }
+        Text(
+            text =
+                "${displayMonth.month.getDisplayName(TextStyle.FULL, Locale.getDefault())} ${displayMonth.year}",
+            style = MaterialTheme.typography.titleLarge,
+        )
+        IconButton(onClick = onNext) {
+            Icon(
+                imageVector = Icons.AutoMirrored.Filled.ArrowForward,
+                contentDescription = stringResource(id = R.string.calendar_next_month),
+            )
+        }
+    }
+}
+
+@Composable
+@Suppress("LongMethod")
+private fun MonthGrid(
+    displayMonth: LocalDate,
+    days: List<CalendarDaySummaryDto>,
+    selectedDate: String?,
+    onDayClick: (String) -> Unit,
+) {
+    val dayMap = days.associateBy { it.date }
+    val firstDayOfMonth = displayMonth.withDayOfMonth(1)
+    val daysInMonth = displayMonth.lengthOfMonth()
+    val firstWeekday = firstDayOfMonth.dayOfWeek.value % 7
+
+    val dayLabels = listOf("Su", "Mo", "Tu", "We", "Th", "Fr", "Sa")
+
+    Column {
+        Row(modifier = Modifier.fillMaxWidth()) {
+            dayLabels.forEach { label ->
+                Text(
+                    text = label,
+                    modifier = Modifier.weight(1f),
+                    textAlign = TextAlign.Center,
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.outline,
+                )
+            }
+        }
+        Spacer(modifier = Modifier.height(4.dp))
+
+        val totalCells = firstWeekday + daysInMonth
+        val rows = (totalCells + 6) / 7
+        for (row in 0 until rows) {
+            Row(modifier = Modifier.fillMaxWidth()) {
+                for (col in 0 until 7) {
+                    val cellIndex = row * 7 + col
+                    val dayNum = cellIndex - firstWeekday + 1
+                    if (dayNum < 1 || dayNum > daysInMonth) {
+                        Spacer(modifier = Modifier.weight(1f).aspectRatio(1f))
+                    } else {
+                        val date = displayMonth.withDayOfMonth(dayNum).toString()
+                        val summary = dayMap[date]
+                        val isSelected = date == selectedDate
+                        val isToday = date == LocalDate.now().toString()
+                        DayCell(
+                            dayNum = dayNum,
+                            total = summary?.total ?: 0,
+                            isSelected = isSelected,
+                            isToday = isToday,
+                            onClick = { onDayClick(date) },
+                            modifier = Modifier.weight(1f),
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun DayCell(
+    dayNum: Int,
+    total: Int,
+    isSelected: Boolean,
+    isToday: Boolean,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val bgColor =
+        when {
+            isSelected -> MaterialTheme.colorScheme.primary
+            isToday -> MaterialTheme.colorScheme.primaryContainer
+            else -> androidx.compose.ui.graphics.Color.Transparent
+        }
+    val textColor =
+        when {
+            isSelected -> MaterialTheme.colorScheme.onPrimary
+            isToday -> MaterialTheme.colorScheme.onPrimaryContainer
+            else -> MaterialTheme.colorScheme.onSurface
+        }
+
+    Box(
+        modifier =
+            modifier
+                .aspectRatio(1f)
+                .padding(2.dp)
+                .clip(CircleShape)
+                .background(bgColor)
+                .clickable(onClick = onClick),
+        contentAlignment = Alignment.Center,
+    ) {
+        Column(horizontalAlignment = Alignment.CenterHorizontally) {
+            Text(
+                text = dayNum.toString(),
+                style = MaterialTheme.typography.bodySmall,
+                color = textColor,
+            )
+            if (total > 0) {
+                Box(
+                    modifier =
+                        Modifier
+                            .size(4.dp)
+                            .clip(CircleShape)
+                            .background(
+                                if (isSelected) MaterialTheme.colorScheme.onPrimary else MaterialTheme.colorScheme.primary,
+                            ),
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun DayItemCard(
+    item: UnifiedDayItemDto,
+    onDelete: (() -> Unit)?,
+) {
+    Card(modifier = Modifier.fillMaxWidth()) {
+        Row(
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .padding(12.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Column(modifier = Modifier.weight(1f)) {
+                Text(text = item.title, style = MaterialTheme.typography.bodyMedium)
+                Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                    Text(
+                        text = item.itemType,
+                        style = MaterialTheme.typography.labelSmall,
+                        color = MaterialTheme.colorScheme.primary,
+                    )
+                    if (item.status.isNotEmpty()) {
+                        Text(
+                            text = item.status,
+                            style = MaterialTheme.typography.labelSmall,
+                            color = MaterialTheme.colorScheme.outline,
+                        )
+                    }
+                }
+                if (!item.detail.isNullOrBlank()) {
+                    Text(
+                        text = item.detail,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.outline,
+                    )
+                }
+            }
+            if (onDelete != null) {
+                TextButton(onClick = onDelete) {
+                    Text(
+                        text = stringResource(id = R.string.action_delete),
+                        color = MaterialTheme.colorScheme.error,
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun AddPlannedItemDialog(
+    onConfirm: (String) -> Unit,
+    onDismiss: () -> Unit,
+) {
+    var title by remember { mutableStateOf("") }
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(text = stringResource(id = R.string.calendar_add_planned_title)) },
+        text = {
+            OutlinedTextField(
+                value = title,
+                onValueChange = { title = it },
+                label = { Text(text = stringResource(id = R.string.calendar_planned_title_label)) },
+                singleLine = true,
+            )
+        },
+        confirmButton = {
+            TextButton(
+                onClick = { if (title.isNotBlank()) onConfirm(title.trim()) },
+                enabled = title.isNotBlank(),
+            ) {
+                Text(text = stringResource(id = R.string.action_add))
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) {
+                Text(text = stringResource(id = R.string.action_cancel))
+            }
+        },
     )
 }

--- a/android/app/src/main/java/com/daynest/android/feature/calendar/CalendarRoute.kt
+++ b/android/app/src/main/java/com/daynest/android/feature/calendar/CalendarRoute.kt
@@ -2,8 +2,6 @@
 
 package com.daynest.android.feature.calendar
 
-private const val DAYS_IN_WEEK = 7
-
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
@@ -51,6 +49,8 @@ import java.time.DayOfWeek
 import java.time.LocalDate
 import java.time.format.TextStyle
 import java.util.Locale
+
+private const val DAYS_IN_WEEK = 7
 
 @Composable
 fun CalendarRoute(

--- a/android/app/src/main/java/com/daynest/android/feature/calendar/CalendarRoute.kt
+++ b/android/app/src/main/java/com/daynest/android/feature/calendar/CalendarRoute.kt
@@ -2,6 +2,8 @@
 
 package com.daynest.android.feature.calendar
 
+private const val DAYS_IN_WEEK = 7
+
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
@@ -259,10 +261,10 @@ private fun MonthGrid(
     val dayMap = remember(days) { days.associateBy { it.date } }
     val firstDayOfMonth = remember(displayMonth) { displayMonth.withDayOfMonth(1) }
     val daysInMonth = remember(displayMonth) { displayMonth.lengthOfMonth() }
-    val firstWeekday = remember(firstDayOfMonth) { firstDayOfMonth.dayOfWeek.value % 7 }
+    val firstWeekday = remember(firstDayOfMonth) { firstDayOfMonth.dayOfWeek.value % DAYS_IN_WEEK }
     val dayLabels = remember {
-        (0 until 7).map { offset ->
-            val dayValue = (DayOfWeek.SUNDAY.value - 1 + offset) % 7 + 1
+        (0 until DAYS_IN_WEEK).map { offset ->
+            val dayValue = (DayOfWeek.SUNDAY.value - 1 + offset) % DAYS_IN_WEEK + 1
             DayOfWeek.of(dayValue).getDisplayName(TextStyle.SHORT, Locale.getDefault())
         }
     }
@@ -282,11 +284,11 @@ private fun MonthGrid(
         Spacer(modifier = Modifier.height(4.dp))
 
         val totalCells = firstWeekday + daysInMonth
-        val rows = (totalCells + 6) / 7
+        val rows = (totalCells + DAYS_IN_WEEK - 1) / DAYS_IN_WEEK
         for (row in 0 until rows) {
             Row(modifier = Modifier.fillMaxWidth()) {
-                for (col in 0 until 7) {
-                    val cellIndex = row * 7 + col
+                for (col in 0 until DAYS_IN_WEEK) {
+                    val cellIndex = row * DAYS_IN_WEEK + col
                     val dayNum = cellIndex - firstWeekday + 1
                     if (dayNum < 1 || dayNum > daysInMonth) {
                         Spacer(modifier = Modifier.weight(1f).aspectRatio(1f))

--- a/android/app/src/main/java/com/daynest/android/feature/calendar/CalendarRoute.kt
+++ b/android/app/src/main/java/com/daynest/android/feature/calendar/CalendarRoute.kt
@@ -19,15 +19,10 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.ArrowBack
-import androidx.compose.material.icons.automirrored.filled.ArrowForward
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.Card
 import androidx.compose.material3.CircularProgressIndicator
-import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
@@ -50,6 +45,7 @@ import com.daynest.android.app.navigation.DaynestDestination
 import com.daynest.android.app.navigation.DaynestNavigationScaffold
 import com.daynest.android.data.calendar.CalendarDaySummaryDto
 import com.daynest.android.data.calendar.UnifiedDayItemDto
+import java.time.DayOfWeek
 import java.time.LocalDate
 import java.time.format.TextStyle
 import java.util.Locale
@@ -226,27 +222,27 @@ private fun MonthHeader(
     onPrevious: () -> Unit,
     onNext: () -> Unit,
 ) {
+    val monthName = remember(displayMonth) {
+        displayMonth.month.getDisplayName(TextStyle.FULL, Locale.getDefault())
+    }
     Row(
         modifier = Modifier.fillMaxWidth(),
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.SpaceBetween,
     ) {
-        IconButton(onClick = onPrevious) {
-            Icon(
-                imageVector = Icons.AutoMirrored.Filled.ArrowBack,
-                contentDescription = stringResource(id = R.string.calendar_prev_month),
-            )
+        TextButton(onClick = onPrevious) {
+            Text(text = stringResource(id = R.string.calendar_prev_month))
         }
         Text(
-            text =
-                "${displayMonth.month.getDisplayName(TextStyle.FULL, Locale.getDefault())} ${displayMonth.year}",
+            text = stringResource(
+                id = R.string.calendar_month_year,
+                monthName,
+                displayMonth.year.toString(),
+            ),
             style = MaterialTheme.typography.titleLarge,
         )
-        IconButton(onClick = onNext) {
-            Icon(
-                imageVector = Icons.AutoMirrored.Filled.ArrowForward,
-                contentDescription = stringResource(id = R.string.calendar_next_month),
-            )
+        TextButton(onClick = onNext) {
+            Text(text = stringResource(id = R.string.calendar_next_month))
         }
     }
 }
@@ -259,12 +255,17 @@ private fun MonthGrid(
     selectedDate: String?,
     onDayClick: (String) -> Unit,
 ) {
-    val dayMap = days.associateBy { it.date }
-    val firstDayOfMonth = displayMonth.withDayOfMonth(1)
-    val daysInMonth = displayMonth.lengthOfMonth()
-    val firstWeekday = firstDayOfMonth.dayOfWeek.value % 7
-
-    val dayLabels = listOf("Su", "Mo", "Tu", "We", "Th", "Fr", "Sa")
+    val today = remember { LocalDate.now().toString() }
+    val dayMap = remember(days) { days.associateBy { it.date } }
+    val firstDayOfMonth = remember(displayMonth) { displayMonth.withDayOfMonth(1) }
+    val daysInMonth = remember(displayMonth) { displayMonth.lengthOfMonth() }
+    val firstWeekday = remember(firstDayOfMonth) { firstDayOfMonth.dayOfWeek.value % 7 }
+    val dayLabels = remember {
+        (0 until 7).map { offset ->
+            val dayValue = (DayOfWeek.SUNDAY.value - 1 + offset) % 7 + 1
+            DayOfWeek.of(dayValue).getDisplayName(TextStyle.SHORT, Locale.getDefault())
+        }
+    }
 
     Column {
         Row(modifier = Modifier.fillMaxWidth()) {
@@ -293,7 +294,7 @@ private fun MonthGrid(
                         val date = displayMonth.withDayOfMonth(dayNum).toString()
                         val summary = dayMap[date]
                         val isSelected = date == selectedDate
-                        val isToday = date == LocalDate.now().toString()
+                        val isToday = date == today
                         DayCell(
                             dayNum = dayNum,
                             total = summary?.total ?: 0,
@@ -354,7 +355,11 @@ private fun DayCell(
                             .size(4.dp)
                             .clip(CircleShape)
                             .background(
-                                if (isSelected) MaterialTheme.colorScheme.onPrimary else MaterialTheme.colorScheme.primary,
+                                if (isSelected) {
+                                    MaterialTheme.colorScheme.onPrimary
+                                } else {
+                                    MaterialTheme.colorScheme.primary
+                                },
                             ),
                 )
             }

--- a/android/app/src/main/java/com/daynest/android/feature/calendar/CalendarRoute.kt
+++ b/android/app/src/main/java/com/daynest/android/feature/calendar/CalendarRoute.kt
@@ -224,9 +224,10 @@ private fun MonthHeader(
     onPrevious: () -> Unit,
     onNext: () -> Unit,
 ) {
-    val monthName = remember(displayMonth) {
-        displayMonth.month.getDisplayName(TextStyle.FULL, Locale.getDefault())
-    }
+    val monthName =
+        remember(displayMonth) {
+            displayMonth.month.getDisplayName(TextStyle.FULL, Locale.getDefault())
+        }
     Row(
         modifier = Modifier.fillMaxWidth(),
         verticalAlignment = Alignment.CenterVertically,
@@ -236,11 +237,12 @@ private fun MonthHeader(
             Text(text = stringResource(id = R.string.calendar_prev_month))
         }
         Text(
-            text = stringResource(
-                id = R.string.calendar_month_year,
-                monthName,
-                displayMonth.year.toString(),
-            ),
+            text =
+                stringResource(
+                    id = R.string.calendar_month_year,
+                    monthName,
+                    displayMonth.year.toString(),
+                ),
             style = MaterialTheme.typography.titleLarge,
         )
         TextButton(onClick = onNext) {
@@ -262,12 +264,13 @@ private fun MonthGrid(
     val firstDayOfMonth = remember(displayMonth) { displayMonth.withDayOfMonth(1) }
     val daysInMonth = remember(displayMonth) { displayMonth.lengthOfMonth() }
     val firstWeekday = remember(firstDayOfMonth) { firstDayOfMonth.dayOfWeek.value % DAYS_IN_WEEK }
-    val dayLabels = remember {
-        (0 until DAYS_IN_WEEK).map { offset ->
-            val dayValue = (DayOfWeek.SUNDAY.value - 1 + offset) % DAYS_IN_WEEK + 1
-            DayOfWeek.of(dayValue).getDisplayName(TextStyle.SHORT, Locale.getDefault())
+    val dayLabels =
+        remember {
+            (0 until DAYS_IN_WEEK).map { offset ->
+                val dayValue = (DayOfWeek.SUNDAY.value - 1 + offset) % DAYS_IN_WEEK + 1
+                DayOfWeek.of(dayValue).getDisplayName(TextStyle.SHORT, Locale.getDefault())
+            }
         }
-    }
 
     Column {
         Row(modifier = Modifier.fillMaxWidth()) {

--- a/android/app/src/main/java/com/daynest/android/feature/calendar/CalendarViewModel.kt
+++ b/android/app/src/main/java/com/daynest/android/feature/calendar/CalendarViewModel.kt
@@ -180,7 +180,9 @@ sealed interface CalendarUiState {
         val isLoadingDay: Boolean,
     ) : CalendarUiState
 
-    data class Error(val displayMonth: LocalDate) : CalendarUiState
+    data class Error(
+        val displayMonth: LocalDate,
+    ) : CalendarUiState
 }
 
 sealed interface CalendarUiEvent {
@@ -188,13 +190,21 @@ sealed interface CalendarUiEvent {
 
     data object NextMonthClicked : CalendarUiEvent
 
-    data class DaySelected(val date: String) : CalendarUiEvent
+    data class DaySelected(
+        val date: String,
+    ) : CalendarUiEvent
 
     data object DayDeselected : CalendarUiEvent
 
-    data class AddPlannedItem(val title: String, val date: String) : CalendarUiEvent
+    data class AddPlannedItem(
+        val title: String,
+        val date: String,
+    ) : CalendarUiEvent
 
-    data class DeletePlannedItem(val id: Int, val date: String) : CalendarUiEvent
+    data class DeletePlannedItem(
+        val id: Int,
+        val date: String,
+    ) : CalendarUiEvent
 
     data object RetryClicked : CalendarUiEvent
 }

--- a/android/app/src/main/java/com/daynest/android/feature/calendar/CalendarViewModel.kt
+++ b/android/app/src/main/java/com/daynest/android/feature/calendar/CalendarViewModel.kt
@@ -1,0 +1,195 @@
+package com.daynest.android.feature.calendar
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.daynest.android.data.calendar.CalendarDaySummaryDto
+import com.daynest.android.data.calendar.CalendarRepository
+import com.daynest.android.data.calendar.UnifiedDayItemDto
+import com.daynest.android.data.today.PlannedItemCreateDto
+import com.daynest.android.data.today.TodayRepository
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import java.time.LocalDate
+import javax.inject.Inject
+
+@HiltViewModel
+class CalendarViewModel
+    @Inject
+    constructor(
+        private val calendarRepository: CalendarRepository,
+        private val todayRepository: TodayRepository,
+    ) : ViewModel() {
+        private val _uiState = MutableStateFlow<CalendarUiState>(CalendarUiState.Loading)
+        val uiState: StateFlow<CalendarUiState> = _uiState.asStateFlow()
+
+        private val today = LocalDate.now()
+
+        init {
+            loadMonth(today.year, today.monthValue)
+        }
+
+        fun onEvent(event: CalendarUiEvent) {
+            when (event) {
+                is CalendarUiEvent.PreviousMonthClicked -> navigateMonth(-1)
+                is CalendarUiEvent.NextMonthClicked -> navigateMonth(1)
+                is CalendarUiEvent.DaySelected -> loadDay(event.date)
+                is CalendarUiEvent.DayDeselected -> clearDay()
+                is CalendarUiEvent.AddPlannedItem -> addPlannedItem(event.title, event.date)
+                is CalendarUiEvent.DeletePlannedItem -> deletePlannedItem(event.id, event.date)
+                is CalendarUiEvent.RetryClicked -> retryCurrentMonth()
+            }
+        }
+
+        private fun navigateMonth(delta: Int) {
+            val current = _uiState.value
+            if (current is CalendarUiState.Content) {
+                val newMonth = current.displayMonth.plusMonths(delta.toLong())
+                loadMonth(newMonth.year, newMonth.monthValue)
+            }
+        }
+
+        private fun retryCurrentMonth() {
+            val current = _uiState.value
+            val month = if (current is CalendarUiState.Content) current.displayMonth else LocalDate.of(today.year, today.monthValue, 1)
+            loadMonth(month.year, month.monthValue)
+        }
+
+        private fun loadMonth(
+            year: Int,
+            month: Int,
+        ) {
+            viewModelScope.launch {
+                val displayMonth = LocalDate.of(year, month, 1)
+                _uiState.update { current ->
+                    if (current is CalendarUiState.Content) {
+                        current.copy(isLoadingMonth = true, displayMonth = displayMonth)
+                    } else {
+                        CalendarUiState.Loading
+                    }
+                }
+                val result = calendarRepository.getMonth(year, month)
+                result
+                    .onSuccess { monthDto ->
+                        _uiState.value =
+                            CalendarUiState.Content(
+                                displayMonth = displayMonth,
+                                days = monthDto.days,
+                                selectedDate = null,
+                                dayItems = emptyList(),
+                                isLoadingMonth = false,
+                                isLoadingDay = false,
+                            )
+                    }.onFailure {
+                        _uiState.value = CalendarUiState.Error(displayMonth = displayMonth)
+                    }
+            }
+        }
+
+        private fun loadDay(date: String) {
+            viewModelScope.launch {
+                _uiState.update { current ->
+                    if (current is CalendarUiState.Content) {
+                        current.copy(selectedDate = date, isLoadingDay = true, dayItems = emptyList())
+                    } else {
+                        current
+                    }
+                }
+                val result = calendarRepository.getDay(date)
+                result
+                    .onSuccess { dayDto ->
+                        _uiState.update { current ->
+                            if (current is CalendarUiState.Content) {
+                                current.copy(dayItems = dayDto.items, isLoadingDay = false)
+                            } else {
+                                current
+                            }
+                        }
+                    }.onFailure {
+                        _uiState.update { current ->
+                            if (current is CalendarUiState.Content) {
+                                current.copy(isLoadingDay = false)
+                            } else {
+                                current
+                            }
+                        }
+                    }
+            }
+        }
+
+        private fun clearDay() {
+            _uiState.update { current ->
+                if (current is CalendarUiState.Content) {
+                    current.copy(selectedDate = null, dayItems = emptyList())
+                } else {
+                    current
+                }
+            }
+        }
+
+        private fun addPlannedItem(
+            title: String,
+            date: String,
+        ) {
+            viewModelScope.launch {
+                val result = todayRepository.createPlannedItem(PlannedItemCreateDto(title = title, plannedFor = date))
+                if (result.isSuccess) {
+                    loadDay(date)
+                    val current = _uiState.value
+                    if (current is CalendarUiState.Content) {
+                        loadMonth(current.displayMonth.year, current.displayMonth.monthValue)
+                    }
+                }
+            }
+        }
+
+        private fun deletePlannedItem(
+            id: Int,
+            date: String,
+        ) {
+            viewModelScope.launch {
+                val result = todayRepository.deletePlannedItem(id)
+                if (result.isSuccess) {
+                    loadDay(date)
+                    val current = _uiState.value
+                    if (current is CalendarUiState.Content) {
+                        loadMonth(current.displayMonth.year, current.displayMonth.monthValue)
+                    }
+                }
+            }
+        }
+    }
+
+sealed interface CalendarUiState {
+    data object Loading : CalendarUiState
+
+    data class Content(
+        val displayMonth: LocalDate,
+        val days: List<CalendarDaySummaryDto>,
+        val selectedDate: String?,
+        val dayItems: List<UnifiedDayItemDto>,
+        val isLoadingMonth: Boolean,
+        val isLoadingDay: Boolean,
+    ) : CalendarUiState
+
+    data class Error(val displayMonth: LocalDate) : CalendarUiState
+}
+
+sealed interface CalendarUiEvent {
+    data object PreviousMonthClicked : CalendarUiEvent
+
+    data object NextMonthClicked : CalendarUiEvent
+
+    data class DaySelected(val date: String) : CalendarUiEvent
+
+    data object DayDeselected : CalendarUiEvent
+
+    data class AddPlannedItem(val title: String, val date: String) : CalendarUiEvent
+
+    data class DeletePlannedItem(val id: Int, val date: String) : CalendarUiEvent
+
+    data object RetryClicked : CalendarUiEvent
+}

--- a/android/app/src/main/java/com/daynest/android/feature/calendar/CalendarViewModel.kt
+++ b/android/app/src/main/java/com/daynest/android/feature/calendar/CalendarViewModel.kt
@@ -54,7 +54,12 @@ class CalendarViewModel
 
         private fun retryCurrentMonth() {
             val current = _uiState.value
-            val month = if (current is CalendarUiState.Content) current.displayMonth else LocalDate.of(today.year, today.monthValue, 1)
+            val month =
+                if (current is CalendarUiState.Content) {
+                    current.displayMonth
+                } else {
+                    LocalDate.of(today.year, today.monthValue, 1)
+                }
             loadMonth(month.year, month.monthValue)
         }
 

--- a/android/app/src/main/java/com/daynest/android/feature/home/HomeRoute.kt
+++ b/android/app/src/main/java/com/daynest/android/feature/home/HomeRoute.kt
@@ -185,7 +185,12 @@ private fun TodayContent(
             items(state.overdue, key = { "overdue_${it.choreInstanceId}" }) { item ->
                 ChoreCard(
                     title = item.title,
-                    subtitle = if (item.overdueSince.isNotEmpty()) stringResource(id = R.string.today_overdue_since, item.overdueSince) else null,
+                    subtitle =
+                        if (item.overdueSince.isNotEmpty()) {
+                            stringResource(id = R.string.today_overdue_since, item.overdueSince)
+                        } else {
+                            null
+                        },
                     onComplete = { onEvent(HomeUiEvent.CompleteChoreClicked(item.choreInstanceId)) },
                     onSkip = { onEvent(HomeUiEvent.SkipChoreClicked(item.choreInstanceId)) },
                 )

--- a/android/app/src/main/java/com/daynest/android/feature/home/HomeRoute.kt
+++ b/android/app/src/main/java/com/daynest/android/feature/home/HomeRoute.kt
@@ -1,27 +1,41 @@
-@file:Suppress("ktlint:standard:function-naming")
+@file:Suppress("ktlint:standard:function-naming", "FunctionNaming")
 
 package com.daynest.android.feature.home
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Card
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.unit.dp
-import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.daynest.android.R
 import com.daynest.android.app.navigation.DaynestDestination
 import com.daynest.android.app.navigation.DaynestNavigationScaffold
+import com.daynest.android.data.today.MedicationTodayItemDto
+import com.daynest.android.data.today.PlannedTodayItemDto
+import com.daynest.android.data.today.RoutineTodayItemDto
+import com.daynest.android.data.today.UpcomingTodayItemDto
 
 @Composable
 @Suppress("FunctionNaming")
@@ -39,7 +53,7 @@ fun HomeRoute(
 }
 
 @Composable
-@Suppress("FunctionNaming", "LongMethod")
+@Suppress("FunctionNaming", "LongMethod", "CyclomaticComplexMethod")
 internal fun HomeScreen(
     uiState: HomeUiState,
     onEvent: (HomeUiEvent) -> Unit,
@@ -49,56 +63,40 @@ internal fun HomeScreen(
         currentRoute = DaynestDestination.HOME,
         onNavigate = onNavigate,
     ) { innerPadding ->
-        Column(
-            modifier =
-                Modifier
-                    .fillMaxSize()
-                    .padding(innerPadding)
-                    .padding(24.dp),
-            horizontalAlignment = Alignment.CenterHorizontally,
-            verticalArrangement = Arrangement.Center,
-        ) {
-            when (val state = uiState) {
-                HomeUiState.Loading -> {
+        when (val state = uiState) {
+            HomeUiState.Loading -> {
+                Column(
+                    modifier =
+                        Modifier
+                            .fillMaxSize()
+                            .padding(innerPadding),
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                    verticalArrangement = Arrangement.Center,
+                ) {
                     CircularProgressIndicator()
                 }
+            }
 
-                is HomeUiState.Content -> {
-                    Text(
-                        text = stringResource(id = R.string.home_welcome),
-                        style = MaterialTheme.typography.headlineMedium,
-                    )
-                    Text(
-                        text =
-                            pluralStringResource(
-                                id = R.plurals.home_items_remaining,
-                                count = state.summary.remainingCount,
-                                state.summary.remainingCount,
-                            ),
-                        modifier = Modifier.padding(top = 12.dp),
-                        style = MaterialTheme.typography.bodyLarge,
-                    )
-                    Button(
-                        onClick = { onEvent(HomeUiEvent.OpenTodayDetailsClicked) },
-                        modifier = Modifier.padding(top = 20.dp),
-                    ) {
-                        Text(
-                            text =
-                                if (state.summary.isCaughtUp) {
-                                    stringResource(id = R.string.home_action_caught_up)
-                                } else {
-                                    stringResource(id = R.string.home_action_plan_today)
-                                },
-                        )
-                    }
-                }
+            is HomeUiState.Content -> {
+                TodayContent(
+                    state = state,
+                    onEvent = onEvent,
+                    modifier = Modifier.padding(innerPadding),
+                )
+            }
 
-                is HomeUiState.Error -> {
+            is HomeUiState.Error -> {
+                Column(
+                    modifier =
+                        Modifier
+                            .fillMaxSize()
+                            .padding(innerPadding)
+                            .padding(24.dp),
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                    verticalArrangement = Arrangement.Center,
+                ) {
                     Text(
-                        text =
-                            when (state.error) {
-                                HomeError.LoadTodayFailed -> stringResource(id = R.string.home_error_generic)
-                            },
+                        text = stringResource(id = R.string.home_error_generic),
                         style = MaterialTheme.typography.bodyLarge,
                     )
                     Button(
@@ -112,3 +110,357 @@ internal fun HomeScreen(
         }
     }
 }
+
+@Composable
+@Suppress("FunctionNaming", "LongMethod", "CyclomaticComplexMethod")
+private fun TodayContent(
+    state: HomeUiState.Content,
+    onEvent: (HomeUiEvent) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    LazyColumn(
+        modifier = modifier.fillMaxSize(),
+        contentPadding = PaddingValues(16.dp),
+        verticalArrangement = Arrangement.spacedBy(12.dp),
+    ) {
+        item {
+            Column {
+                Text(
+                    text = stringResource(id = R.string.home_welcome),
+                    style = MaterialTheme.typography.headlineMedium,
+                )
+                if (state.isStale) {
+                    Text(
+                        text = stringResource(id = R.string.home_stale_notice),
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.outline,
+                    )
+                }
+                Spacer(modifier = Modifier.height(4.dp))
+                Text(
+                    text =
+                        if (state.summary.isCaughtUp) {
+                            stringResource(id = R.string.home_all_caught_up)
+                        } else {
+                            stringResource(id = R.string.home_items_remaining_label, state.summary.remainingCount)
+                        },
+                    style = MaterialTheme.typography.bodyLarge,
+                )
+            }
+        }
+
+        if (state.medication.isNotEmpty()) {
+            item {
+                SectionHeader(title = stringResource(id = R.string.today_section_medication))
+            }
+            items(state.medication, key = { "med_${it.medicationDoseInstanceId}" }) { item ->
+                MedicationTodayCard(
+                    item = item,
+                    onTake = { onEvent(HomeUiEvent.TakeMedicationClicked(item.medicationDoseInstanceId)) },
+                    onSkip = { onEvent(HomeUiEvent.SkipMedicationClicked(item.medicationDoseInstanceId)) },
+                )
+            }
+        }
+
+        if (state.routines.isNotEmpty()) {
+            item {
+                SectionHeader(title = stringResource(id = R.string.today_section_routines))
+            }
+            items(state.routines, key = { "routine_${it.taskInstanceId}" }) { item ->
+                RoutineCard(
+                    item = item,
+                    onComplete = { onEvent(HomeUiEvent.CompleteTaskClicked(item.taskInstanceId)) },
+                    onSkip = { onEvent(HomeUiEvent.SkipTaskClicked(item.taskInstanceId)) },
+                )
+            }
+        }
+
+        if (state.overdue.isNotEmpty()) {
+            item {
+                SectionHeader(
+                    title = stringResource(id = R.string.today_section_overdue),
+                    titleColor = MaterialTheme.colorScheme.error,
+                )
+            }
+            items(state.overdue, key = { "overdue_${it.choreInstanceId}" }) { item ->
+                ChoreCard(
+                    title = item.title,
+                    subtitle = if (item.overdueSince.isNotEmpty()) stringResource(id = R.string.today_overdue_since, item.overdueSince) else null,
+                    onComplete = { onEvent(HomeUiEvent.CompleteChoreClicked(item.choreInstanceId)) },
+                    onSkip = { onEvent(HomeUiEvent.SkipChoreClicked(item.choreInstanceId)) },
+                )
+            }
+        }
+
+        if (state.dueToday.isNotEmpty()) {
+            item {
+                SectionHeader(title = stringResource(id = R.string.today_section_due_today))
+            }
+            items(state.dueToday, key = { "due_${it.choreInstanceId}" }) { item ->
+                ChoreCard(
+                    title = item.title,
+                    subtitle = null,
+                    onComplete = { onEvent(HomeUiEvent.CompleteChoreClicked(item.choreInstanceId)) },
+                    onSkip = { onEvent(HomeUiEvent.SkipChoreClicked(item.choreInstanceId)) },
+                )
+            }
+        }
+
+        if (state.planned.isNotEmpty()) {
+            item {
+                SectionHeader(title = stringResource(id = R.string.today_section_planned))
+            }
+            items(state.planned, key = { "planned_${it.id}" }) { item ->
+                PlannedItemCard(
+                    item = item,
+                    onToggleDone = { onEvent(HomeUiEvent.MarkPlannedDoneClicked(item.id, !item.isDone)) },
+                    onDelete = { onEvent(HomeUiEvent.DeletePlannedClicked(item.id)) },
+                )
+            }
+        }
+
+        if (state.upcoming.isNotEmpty()) {
+            item {
+                SectionHeader(title = stringResource(id = R.string.today_section_upcoming))
+            }
+            items(state.upcoming, key = { "upcoming_${it.choreInstanceId}" }) { item ->
+                UpcomingChoreCard(item = item)
+            }
+        }
+
+        if (state.medicationHistory.isNotEmpty()) {
+            item {
+                SectionHeader(title = stringResource(id = R.string.today_section_medication_history))
+            }
+            items(state.medicationHistory, key = { "medhist_${it.medicationDoseInstanceId}" }) { item ->
+                Card(modifier = Modifier.fillMaxWidth()) {
+                    Column(modifier = Modifier.padding(12.dp)) {
+                        Text(text = item.name, style = MaterialTheme.typography.bodyMedium)
+                        Text(
+                            text = item.status,
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.outline,
+                        )
+                    }
+                }
+            }
+        }
+
+        if (state.summary.isCaughtUp) {
+            item {
+                Spacer(modifier = Modifier.height(8.dp))
+                Text(
+                    text = stringResource(id = R.string.home_all_caught_up),
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.outline,
+                    modifier = Modifier.fillMaxWidth(),
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun SectionHeader(
+    title: String,
+    titleColor: androidx.compose.ui.graphics.Color = MaterialTheme.colorScheme.onSurface,
+) {
+    Text(
+        text = title,
+        style = MaterialTheme.typography.titleSmall,
+        color = titleColor,
+        modifier = Modifier.padding(top = 4.dp, bottom = 2.dp),
+    )
+}
+
+@Composable
+@Suppress("FunctionNaming")
+private fun MedicationTodayCard(
+    item: MedicationTodayItemDto,
+    onTake: () -> Unit,
+    onSkip: () -> Unit,
+) {
+    Card(modifier = Modifier.fillMaxWidth()) {
+        Row(
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .padding(12.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Column(modifier = Modifier.weight(1f)) {
+                Text(text = item.name, style = MaterialTheme.typography.bodyMedium)
+                if (item.instructions.isNotEmpty()) {
+                    Text(
+                        text = item.instructions,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.outline,
+                    )
+                }
+            }
+            TextButton(onClick = onTake) {
+                Text(text = stringResource(id = R.string.action_take))
+            }
+            TextButton(onClick = onSkip) {
+                Text(text = stringResource(id = R.string.action_skip))
+            }
+        }
+    }
+}
+
+@Composable
+@Suppress("FunctionNaming")
+private fun RoutineCard(
+    item: RoutineTodayItemDto,
+    onComplete: () -> Unit,
+    onSkip: () -> Unit,
+) {
+    val isDone = item.status == "completed"
+    Card(modifier = Modifier.fillMaxWidth()) {
+        Row(
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .padding(12.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Text(
+                text = item.title,
+                style = MaterialTheme.typography.bodyMedium,
+                textDecoration = if (isDone) TextDecoration.LineThrough else TextDecoration.None,
+                modifier = Modifier.weight(1f),
+            )
+            if (!isDone) {
+                TextButton(onClick = onComplete) {
+                    Text(text = stringResource(id = R.string.action_done))
+                }
+                TextButton(onClick = onSkip) {
+                    Text(text = stringResource(id = R.string.action_skip))
+                }
+            }
+        }
+    }
+}
+
+@Composable
+@Suppress("FunctionNaming")
+private fun ChoreCard(
+    title: String,
+    subtitle: String?,
+    onComplete: () -> Unit,
+    onSkip: () -> Unit,
+) {
+    Card(modifier = Modifier.fillMaxWidth()) {
+        Row(
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .padding(12.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Column(modifier = Modifier.weight(1f)) {
+                Text(text = title, style = MaterialTheme.typography.bodyMedium)
+                if (subtitle != null) {
+                    Text(
+                        text = subtitle,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.outline,
+                    )
+                }
+            }
+            TextButton(onClick = onComplete) {
+                Text(text = stringResource(id = R.string.action_done))
+            }
+            TextButton(onClick = onSkip) {
+                Text(text = stringResource(id = R.string.action_skip))
+            }
+        }
+    }
+}
+
+@Composable
+@Suppress("FunctionNaming")
+private fun PlannedItemCard(
+    item: PlannedTodayItemDto,
+    onToggleDone: () -> Unit,
+    onDelete: () -> Unit,
+) {
+    Card(modifier = Modifier.fillMaxWidth()) {
+        Row(
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .padding(12.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = item.title,
+                    style = MaterialTheme.typography.bodyMedium,
+                    textDecoration = if (item.isDone) TextDecoration.LineThrough else TextDecoration.None,
+                )
+                if (!item.notes.isNullOrBlank()) {
+                    Text(
+                        text = item.notes,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.outline,
+                    )
+                }
+                if (!item.moduleKey.isNullOrBlank()) {
+                    Text(
+                        text = item.moduleKey,
+                        style = MaterialTheme.typography.labelSmall,
+                        color = MaterialTheme.colorScheme.primary,
+                    )
+                }
+            }
+            TextButton(onClick = onToggleDone) {
+                Text(
+                    text =
+                        if (item.isDone) {
+                            stringResource(id = R.string.action_undo)
+                        } else {
+                            stringResource(id = R.string.action_done)
+                        },
+                )
+            }
+            TextButton(
+                onClick = onDelete,
+                colors =
+                    ButtonDefaults.textButtonColors(
+                        contentColor = MaterialTheme.colorScheme.error,
+                    ),
+            ) {
+                Text(text = stringResource(id = R.string.action_delete))
+            }
+        }
+    }
+}
+
+@Composable
+@Suppress("FunctionNaming")
+private fun UpcomingChoreCard(item: UpcomingTodayItemDto) {
+    Card(modifier = Modifier.fillMaxWidth()) {
+        Row(
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .padding(12.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Text(
+                text = item.title,
+                style = MaterialTheme.typography.bodyMedium,
+                modifier = Modifier.weight(1f),
+            )
+            if (item.scheduledDate.isNotEmpty()) {
+                Text(
+                    text = item.scheduledDate,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.outline,
+                )
+            }
+        }
+    }
+}
+

--- a/android/app/src/main/java/com/daynest/android/feature/home/HomeRoute.kt
+++ b/android/app/src/main/java/com/daynest/android/feature/home/HomeRoute.kt
@@ -468,4 +468,3 @@ private fun UpcomingChoreCard(item: UpcomingTodayItemDto) {
         }
     }
 }
-

--- a/android/app/src/main/java/com/daynest/android/feature/home/HomeViewModel.kt
+++ b/android/app/src/main/java/com/daynest/android/feature/home/HomeViewModel.kt
@@ -202,21 +202,38 @@ sealed interface HomeUiEvent {
 
     data object RefreshRequested : HomeUiEvent
 
-    data class CompleteChoreClicked(val choreInstanceId: Int) : HomeUiEvent
+    data class CompleteChoreClicked(
+        val choreInstanceId: Int,
+    ) : HomeUiEvent
 
-    data class SkipChoreClicked(val choreInstanceId: Int) : HomeUiEvent
+    data class SkipChoreClicked(
+        val choreInstanceId: Int,
+    ) : HomeUiEvent
 
-    data class CompleteTaskClicked(val taskInstanceId: Int) : HomeUiEvent
+    data class CompleteTaskClicked(
+        val taskInstanceId: Int,
+    ) : HomeUiEvent
 
-    data class SkipTaskClicked(val taskInstanceId: Int) : HomeUiEvent
+    data class SkipTaskClicked(
+        val taskInstanceId: Int,
+    ) : HomeUiEvent
 
-    data class TakeMedicationClicked(val doseInstanceId: Int) : HomeUiEvent
+    data class TakeMedicationClicked(
+        val doseInstanceId: Int,
+    ) : HomeUiEvent
 
-    data class SkipMedicationClicked(val doseInstanceId: Int) : HomeUiEvent
+    data class SkipMedicationClicked(
+        val doseInstanceId: Int,
+    ) : HomeUiEvent
 
-    data class MarkPlannedDoneClicked(val id: Int, val isDone: Boolean) : HomeUiEvent
+    data class MarkPlannedDoneClicked(
+        val id: Int,
+        val isDone: Boolean,
+    ) : HomeUiEvent
 
-    data class DeletePlannedClicked(val id: Int) : HomeUiEvent
+    data class DeletePlannedClicked(
+        val id: Int,
+    ) : HomeUiEvent
 }
 
 enum class HomeError {

--- a/android/app/src/main/java/com/daynest/android/feature/home/HomeViewModel.kt
+++ b/android/app/src/main/java/com/daynest/android/feature/home/HomeViewModel.kt
@@ -3,7 +3,14 @@ package com.daynest.android.feature.home
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.daynest.android.core.model.TodaySummary
+import com.daynest.android.data.today.DueTodayItemDto
+import com.daynest.android.data.today.MedicationHistoryItemDto
+import com.daynest.android.data.today.MedicationTodayItemDto
+import com.daynest.android.data.today.OverdueTodayItemDto
+import com.daynest.android.data.today.PlannedTodayItemDto
+import com.daynest.android.data.today.RoutineTodayItemDto
 import com.daynest.android.data.today.TodayRepository
+import com.daynest.android.data.today.UpcomingTodayItemDto
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -29,7 +36,47 @@ class HomeViewModel
                         if (summary == null) {
                             current
                         } else {
-                            HomeUiState.Content(summary = summary, isStale = false)
+                            when (val c = current) {
+                                is HomeUiState.Content -> c.copy(summary = summary)
+                                else -> HomeUiState.Content(summary = summary)
+                            }
+                        }
+                    }
+                }
+            }
+            viewModelScope.launch {
+                repository.observeTodayResponse().collect { response ->
+                    if (response != null) {
+                        _uiState.update { current ->
+                            when (val c = current) {
+                                is HomeUiState.Content ->
+                                    c.copy(
+                                        medication = response.medication,
+                                        medicationHistory = response.medicationHistory,
+                                        routines = response.routines,
+                                        overdue = response.overdue,
+                                        dueToday = response.dueToday,
+                                        upcoming = response.upcoming,
+                                        planned = response.planned,
+                                    )
+                                else ->
+                                    HomeUiState.Content(
+                                        summary =
+                                            TodaySummary(
+                                                routinesCount = response.routines.size,
+                                                choresCount = response.dueToday.size + response.overdue.size,
+                                                medicationsCount = response.medication.size,
+                                                plannedPendingCount = response.planned.count { !it.isDone },
+                                            ),
+                                        medication = response.medication,
+                                        medicationHistory = response.medicationHistory,
+                                        routines = response.routines,
+                                        overdue = response.overdue,
+                                        dueToday = response.dueToday,
+                                        upcoming = response.upcoming,
+                                        planned = response.planned,
+                                    )
+                            }
                         }
                     }
                 }
@@ -40,7 +87,75 @@ class HomeViewModel
         fun onEvent(event: HomeUiEvent) {
             when (event) {
                 HomeUiEvent.RetryClicked -> refresh()
-                HomeUiEvent.OpenTodayDetailsClicked -> Unit
+                HomeUiEvent.RefreshRequested -> refresh()
+                is HomeUiEvent.CompleteChoreClicked -> choreAction(event.choreInstanceId, complete = true)
+                is HomeUiEvent.SkipChoreClicked -> choreAction(event.choreInstanceId, complete = false)
+                is HomeUiEvent.CompleteTaskClicked -> taskAction(event.taskInstanceId, complete = true)
+                is HomeUiEvent.SkipTaskClicked -> taskAction(event.taskInstanceId, complete = false)
+                is HomeUiEvent.TakeMedicationClicked -> doseAction(event.doseInstanceId, take = true)
+                is HomeUiEvent.SkipMedicationClicked -> doseAction(event.doseInstanceId, take = false)
+                is HomeUiEvent.MarkPlannedDoneClicked -> markPlannedDone(event.id, event.isDone)
+                is HomeUiEvent.DeletePlannedClicked -> deletePlanned(event.id)
+            }
+        }
+
+        private fun choreAction(
+            id: Int,
+            complete: Boolean,
+        ) {
+            viewModelScope.launch {
+                val result = if (complete) repository.completeChore(id) else repository.skipChore(id)
+                if (result.isSuccess) refresh()
+            }
+        }
+
+        private fun taskAction(
+            id: Int,
+            complete: Boolean,
+        ) {
+            viewModelScope.launch {
+                val result = if (complete) repository.completeTask(id) else repository.skipTask(id)
+                if (result.isSuccess) refresh()
+            }
+        }
+
+        private fun doseAction(
+            id: Int,
+            take: Boolean,
+        ) {
+            viewModelScope.launch {
+                val result = if (take) repository.takeDose(id) else repository.skipDose(id)
+                if (result.isSuccess) refresh()
+            }
+        }
+
+        private fun markPlannedDone(
+            id: Int,
+            isDone: Boolean,
+        ) {
+            val currentPlanned =
+                (_uiState.value as? HomeUiState.Content)
+                    ?.planned
+                    ?.firstOrNull { it.id == id }
+                    ?: return
+            viewModelScope.launch {
+                val result = repository.markPlannedDone(id, currentPlanned, isDone)
+                if (result.isSuccess) refresh()
+            }
+        }
+
+        private fun deletePlanned(id: Int) {
+            viewModelScope.launch {
+                val result = repository.deletePlannedItem(id)
+                if (result.isSuccess) {
+                    _uiState.update { current ->
+                        if (current is HomeUiState.Content) {
+                            current.copy(planned = current.planned.filter { it.id != id })
+                        } else {
+                            current
+                        }
+                    }
+                }
             }
         }
 
@@ -67,6 +182,13 @@ sealed interface HomeUiState {
 
     data class Content(
         val summary: TodaySummary,
+        val medication: List<MedicationTodayItemDto> = emptyList(),
+        val medicationHistory: List<MedicationHistoryItemDto> = emptyList(),
+        val routines: List<RoutineTodayItemDto> = emptyList(),
+        val overdue: List<OverdueTodayItemDto> = emptyList(),
+        val dueToday: List<DueTodayItemDto> = emptyList(),
+        val upcoming: List<UpcomingTodayItemDto> = emptyList(),
+        val planned: List<PlannedTodayItemDto> = emptyList(),
         val isStale: Boolean = false,
     ) : HomeUiState
 
@@ -78,7 +200,23 @@ sealed interface HomeUiState {
 sealed interface HomeUiEvent {
     data object RetryClicked : HomeUiEvent
 
-    data object OpenTodayDetailsClicked : HomeUiEvent
+    data object RefreshRequested : HomeUiEvent
+
+    data class CompleteChoreClicked(val choreInstanceId: Int) : HomeUiEvent
+
+    data class SkipChoreClicked(val choreInstanceId: Int) : HomeUiEvent
+
+    data class CompleteTaskClicked(val taskInstanceId: Int) : HomeUiEvent
+
+    data class SkipTaskClicked(val taskInstanceId: Int) : HomeUiEvent
+
+    data class TakeMedicationClicked(val doseInstanceId: Int) : HomeUiEvent
+
+    data class SkipMedicationClicked(val doseInstanceId: Int) : HomeUiEvent
+
+    data class MarkPlannedDoneClicked(val id: Int, val isDone: Boolean) : HomeUiEvent
+
+    data class DeletePlannedClicked(val id: Int) : HomeUiEvent
 }
 
 enum class HomeError {

--- a/android/app/src/main/java/com/daynest/android/feature/medication/MedicationRoute.kt
+++ b/android/app/src/main/java/com/daynest/android/feature/medication/MedicationRoute.kt
@@ -106,6 +106,7 @@ private fun MedicationScreen(
 }
 
 @Composable
+@Suppress("LongMethod")
 private fun MedicationContent(
     state: MedicationUiState.Content,
     onEvent: (MedicationUiEvent) -> Unit,
@@ -263,6 +264,7 @@ private fun MedicationHistoryCard(item: MedicationHistoryItemDto) {
 }
 
 @Composable
+@Suppress("LongMethod")
 private fun CreateMedicationPlanDialog(
     onConfirm: (MedicationPlanInputDto) -> Unit,
     onDismiss: () -> Unit,

--- a/android/app/src/main/java/com/daynest/android/feature/medication/MedicationRoute.kt
+++ b/android/app/src/main/java/com/daynest/android/feature/medication/MedicationRoute.kt
@@ -2,23 +2,331 @@
 
 package com.daynest.android.feature.medication
 
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.daynest.android.R
 import com.daynest.android.app.navigation.DaynestDestination
-import com.daynest.android.app.navigation.DaynestParityRoute
+import com.daynest.android.app.navigation.DaynestNavigationScaffold
+import com.daynest.android.data.medication.MedicationHistoryItemDto
+import com.daynest.android.data.medication.MedicationPlanDto
+import com.daynest.android.data.medication.MedicationPlanInputDto
+import java.time.LocalDate
 
 @Composable
-fun MedicationRoute(onNavigate: (String) -> Unit = {}) {
-    DaynestParityRoute(
+fun MedicationRoute(
+    onNavigate: (String) -> Unit = {},
+    viewModel: MedicationViewModel = hiltViewModel(),
+) {
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    MedicationScreen(uiState = uiState, onEvent = viewModel::onEvent, onNavigate = onNavigate)
+}
+
+@Composable
+private fun MedicationScreen(
+    uiState: MedicationUiState,
+    onEvent: (MedicationUiEvent) -> Unit,
+    onNavigate: (String) -> Unit,
+) {
+    DaynestNavigationScaffold(
         currentRoute = DaynestDestination.MEDICATION,
         onNavigate = onNavigate,
-        titleRes = R.string.medication_title,
-        subtitleRes = R.string.medication_subtitle,
-        capabilityResIds =
-            listOf(
-                R.string.medication_capability_today,
-                R.string.medication_capability_history,
-                R.string.medication_capability_strict,
-            ),
+    ) { innerPadding ->
+        when (uiState) {
+            MedicationUiState.Loading -> {
+                Box(
+                    modifier =
+                        Modifier
+                            .fillMaxSize()
+                            .padding(innerPadding),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    CircularProgressIndicator()
+                }
+            }
+
+            MedicationUiState.Error -> {
+                Column(
+                    modifier =
+                        Modifier
+                            .fillMaxSize()
+                            .padding(innerPadding)
+                            .padding(24.dp),
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                    verticalArrangement = Arrangement.Center,
+                ) {
+                    Text(
+                        text = stringResource(id = R.string.medication_error),
+                        style = MaterialTheme.typography.bodyLarge,
+                    )
+                    Button(
+                        onClick = { onEvent(MedicationUiEvent.RetryClicked) },
+                        modifier = Modifier.padding(top = 16.dp),
+                    ) {
+                        Text(text = stringResource(id = R.string.home_retry))
+                    }
+                }
+            }
+
+            is MedicationUiState.Content -> {
+                MedicationContent(
+                    state = uiState,
+                    onEvent = onEvent,
+                    modifier = Modifier.padding(innerPadding),
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun MedicationContent(
+    state: MedicationUiState.Content,
+    onEvent: (MedicationUiEvent) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    LazyColumn(
+        modifier = modifier.fillMaxSize(),
+        contentPadding = PaddingValues(16.dp),
+        verticalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        item {
+            Text(
+                text = stringResource(id = R.string.medication_title),
+                style = MaterialTheme.typography.headlineMedium,
+            )
+        }
+
+        item {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Text(
+                    text = stringResource(id = R.string.medication_plans_section),
+                    style = MaterialTheme.typography.titleMedium,
+                    modifier = Modifier.weight(1f),
+                )
+                TextButton(onClick = { onEvent(MedicationUiEvent.ShowCreateForm) }) {
+                    Text(text = stringResource(id = R.string.medication_add_plan))
+                }
+            }
+        }
+
+        if (state.plans.isEmpty()) {
+            item {
+                Text(
+                    text = stringResource(id = R.string.medication_no_plans),
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.outline,
+                )
+            }
+        } else {
+            items(state.plans, key = { it.id }) { plan ->
+                MedicationPlanCard(plan = plan)
+            }
+        }
+
+        item {
+            Text(
+                text = stringResource(id = R.string.medication_history_section),
+                style = MaterialTheme.typography.titleMedium,
+                modifier = Modifier.padding(top = 8.dp),
+            )
+        }
+
+        if (state.history.isEmpty()) {
+            item {
+                Text(
+                    text = stringResource(id = R.string.medication_no_history),
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.outline,
+                )
+            }
+        } else {
+            items(state.history, key = { it.medicationDoseInstanceId }) { item ->
+                MedicationHistoryCard(item = item)
+            }
+        }
+    }
+
+    if (state.showCreateForm) {
+        CreateMedicationPlanDialog(
+            onConfirm = { onEvent(MedicationUiEvent.CreatePlanClicked(it)) },
+            onDismiss = { onEvent(MedicationUiEvent.DismissCreateForm) },
+        )
+    }
+}
+
+@Composable
+private fun MedicationPlanCard(plan: MedicationPlanDto) {
+    Card(modifier = Modifier.fillMaxWidth()) {
+        Column(modifier = Modifier.padding(12.dp)) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Text(
+                    text = plan.name,
+                    style = MaterialTheme.typography.bodyMedium,
+                    modifier = Modifier.weight(1f),
+                )
+                if (!plan.isActive) {
+                    Text(
+                        text = stringResource(id = R.string.medication_inactive),
+                        style = MaterialTheme.typography.labelSmall,
+                        color = MaterialTheme.colorScheme.outline,
+                    )
+                }
+            }
+            if (plan.instructions.isNotEmpty()) {
+                Text(
+                    text = plan.instructions,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.outline,
+                )
+            }
+            Text(
+                text =
+                    stringResource(
+                        id = R.string.medication_plan_schedule,
+                        plan.scheduleTime,
+                        plan.everyNDays,
+                    ),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.outline,
+            )
+        }
+    }
+}
+
+@Composable
+private fun MedicationHistoryCard(item: MedicationHistoryItemDto) {
+    Card(modifier = Modifier.fillMaxWidth()) {
+        Row(
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .padding(12.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Column(modifier = Modifier.weight(1f)) {
+                Text(text = item.name, style = MaterialTheme.typography.bodyMedium)
+                if (item.scheduledAt.isNotEmpty()) {
+                    Text(
+                        text = item.scheduledAt,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.outline,
+                    )
+                }
+            }
+            val statusColor =
+                when (item.status) {
+                    "taken" -> MaterialTheme.colorScheme.primary
+                    "skipped" -> MaterialTheme.colorScheme.outline
+                    "missed" -> MaterialTheme.colorScheme.error
+                    else -> MaterialTheme.colorScheme.outline
+                }
+            Text(
+                text = item.status,
+                style = MaterialTheme.typography.labelSmall,
+                color = statusColor,
+            )
+        }
+    }
+}
+
+@Composable
+private fun CreateMedicationPlanDialog(
+    onConfirm: (MedicationPlanInputDto) -> Unit,
+    onDismiss: () -> Unit,
+) {
+    var name by remember { mutableStateOf("") }
+    var instructions by remember { mutableStateOf("") }
+    var scheduleTime by remember { mutableStateOf("08:00") }
+    var everyNDays by remember { mutableStateOf("1") }
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(text = stringResource(id = R.string.medication_create_title)) },
+        text = {
+            Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                OutlinedTextField(
+                    value = name,
+                    onValueChange = { name = it },
+                    label = { Text(text = stringResource(id = R.string.medication_name_label)) },
+                    singleLine = true,
+                )
+                OutlinedTextField(
+                    value = instructions,
+                    onValueChange = { instructions = it },
+                    label = { Text(text = stringResource(id = R.string.medication_instructions_label)) },
+                    singleLine = true,
+                )
+                OutlinedTextField(
+                    value = scheduleTime,
+                    onValueChange = { scheduleTime = it },
+                    label = { Text(text = stringResource(id = R.string.medication_time_label)) },
+                    singleLine = true,
+                )
+                OutlinedTextField(
+                    value = everyNDays,
+                    onValueChange = { everyNDays = it.filter { c -> c.isDigit() } },
+                    label = { Text(text = stringResource(id = R.string.medication_every_n_days_label)) },
+                    singleLine = true,
+                )
+            }
+        },
+        confirmButton = {
+            TextButton(
+                onClick = {
+                    if (name.isNotBlank()) {
+                        onConfirm(
+                            MedicationPlanInputDto(
+                                name = name.trim(),
+                                instructions = instructions.trim(),
+                                startDate = LocalDate.now().toString(),
+                                scheduleTime = scheduleTime.trim().ifBlank { "08:00" },
+                                everyNDays = everyNDays.toIntOrNull() ?: 1,
+                            ),
+                        )
+                    }
+                },
+                enabled = name.isNotBlank(),
+            ) {
+                Text(text = stringResource(id = R.string.action_add))
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) {
+                Text(text = stringResource(id = R.string.action_cancel))
+            }
+        },
     )
 }

--- a/android/app/src/main/java/com/daynest/android/feature/medication/MedicationViewModel.kt
+++ b/android/app/src/main/java/com/daynest/android/feature/medication/MedicationViewModel.kt
@@ -1,0 +1,109 @@
+package com.daynest.android.feature.medication
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.daynest.android.data.medication.MedicationHistoryItemDto
+import com.daynest.android.data.medication.MedicationPlanDto
+import com.daynest.android.data.medication.MedicationPlanInputDto
+import com.daynest.android.data.medication.MedicationRepository
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class MedicationViewModel
+    @Inject
+    constructor(
+        private val repository: MedicationRepository,
+    ) : ViewModel() {
+        private val _uiState = MutableStateFlow<MedicationUiState>(MedicationUiState.Loading)
+        val uiState: StateFlow<MedicationUiState> = _uiState.asStateFlow()
+
+        init {
+            load()
+        }
+
+        fun onEvent(event: MedicationUiEvent) {
+            when (event) {
+                is MedicationUiEvent.RetryClicked -> load()
+                is MedicationUiEvent.CreatePlanClicked -> createPlan(event.input)
+                is MedicationUiEvent.DismissCreateForm -> dismissForm()
+                is MedicationUiEvent.ShowCreateForm -> showForm()
+            }
+        }
+
+        private fun load() {
+            viewModelScope.launch {
+                _uiState.value = MedicationUiState.Loading
+                val plansResult = repository.listPlans()
+                val historyResult = repository.getHistory()
+
+                if (plansResult.isSuccess) {
+                    _uiState.value =
+                        MedicationUiState.Content(
+                            plans = plansResult.getOrElse { emptyList() },
+                            history = historyResult.getOrElse { emptyList() },
+                            showCreateForm = false,
+                        )
+                } else {
+                    _uiState.value = MedicationUiState.Error
+                }
+            }
+        }
+
+        private fun showForm() {
+            _uiState.update { current ->
+                if (current is MedicationUiState.Content) current.copy(showCreateForm = true) else current
+            }
+        }
+
+        private fun dismissForm() {
+            _uiState.update { current ->
+                if (current is MedicationUiState.Content) current.copy(showCreateForm = false) else current
+            }
+        }
+
+        private fun createPlan(input: MedicationPlanInputDto) {
+            viewModelScope.launch {
+                val result = repository.createPlan(input)
+                result.onSuccess { newPlan ->
+                    _uiState.update { current ->
+                        if (current is MedicationUiState.Content) {
+                            current.copy(
+                                plans = current.plans + newPlan,
+                                showCreateForm = false,
+                            )
+                        } else {
+                            current
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+sealed interface MedicationUiState {
+    data object Loading : MedicationUiState
+
+    data class Content(
+        val plans: List<MedicationPlanDto>,
+        val history: List<MedicationHistoryItemDto>,
+        val showCreateForm: Boolean,
+    ) : MedicationUiState
+
+    data object Error : MedicationUiState
+}
+
+sealed interface MedicationUiEvent {
+    data object RetryClicked : MedicationUiEvent
+
+    data object ShowCreateForm : MedicationUiEvent
+
+    data object DismissCreateForm : MedicationUiEvent
+
+    data class CreatePlanClicked(val input: MedicationPlanInputDto) : MedicationUiEvent
+}

--- a/android/app/src/main/java/com/daynest/android/feature/medication/MedicationViewModel.kt
+++ b/android/app/src/main/java/com/daynest/android/feature/medication/MedicationViewModel.kt
@@ -105,5 +105,7 @@ sealed interface MedicationUiEvent {
 
     data object DismissCreateForm : MedicationUiEvent
 
-    data class CreatePlanClicked(val input: MedicationPlanInputDto) : MedicationUiEvent
+    data class CreatePlanClicked(
+        val input: MedicationPlanInputDto,
+    ) : MedicationUiEvent
 }

--- a/android/app/src/main/java/com/daynest/android/feature/settings/SettingsRoute.kt
+++ b/android/app/src/main/java/com/daynest/android/feature/settings/SettingsRoute.kt
@@ -90,6 +90,7 @@ private fun SettingsScreen(
 }
 
 @Composable
+@Suppress("LongMethod")
 private fun SettingsContent(
     state: SettingsUiState.Content,
     onEvent: (SettingsUiEvent) -> Unit,

--- a/android/app/src/main/java/com/daynest/android/feature/settings/SettingsRoute.kt
+++ b/android/app/src/main/java/com/daynest/android/feature/settings/SettingsRoute.kt
@@ -2,23 +2,335 @@
 
 package com.daynest.android.feature.settings
 
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Card
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.daynest.android.R
 import com.daynest.android.app.navigation.DaynestDestination
-import com.daynest.android.app.navigation.DaynestParityRoute
+import com.daynest.android.app.navigation.DaynestNavigationScaffold
+import com.daynest.android.data.settings.IntegrationClientDto
+import com.daynest.android.data.settings.IntegrationClientInputDto
 
 @Composable
-fun SettingsRoute(onNavigate: (String) -> Unit = {}) {
-    DaynestParityRoute(
+fun SettingsRoute(
+    onNavigate: (String) -> Unit = {},
+    onSignedOut: (() -> Unit)? = null,
+    viewModel: SettingsViewModel = hiltViewModel(),
+) {
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+
+    LaunchedEffect(uiState) {
+        if (uiState is SettingsUiState.SignedOut) {
+            onSignedOut?.invoke()
+        }
+    }
+
+    SettingsScreen(uiState = uiState, onEvent = viewModel::onEvent, onNavigate = onNavigate)
+}
+
+@Composable
+private fun SettingsScreen(
+    uiState: SettingsUiState,
+    onEvent: (SettingsUiEvent) -> Unit,
+    onNavigate: (String) -> Unit,
+) {
+    DaynestNavigationScaffold(
         currentRoute = DaynestDestination.SETTINGS,
         onNavigate = onNavigate,
-        titleRes = R.string.settings_title,
-        subtitleRes = R.string.settings_subtitle,
-        capabilityResIds =
-            listOf(
-                R.string.settings_capability_account,
-                R.string.settings_capability_integrations,
-                R.string.settings_capability_clients,
-            ),
+    ) { innerPadding ->
+        when (uiState) {
+            SettingsUiState.Loading, SettingsUiState.SignedOut -> {
+                Box(
+                    modifier =
+                        Modifier
+                            .fillMaxSize()
+                            .padding(innerPadding),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    CircularProgressIndicator()
+                }
+            }
+
+            is SettingsUiState.Content -> {
+                SettingsContent(
+                    state = uiState,
+                    onEvent = onEvent,
+                    modifier = Modifier.padding(innerPadding),
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun SettingsContent(
+    state: SettingsUiState.Content,
+    onEvent: (SettingsUiEvent) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    LazyColumn(
+        modifier = modifier.fillMaxSize(),
+        contentPadding = PaddingValues(16.dp),
+        verticalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        item {
+            Text(
+                text = stringResource(id = R.string.settings_title),
+                style = MaterialTheme.typography.headlineMedium,
+            )
+        }
+
+        item {
+            HorizontalDivider(modifier = Modifier.padding(vertical = 4.dp))
+            Text(
+                text = stringResource(id = R.string.settings_account_section),
+                style = MaterialTheme.typography.titleMedium,
+            )
+        }
+
+        item {
+            Card(modifier = Modifier.fillMaxWidth()) {
+                Row(
+                    modifier =
+                        Modifier
+                            .fillMaxWidth()
+                            .padding(12.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    Text(
+                        text = stringResource(id = R.string.settings_session_active),
+                        style = MaterialTheme.typography.bodyMedium,
+                        modifier = Modifier.weight(1f),
+                    )
+                    TextButton(onClick = { onEvent(SettingsUiEvent.SignOutClicked) }) {
+                        Text(
+                            text = stringResource(id = R.string.settings_sign_out),
+                            color = MaterialTheme.colorScheme.error,
+                        )
+                    }
+                }
+            }
+        }
+
+        item {
+            HorizontalDivider(modifier = Modifier.padding(vertical = 4.dp))
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Text(
+                    text = stringResource(id = R.string.settings_integrations_section),
+                    style = MaterialTheme.typography.titleMedium,
+                    modifier = Modifier.weight(1f),
+                )
+                TextButton(onClick = { onEvent(SettingsUiEvent.ShowCreateClientForm) }) {
+                    Text(text = stringResource(id = R.string.settings_new_client))
+                }
+            }
+        }
+
+        if (state.loadError) {
+            item {
+                Text(
+                    text = stringResource(id = R.string.settings_clients_error),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.error,
+                )
+                TextButton(onClick = { onEvent(SettingsUiEvent.RetryClicked) }) {
+                    Text(text = stringResource(id = R.string.home_retry))
+                }
+            }
+        } else if (state.clients.isEmpty()) {
+            item {
+                Text(
+                    text = stringResource(id = R.string.settings_no_clients),
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.outline,
+                )
+            }
+        } else {
+            items(state.clients, key = { it.id }) { client ->
+                IntegrationClientCard(client = client)
+            }
+        }
+    }
+
+    if (state.showCreateForm) {
+        CreateClientDialog(
+            onConfirm = { onEvent(SettingsUiEvent.CreateClient(it)) },
+            onDismiss = { onEvent(SettingsUiEvent.DismissCreateClientForm) },
+        )
+    }
+
+    if (state.newApiKey != null) {
+        NewApiKeyDialog(
+            apiKey = state.newApiKey,
+            onDismiss = { onEvent(SettingsUiEvent.DismissNewKeyDialog) },
+        )
+    }
+}
+
+@Composable
+private fun IntegrationClientCard(client: IntegrationClientDto) {
+    Card(modifier = Modifier.fillMaxWidth()) {
+        Column(modifier = Modifier.padding(12.dp)) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Text(
+                    text = client.name,
+                    style = MaterialTheme.typography.bodyMedium,
+                    modifier = Modifier.weight(1f),
+                )
+                Text(
+                    text =
+                        if (client.isActive) {
+                            stringResource(id = R.string.settings_client_active)
+                        } else {
+                            stringResource(id = R.string.settings_client_inactive)
+                        },
+                    style = MaterialTheme.typography.labelSmall,
+                    color =
+                        if (client.isActive) {
+                            MaterialTheme.colorScheme.primary
+                        } else {
+                            MaterialTheme.colorScheme.outline
+                        },
+                )
+            }
+            if (client.scopes.isNotEmpty()) {
+                Text(
+                    text = client.scopes.joinToString(", "),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.outline,
+                )
+            }
+            Text(
+                text =
+                    stringResource(
+                        id = R.string.settings_client_rate_limit,
+                        client.rateLimitPerMinute,
+                    ),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.outline,
+            )
+        }
+    }
+}
+
+@Composable
+private fun CreateClientDialog(
+    onConfirm: (IntegrationClientInputDto) -> Unit,
+    onDismiss: () -> Unit,
+) {
+    var name by remember { mutableStateOf("") }
+    var scopes by remember { mutableStateOf("read") }
+    var rateLimit by remember { mutableStateOf("60") }
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(text = stringResource(id = R.string.settings_create_client_title)) },
+        text = {
+            Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                OutlinedTextField(
+                    value = name,
+                    onValueChange = { name = it },
+                    label = { Text(text = stringResource(id = R.string.settings_client_name_label)) },
+                    singleLine = true,
+                )
+                OutlinedTextField(
+                    value = scopes,
+                    onValueChange = { scopes = it },
+                    label = { Text(text = stringResource(id = R.string.settings_client_scopes_label)) },
+                    singleLine = true,
+                )
+                OutlinedTextField(
+                    value = rateLimit,
+                    onValueChange = { rateLimit = it.filter { c -> c.isDigit() } },
+                    label = { Text(text = stringResource(id = R.string.settings_client_rate_limit_label)) },
+                    singleLine = true,
+                )
+            }
+        },
+        confirmButton = {
+            TextButton(
+                onClick = {
+                    if (name.isNotBlank()) {
+                        onConfirm(
+                            IntegrationClientInputDto(
+                                name = name.trim(),
+                                scopes = scopes.split(",").map { it.trim() }.filter { it.isNotBlank() },
+                                rateLimitPerMinute = rateLimit.toIntOrNull() ?: 60,
+                            ),
+                        )
+                    }
+                },
+                enabled = name.isNotBlank(),
+            ) {
+                Text(text = stringResource(id = R.string.action_add))
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) {
+                Text(text = stringResource(id = R.string.action_cancel))
+            }
+        },
+    )
+}
+
+@Composable
+private fun NewApiKeyDialog(
+    apiKey: String,
+    onDismiss: () -> Unit,
+) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(text = stringResource(id = R.string.settings_new_key_title)) },
+        text = {
+            Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                Text(
+                    text = stringResource(id = R.string.settings_new_key_notice),
+                    style = MaterialTheme.typography.bodyMedium,
+                )
+                Text(
+                    text = apiKey,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.primary,
+                )
+            }
+        },
+        confirmButton = {
+            TextButton(onClick = onDismiss) {
+                Text(text = stringResource(id = R.string.settings_new_key_dismiss))
+            }
+        },
     )
 }

--- a/android/app/src/main/java/com/daynest/android/feature/settings/SettingsViewModel.kt
+++ b/android/app/src/main/java/com/daynest/android/feature/settings/SettingsViewModel.kt
@@ -132,5 +132,7 @@ sealed interface SettingsUiEvent {
 
     data object DismissNewKeyDialog : SettingsUiEvent
 
-    data class CreateClient(val input: IntegrationClientInputDto) : SettingsUiEvent
+    data class CreateClient(
+        val input: IntegrationClientInputDto,
+    ) : SettingsUiEvent
 }

--- a/android/app/src/main/java/com/daynest/android/feature/settings/SettingsViewModel.kt
+++ b/android/app/src/main/java/com/daynest/android/feature/settings/SettingsViewModel.kt
@@ -1,0 +1,136 @@
+package com.daynest.android.feature.settings
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.daynest.android.data.auth.AuthRepository
+import com.daynest.android.data.settings.IntegrationClientCreateResponseDto
+import com.daynest.android.data.settings.IntegrationClientDto
+import com.daynest.android.data.settings.IntegrationClientInputDto
+import com.daynest.android.data.settings.SettingsRepository
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class SettingsViewModel
+    @Inject
+    constructor(
+        private val settingsRepository: SettingsRepository,
+        private val authRepository: AuthRepository,
+    ) : ViewModel() {
+        private val _uiState = MutableStateFlow<SettingsUiState>(SettingsUiState.Loading)
+        val uiState: StateFlow<SettingsUiState> = _uiState.asStateFlow()
+
+        init {
+            load()
+        }
+
+        fun onEvent(event: SettingsUiEvent) {
+            when (event) {
+                SettingsUiEvent.RetryClicked -> load()
+                SettingsUiEvent.SignOutClicked -> signOut()
+                SettingsUiEvent.ShowCreateClientForm -> showCreateForm()
+                SettingsUiEvent.DismissCreateClientForm -> dismissCreateForm()
+                SettingsUiEvent.DismissNewKeyDialog -> dismissNewKeyDialog()
+                is SettingsUiEvent.CreateClient -> createClient(event.input)
+            }
+        }
+
+        private fun load() {
+            viewModelScope.launch {
+                _uiState.value = SettingsUiState.Loading
+                val result = settingsRepository.listClients()
+                _uiState.value =
+                    SettingsUiState.Content(
+                        clients = result.getOrElse { emptyList() },
+                        showCreateForm = false,
+                        newApiKey = null,
+                        loadError = result.isFailure,
+                    )
+            }
+        }
+
+        private fun showCreateForm() {
+            _uiState.update { current ->
+                if (current is SettingsUiState.Content) current.copy(showCreateForm = true) else current
+            }
+        }
+
+        private fun dismissCreateForm() {
+            _uiState.update { current ->
+                if (current is SettingsUiState.Content) current.copy(showCreateForm = false) else current
+            }
+        }
+
+        private fun dismissNewKeyDialog() {
+            _uiState.update { current ->
+                if (current is SettingsUiState.Content) current.copy(newApiKey = null) else current
+            }
+        }
+
+        private fun createClient(input: IntegrationClientInputDto) {
+            viewModelScope.launch {
+                val result = settingsRepository.createClient(input)
+                result.onSuccess { created ->
+                    _uiState.update { current ->
+                        if (current is SettingsUiState.Content) {
+                            current.copy(
+                                clients = current.clients + created.toDto(),
+                                showCreateForm = false,
+                                newApiKey = created.apiKey,
+                            )
+                        } else {
+                            current
+                        }
+                    }
+                }
+            }
+        }
+
+        private fun signOut() {
+            viewModelScope.launch {
+                authRepository.signOut()
+                _uiState.value = SettingsUiState.SignedOut
+            }
+        }
+
+        private fun IntegrationClientCreateResponseDto.toDto() =
+            IntegrationClientDto(
+                id = id,
+                name = name,
+                scopes = scopes,
+                rateLimitPerMinute = rateLimitPerMinute,
+                isActive = isActive,
+            )
+    }
+
+sealed interface SettingsUiState {
+    data object Loading : SettingsUiState
+
+    data class Content(
+        val clients: List<IntegrationClientDto>,
+        val showCreateForm: Boolean,
+        val newApiKey: String?,
+        val loadError: Boolean,
+    ) : SettingsUiState
+
+    data object SignedOut : SettingsUiState
+}
+
+sealed interface SettingsUiEvent {
+    data object RetryClicked : SettingsUiEvent
+
+    data object SignOutClicked : SettingsUiEvent
+
+    data object ShowCreateClientForm : SettingsUiEvent
+
+    data object DismissCreateClientForm : SettingsUiEvent
+
+    data object DismissNewKeyDialog : SettingsUiEvent
+
+    data class CreateClient(val input: IntegrationClientInputDto) : SettingsUiEvent
+}

--- a/android/app/src/main/java/com/daynest/android/feature/templates/TemplatesRoute.kt
+++ b/android/app/src/main/java/com/daynest/android/feature/templates/TemplatesRoute.kt
@@ -2,23 +2,458 @@
 
 package com.daynest.android.feature.templates
 
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Card
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.daynest.android.R
 import com.daynest.android.app.navigation.DaynestDestination
-import com.daynest.android.app.navigation.DaynestParityRoute
+import com.daynest.android.app.navigation.DaynestNavigationScaffold
+import com.daynest.android.data.templates.ChoreTemplateDto
+import com.daynest.android.data.templates.ChoreTemplateInputDto
+import com.daynest.android.data.templates.RoutineTemplateDto
+import com.daynest.android.data.templates.RoutineTemplateInputDto
+import java.time.LocalDate
 
 @Composable
-fun TemplatesRoute(onNavigate: (String) -> Unit = {}) {
-    DaynestParityRoute(
+fun TemplatesRoute(
+    onNavigate: (String) -> Unit = {},
+    viewModel: TemplatesViewModel = hiltViewModel(),
+) {
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    TemplatesScreen(uiState = uiState, onEvent = viewModel::onEvent, onNavigate = onNavigate)
+}
+
+@Composable
+private fun TemplatesScreen(
+    uiState: TemplatesUiState,
+    onEvent: (TemplatesUiEvent) -> Unit,
+    onNavigate: (String) -> Unit,
+) {
+    DaynestNavigationScaffold(
         currentRoute = DaynestDestination.TEMPLATES,
         onNavigate = onNavigate,
-        titleRes = R.string.templates_title,
-        subtitleRes = R.string.templates_subtitle,
-        capabilityResIds =
-            listOf(
-                R.string.templates_capability_routines,
-                R.string.templates_capability_chores,
-                R.string.templates_capability_recurring,
-            ),
+    ) { innerPadding ->
+        when (uiState) {
+            TemplatesUiState.Loading -> {
+                Box(
+                    modifier =
+                        Modifier
+                            .fillMaxSize()
+                            .padding(innerPadding),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    CircularProgressIndicator()
+                }
+            }
+
+            TemplatesUiState.Error -> {
+                Column(
+                    modifier =
+                        Modifier
+                            .fillMaxSize()
+                            .padding(innerPadding)
+                            .padding(24.dp),
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                    verticalArrangement = Arrangement.Center,
+                ) {
+                    Text(
+                        text = stringResource(id = R.string.templates_error),
+                        style = MaterialTheme.typography.bodyLarge,
+                    )
+                    Button(
+                        onClick = { onEvent(TemplatesUiEvent.RetryClicked) },
+                        modifier = Modifier.padding(top = 16.dp),
+                    ) {
+                        Text(text = stringResource(id = R.string.home_retry))
+                    }
+                }
+            }
+
+            is TemplatesUiState.Content -> {
+                TemplatesContent(
+                    state = uiState,
+                    onEvent = onEvent,
+                    modifier = Modifier.padding(innerPadding),
+                )
+            }
+        }
+    }
+}
+
+@Composable
+@Suppress("LongMethod", "CyclomaticComplexMethod")
+private fun TemplatesContent(
+    state: TemplatesUiState.Content,
+    onEvent: (TemplatesUiEvent) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    LazyColumn(
+        modifier = modifier.fillMaxSize(),
+        contentPadding = PaddingValues(16.dp),
+        verticalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        item {
+            Text(
+                text = stringResource(id = R.string.templates_title),
+                style = MaterialTheme.typography.headlineMedium,
+            )
+        }
+
+        item {
+            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                FilterChip(
+                    selected = state.selectedTab == TemplateTab.Routines,
+                    onClick = { onEvent(TemplatesUiEvent.TabSelected(TemplateTab.Routines)) },
+                    label = { Text(text = stringResource(id = R.string.templates_tab_routines)) },
+                )
+                FilterChip(
+                    selected = state.selectedTab == TemplateTab.Chores,
+                    onClick = { onEvent(TemplatesUiEvent.TabSelected(TemplateTab.Chores)) },
+                    label = { Text(text = stringResource(id = R.string.templates_tab_chores)) },
+                )
+            }
+        }
+
+        when (state.selectedTab) {
+            TemplateTab.Routines -> {
+                item {
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        Text(
+                            text = stringResource(id = R.string.templates_tab_routines),
+                            style = MaterialTheme.typography.titleMedium,
+                            modifier = Modifier.weight(1f),
+                        )
+                        TextButton(onClick = { onEvent(TemplatesUiEvent.ShowCreateRoutineForm) }) {
+                            Text(text = stringResource(id = R.string.templates_add_routine))
+                        }
+                    }
+                }
+                if (state.routines.isEmpty()) {
+                    item {
+                        Text(
+                            text = stringResource(id = R.string.templates_no_routines),
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = MaterialTheme.colorScheme.outline,
+                        )
+                    }
+                } else {
+                    items(state.routines, key = { "routine_${it.id}" }) { routine ->
+                        RoutineTemplateCard(
+                            routine = routine,
+                            onDelete = { onEvent(TemplatesUiEvent.DeleteRoutine(routine.id)) },
+                        )
+                    }
+                }
+            }
+
+            TemplateTab.Chores -> {
+                item {
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        Text(
+                            text = stringResource(id = R.string.templates_tab_chores),
+                            style = MaterialTheme.typography.titleMedium,
+                            modifier = Modifier.weight(1f),
+                        )
+                        TextButton(onClick = { onEvent(TemplatesUiEvent.ShowCreateChoreForm) }) {
+                            Text(text = stringResource(id = R.string.templates_add_chore))
+                        }
+                    }
+                }
+                if (state.chores.isEmpty()) {
+                    item {
+                        Text(
+                            text = stringResource(id = R.string.templates_no_chores),
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = MaterialTheme.colorScheme.outline,
+                        )
+                    }
+                } else {
+                    items(state.chores, key = { "chore_${it.id}" }) { chore ->
+                        ChoreTemplateCard(
+                            chore = chore,
+                            onDelete = { onEvent(TemplatesUiEvent.DeleteChore(chore.id)) },
+                        )
+                    }
+                }
+            }
+        }
+    }
+
+    when (state.createForm) {
+        TemplateCreateForm.Routine ->
+            CreateRoutineDialog(
+                onConfirm = { onEvent(TemplatesUiEvent.CreateRoutine(it)) },
+                onDismiss = { onEvent(TemplatesUiEvent.DismissCreateForm) },
+            )
+
+        TemplateCreateForm.Chore ->
+            CreateChoreDialog(
+                onConfirm = { onEvent(TemplatesUiEvent.CreateChore(it)) },
+                onDismiss = { onEvent(TemplatesUiEvent.DismissCreateForm) },
+            )
+
+        null -> Unit
+    }
+}
+
+@Composable
+private fun RoutineTemplateCard(
+    routine: RoutineTemplateDto,
+    onDelete: () -> Unit,
+) {
+    Card(modifier = Modifier.fillMaxWidth()) {
+        Row(
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .padding(12.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Column(modifier = Modifier.weight(1f)) {
+                Text(text = routine.name, style = MaterialTheme.typography.bodyMedium)
+                if (!routine.description.isNullOrBlank()) {
+                    Text(
+                        text = routine.description,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.outline,
+                    )
+                }
+                Text(
+                    text =
+                        stringResource(
+                            id = R.string.templates_every_n_days,
+                            routine.everyNDays,
+                        ),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.outline,
+                )
+                if (!routine.isActive) {
+                    Text(
+                        text = stringResource(id = R.string.templates_inactive),
+                        style = MaterialTheme.typography.labelSmall,
+                        color = MaterialTheme.colorScheme.outline,
+                    )
+                }
+            }
+            TextButton(
+                onClick = onDelete,
+                colors =
+                    ButtonDefaults.textButtonColors(
+                        contentColor = MaterialTheme.colorScheme.error,
+                    ),
+            ) {
+                Text(text = stringResource(id = R.string.action_delete))
+            }
+        }
+    }
+}
+
+@Composable
+private fun ChoreTemplateCard(
+    chore: ChoreTemplateDto,
+    onDelete: () -> Unit,
+) {
+    Card(modifier = Modifier.fillMaxWidth()) {
+        Row(
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .padding(12.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Column(modifier = Modifier.weight(1f)) {
+                Text(text = chore.name, style = MaterialTheme.typography.bodyMedium)
+                if (!chore.description.isNullOrBlank()) {
+                    Text(
+                        text = chore.description,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.outline,
+                    )
+                }
+                Text(
+                    text =
+                        stringResource(
+                            id = R.string.templates_every_n_days,
+                            chore.everyNDays,
+                        ),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.outline,
+                )
+                if (!chore.isActive) {
+                    Text(
+                        text = stringResource(id = R.string.templates_inactive),
+                        style = MaterialTheme.typography.labelSmall,
+                        color = MaterialTheme.colorScheme.outline,
+                    )
+                }
+            }
+            TextButton(
+                onClick = onDelete,
+                colors =
+                    ButtonDefaults.textButtonColors(
+                        contentColor = MaterialTheme.colorScheme.error,
+                    ),
+            ) {
+                Text(text = stringResource(id = R.string.action_delete))
+            }
+        }
+    }
+}
+
+@Composable
+private fun CreateRoutineDialog(
+    onConfirm: (RoutineTemplateInputDto) -> Unit,
+    onDismiss: () -> Unit,
+) {
+    var name by remember { mutableStateOf("") }
+    var description by remember { mutableStateOf("") }
+    var everyNDays by remember { mutableStateOf("1") }
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(text = stringResource(id = R.string.templates_create_routine_title)) },
+        text = {
+            Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                OutlinedTextField(
+                    value = name,
+                    onValueChange = { name = it },
+                    label = { Text(text = stringResource(id = R.string.templates_name_label)) },
+                    singleLine = true,
+                )
+                OutlinedTextField(
+                    value = description,
+                    onValueChange = { description = it },
+                    label = { Text(text = stringResource(id = R.string.templates_description_label)) },
+                    singleLine = true,
+                )
+                OutlinedTextField(
+                    value = everyNDays,
+                    onValueChange = { everyNDays = it.filter { c -> c.isDigit() } },
+                    label = { Text(text = stringResource(id = R.string.templates_every_n_days_label)) },
+                    singleLine = true,
+                )
+            }
+        },
+        confirmButton = {
+            TextButton(
+                onClick = {
+                    if (name.isNotBlank()) {
+                        onConfirm(
+                            RoutineTemplateInputDto(
+                                name = name.trim(),
+                                description = description.trim().ifBlank { null },
+                                startDate = LocalDate.now().toString(),
+                                everyNDays = everyNDays.toIntOrNull() ?: 1,
+                                isActive = true,
+                            ),
+                        )
+                    }
+                },
+                enabled = name.isNotBlank(),
+            ) {
+                Text(text = stringResource(id = R.string.action_add))
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) {
+                Text(text = stringResource(id = R.string.action_cancel))
+            }
+        },
+    )
+}
+
+@Composable
+private fun CreateChoreDialog(
+    onConfirm: (ChoreTemplateInputDto) -> Unit,
+    onDismiss: () -> Unit,
+) {
+    var name by remember { mutableStateOf("") }
+    var description by remember { mutableStateOf("") }
+    var everyNDays by remember { mutableStateOf("7") }
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(text = stringResource(id = R.string.templates_create_chore_title)) },
+        text = {
+            Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                OutlinedTextField(
+                    value = name,
+                    onValueChange = { name = it },
+                    label = { Text(text = stringResource(id = R.string.templates_name_label)) },
+                    singleLine = true,
+                )
+                OutlinedTextField(
+                    value = description,
+                    onValueChange = { description = it },
+                    label = { Text(text = stringResource(id = R.string.templates_description_label)) },
+                    singleLine = true,
+                )
+                OutlinedTextField(
+                    value = everyNDays,
+                    onValueChange = { everyNDays = it.filter { c -> c.isDigit() } },
+                    label = { Text(text = stringResource(id = R.string.templates_every_n_days_label)) },
+                    singleLine = true,
+                )
+            }
+        },
+        confirmButton = {
+            TextButton(
+                onClick = {
+                    if (name.isNotBlank()) {
+                        onConfirm(
+                            ChoreTemplateInputDto(
+                                name = name.trim(),
+                                description = description.trim().ifBlank { null },
+                                startDate = LocalDate.now().toString(),
+                                everyNDays = everyNDays.toIntOrNull() ?: 7,
+                                isActive = true,
+                            ),
+                        )
+                    }
+                },
+                enabled = name.isNotBlank(),
+            ) {
+                Text(text = stringResource(id = R.string.action_add))
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) {
+                Text(text = stringResource(id = R.string.action_cancel))
+            }
+        },
     )
 }

--- a/android/app/src/main/java/com/daynest/android/feature/templates/TemplatesViewModel.kt
+++ b/android/app/src/main/java/com/daynest/android/feature/templates/TemplatesViewModel.kt
@@ -154,7 +154,9 @@ sealed interface TemplatesUiState {
 sealed interface TemplatesUiEvent {
     data object RetryClicked : TemplatesUiEvent
 
-    data class TabSelected(val tab: TemplateTab) : TemplatesUiEvent
+    data class TabSelected(
+        val tab: TemplateTab,
+    ) : TemplatesUiEvent
 
     data object ShowCreateRoutineForm : TemplatesUiEvent
 
@@ -162,11 +164,19 @@ sealed interface TemplatesUiEvent {
 
     data object DismissCreateForm : TemplatesUiEvent
 
-    data class CreateRoutine(val input: RoutineTemplateInputDto) : TemplatesUiEvent
+    data class CreateRoutine(
+        val input: RoutineTemplateInputDto,
+    ) : TemplatesUiEvent
 
-    data class CreateChore(val input: ChoreTemplateInputDto) : TemplatesUiEvent
+    data class CreateChore(
+        val input: ChoreTemplateInputDto,
+    ) : TemplatesUiEvent
 
-    data class DeleteRoutine(val id: Int) : TemplatesUiEvent
+    data class DeleteRoutine(
+        val id: Int,
+    ) : TemplatesUiEvent
 
-    data class DeleteChore(val id: Int) : TemplatesUiEvent
+    data class DeleteChore(
+        val id: Int,
+    ) : TemplatesUiEvent
 }

--- a/android/app/src/main/java/com/daynest/android/feature/templates/TemplatesViewModel.kt
+++ b/android/app/src/main/java/com/daynest/android/feature/templates/TemplatesViewModel.kt
@@ -1,0 +1,172 @@
+package com.daynest.android.feature.templates
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.daynest.android.data.templates.ChoreTemplateDto
+import com.daynest.android.data.templates.ChoreTemplateInputDto
+import com.daynest.android.data.templates.RoutineTemplateDto
+import com.daynest.android.data.templates.RoutineTemplateInputDto
+import com.daynest.android.data.templates.TemplatesRepository
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class TemplatesViewModel
+    @Inject
+    constructor(
+        private val repository: TemplatesRepository,
+    ) : ViewModel() {
+        private val _uiState = MutableStateFlow<TemplatesUiState>(TemplatesUiState.Loading)
+        val uiState: StateFlow<TemplatesUiState> = _uiState.asStateFlow()
+
+        init {
+            load()
+        }
+
+        fun onEvent(event: TemplatesUiEvent) {
+            when (event) {
+                TemplatesUiEvent.RetryClicked -> load()
+                is TemplatesUiEvent.TabSelected -> setTab(event.tab)
+                TemplatesUiEvent.ShowCreateRoutineForm -> setCreateForm(TemplateCreateForm.Routine)
+                TemplatesUiEvent.ShowCreateChoreForm -> setCreateForm(TemplateCreateForm.Chore)
+                TemplatesUiEvent.DismissCreateForm -> setCreateForm(null)
+                is TemplatesUiEvent.CreateRoutine -> createRoutine(event.input)
+                is TemplatesUiEvent.CreateChore -> createChore(event.input)
+                is TemplatesUiEvent.DeleteRoutine -> deleteRoutine(event.id)
+                is TemplatesUiEvent.DeleteChore -> deleteChore(event.id)
+            }
+        }
+
+        private fun load() {
+            viewModelScope.launch {
+                _uiState.value = TemplatesUiState.Loading
+                val routinesResult = repository.listRoutines()
+                val choresResult = repository.listChores()
+                if (routinesResult.isSuccess || choresResult.isSuccess) {
+                    _uiState.value =
+                        TemplatesUiState.Content(
+                            routines = routinesResult.getOrElse { emptyList() },
+                            chores = choresResult.getOrElse { emptyList() },
+                            selectedTab = TemplateTab.Routines,
+                            createForm = null,
+                        )
+                } else {
+                    _uiState.value = TemplatesUiState.Error
+                }
+            }
+        }
+
+        private fun setTab(tab: TemplateTab) {
+            _uiState.update { current ->
+                if (current is TemplatesUiState.Content) current.copy(selectedTab = tab) else current
+            }
+        }
+
+        private fun setCreateForm(form: TemplateCreateForm?) {
+            _uiState.update { current ->
+                if (current is TemplatesUiState.Content) current.copy(createForm = form) else current
+            }
+        }
+
+        private fun createRoutine(input: RoutineTemplateInputDto) {
+            viewModelScope.launch {
+                val result = repository.createRoutine(input)
+                result.onSuccess { newRoutine ->
+                    _uiState.update { current ->
+                        if (current is TemplatesUiState.Content) {
+                            current.copy(routines = current.routines + newRoutine, createForm = null)
+                        } else {
+                            current
+                        }
+                    }
+                }
+            }
+        }
+
+        private fun createChore(input: ChoreTemplateInputDto) {
+            viewModelScope.launch {
+                val result = repository.createChore(input)
+                result.onSuccess { newChore ->
+                    _uiState.update { current ->
+                        if (current is TemplatesUiState.Content) {
+                            current.copy(chores = current.chores + newChore, createForm = null)
+                        } else {
+                            current
+                        }
+                    }
+                }
+            }
+        }
+
+        private fun deleteRoutine(id: Int) {
+            viewModelScope.launch {
+                val result = repository.deleteRoutine(id)
+                if (result.isSuccess) {
+                    _uiState.update { current ->
+                        if (current is TemplatesUiState.Content) {
+                            current.copy(routines = current.routines.filter { it.id != id })
+                        } else {
+                            current
+                        }
+                    }
+                }
+            }
+        }
+
+        private fun deleteChore(id: Int) {
+            viewModelScope.launch {
+                val result = repository.deleteChore(id)
+                if (result.isSuccess) {
+                    _uiState.update { current ->
+                        if (current is TemplatesUiState.Content) {
+                            current.copy(chores = current.chores.filter { it.id != id })
+                        } else {
+                            current
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+enum class TemplateTab { Routines, Chores }
+
+enum class TemplateCreateForm { Routine, Chore }
+
+sealed interface TemplatesUiState {
+    data object Loading : TemplatesUiState
+
+    data class Content(
+        val routines: List<RoutineTemplateDto>,
+        val chores: List<ChoreTemplateDto>,
+        val selectedTab: TemplateTab,
+        val createForm: TemplateCreateForm?,
+    ) : TemplatesUiState
+
+    data object Error : TemplatesUiState
+}
+
+sealed interface TemplatesUiEvent {
+    data object RetryClicked : TemplatesUiEvent
+
+    data class TabSelected(val tab: TemplateTab) : TemplatesUiEvent
+
+    data object ShowCreateRoutineForm : TemplatesUiEvent
+
+    data object ShowCreateChoreForm : TemplatesUiEvent
+
+    data object DismissCreateForm : TemplatesUiEvent
+
+    data class CreateRoutine(val input: RoutineTemplateInputDto) : TemplatesUiEvent
+
+    data class CreateChore(val input: ChoreTemplateInputDto) : TemplatesUiEvent
+
+    data class DeleteRoutine(val id: Int) : TemplatesUiEvent
+
+    data class DeleteChore(val id: Int) : TemplatesUiEvent
+}

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -45,6 +45,7 @@
     <string name="calendar_error">Unable to load calendar data.</string>
     <string name="calendar_prev_month">Previous month</string>
     <string name="calendar_next_month">Next month</string>
+    <string name="calendar_month_year">%1$s %2$s</string>
     <string name="calendar_day_detail_header">%1$s</string>
     <string name="calendar_day_empty">No items for this day.</string>
     <string name="calendar_add_planned">+ Add planned</string>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -1,10 +1,13 @@
 <resources>
     <string name="app_name">Daynest</string>
-    <string name="home_welcome">Welcome to Daynest</string>
+    <string name="home_welcome">Today</string>
     <string name="home_action_plan_today">Plan today</string>
     <string name="home_action_caught_up">You\'re all caught up</string>
     <string name="home_retry">Retry</string>
     <string name="home_error_generic">Unable to load today data.</string>
+    <string name="home_stale_notice">Showing cached data.</string>
+    <string name="home_all_caught_up">You\'re all caught up for today.</string>
+    <string name="home_items_remaining_label">%1$d item(s) remaining</string>
 
     <string name="auth_title">Sign in to Daynest</string>
     <string name="auth_email_label">Email</string>
@@ -13,30 +16,105 @@
     <string name="auth_error_missing_credentials">Enter both email and password.</string>
     <string name="auth_error_sign_in_failed">Unable to sign in. Please try again.</string>
 
+    <!-- Today screen sections -->
+    <string name="today_section_medication">Medication</string>
+    <string name="today_section_medication_history">Medication History</string>
+    <string name="today_section_routines">Routines</string>
+    <string name="today_section_overdue">Overdue</string>
+    <string name="today_section_due_today">Due Today</string>
+    <string name="today_section_upcoming">Upcoming</string>
+    <string name="today_section_planned">Planned</string>
+    <string name="today_overdue_since">Overdue since %1$s</string>
+
+    <!-- Common actions -->
+    <string name="action_done">Done</string>
+    <string name="action_undo">Undo</string>
+    <string name="action_skip">Skip</string>
+    <string name="action_take">Take</string>
+    <string name="action_delete">Delete</string>
+    <string name="action_add">Add</string>
+    <string name="action_cancel">Cancel</string>
+
+    <!-- Calendar -->
     <string name="calendar_title">Calendar</string>
     <string name="calendar_subtitle">Month and day planning, matching the web calendar workspace.</string>
     <string name="calendar_capability_month">Review month-level counts for routines, chores, medication, and planned items.</string>
     <string name="calendar_capability_day">Open a day detail view that keeps completed, pending, and overdue work visible.</string>
     <string name="calendar_capability_planned">Create and organize planned items with optional notes and module metadata.</string>
     <string name="calendar_capability_backup">Export and import planned-item backups from the same product surface.</string>
+    <string name="calendar_error">Unable to load calendar data.</string>
+    <string name="calendar_prev_month">Previous month</string>
+    <string name="calendar_next_month">Next month</string>
+    <string name="calendar_day_detail_header">%1$s</string>
+    <string name="calendar_day_empty">No items for this day.</string>
+    <string name="calendar_add_planned">+ Add planned</string>
+    <string name="calendar_add_planned_title">Add planned item</string>
+    <string name="calendar_planned_title_label">Title</string>
 
+    <!-- Medication -->
     <string name="medication_title">Medication</string>
     <string name="medication_subtitle">Medication planning and dose tracking are available from native navigation.</string>
     <string name="medication_capability_today">Track today\'s scheduled medication doses alongside the Today checklist.</string>
     <string name="medication_capability_history">Review dose history statuses such as taken, skipped, and missed.</string>
     <string name="medication_capability_strict">Keep medication modeled separately from routine chores for safer reminders.</string>
+    <string name="medication_error">Unable to load medication data.</string>
+    <string name="medication_plans_section">Plans</string>
+    <string name="medication_history_section">History</string>
+    <string name="medication_no_plans">No medication plans yet.</string>
+    <string name="medication_no_history">No dose history yet.</string>
+    <string name="medication_inactive">Inactive</string>
+    <string name="medication_add_plan">+ Add plan</string>
+    <string name="medication_create_title">Add medication plan</string>
+    <string name="medication_name_label">Name</string>
+    <string name="medication_instructions_label">Instructions</string>
+    <string name="medication_time_label">Schedule time (HH:MM)</string>
+    <string name="medication_every_n_days_label">Every N days</string>
+    <string name="medication_plan_schedule">%1$s · every %2$d day(s)</string>
 
+    <!-- Templates -->
     <string name="templates_title">Templates</string>
     <string name="templates_subtitle">Reusable routine and chore setup now has a native destination.</string>
     <string name="templates_capability_routines">Manage routine templates that generate daily task instances.</string>
     <string name="templates_capability_chores">Manage chore templates for recurring household work.</string>
     <string name="templates_capability_recurring">Keep recurrence understandable while supporting repeating work.</string>
+    <string name="templates_error">Unable to load templates.</string>
+    <string name="templates_tab_routines">Routines</string>
+    <string name="templates_tab_chores">Chores</string>
+    <string name="templates_no_routines">No routine templates yet.</string>
+    <string name="templates_no_chores">No chore templates yet.</string>
+    <string name="templates_add_routine">+ Add routine</string>
+    <string name="templates_add_chore">+ Add chore</string>
+    <string name="templates_create_routine_title">Add routine template</string>
+    <string name="templates_create_chore_title">Add chore template</string>
+    <string name="templates_name_label">Name</string>
+    <string name="templates_description_label">Description (optional)</string>
+    <string name="templates_every_n_days_label">Every N days</string>
+    <string name="templates_every_n_days">Every %1$d day(s)</string>
+    <string name="templates_inactive">Inactive</string>
 
+    <!-- Settings -->
     <string name="settings_title">Settings</string>
     <string name="settings_subtitle">Account and integration controls are represented across platforms.</string>
     <string name="settings_capability_account">Review account session state and future profile preferences.</string>
     <string name="settings_capability_integrations">Connect integration surfaces such as Home Assistant and MCP clients.</string>
     <string name="settings_capability_clients">Prepare integration clients with scoped access from one settings area.</string>
+    <string name="settings_account_section">Account</string>
+    <string name="settings_session_active">Signed in</string>
+    <string name="settings_sign_out">Sign out</string>
+    <string name="settings_integrations_section">Integration Clients</string>
+    <string name="settings_new_client">+ New client</string>
+    <string name="settings_no_clients">No integration clients configured.</string>
+    <string name="settings_clients_error">Unable to load integration clients.</string>
+    <string name="settings_client_active">Active</string>
+    <string name="settings_client_inactive">Inactive</string>
+    <string name="settings_client_rate_limit">%1$d req/min</string>
+    <string name="settings_create_client_title">New integration client</string>
+    <string name="settings_client_name_label">Name</string>
+    <string name="settings_client_scopes_label">Scopes (comma-separated)</string>
+    <string name="settings_client_rate_limit_label">Rate limit (per minute)</string>
+    <string name="settings_new_key_title">API Key Created</string>
+    <string name="settings_new_key_notice">Copy this key now — it will not be shown again.</string>
+    <string name="settings_new_key_dismiss">I\'ve copied it</string>
 
     <string name="parity_more_coming">Native editing controls will continue to grow from the same shared API contracts.</string>
 

--- a/android/app/src/test/java/com/daynest/android/data/today/TodayRepositoryTest.kt
+++ b/android/app/src/test/java/com/daynest/android/data/today/TodayRepositoryTest.kt
@@ -36,7 +36,7 @@ class TodayRepositoryTest {
                         ),
                     )
                 }
-            val repository = TodayRepository(todayApi = api, todaySummaryDao = dao)
+            val repository = TodayRepository(todayApi = api, todayActionsApi = StubTodayActionsApi(), todaySummaryDao = dao)
 
             repository.observeTodaySummary().test {
                 assertNull(awaitItem())
@@ -76,7 +76,7 @@ class TodayRepositoryTest {
                 FakeTodayApi().apply {
                     enqueueError(RuntimeException("network unavailable"))
                 }
-            val repository = TodayRepository(todayApi = api, todaySummaryDao = dao)
+            val repository = TodayRepository(todayApi = api, todayActionsApi = StubTodayActionsApi(), todaySummaryDao = dao)
 
             repository.observeTodaySummary().test {
                 val cached = awaitItem()
@@ -99,7 +99,7 @@ class TodayRepositoryTest {
                 FakeTodayApi().apply {
                     enqueueError(RuntimeException("no connection"))
                 }
-            val repository = TodayRepository(todayApi = api, todaySummaryDao = dao)
+            val repository = TodayRepository(todayApi = api, todayActionsApi = StubTodayActionsApi(), todaySummaryDao = dao)
 
             repository.observeTodaySummary().test {
                 assertNull(awaitItem())
@@ -158,4 +158,30 @@ private sealed interface FakeApiResponse {
     data class Error(
         val error: Throwable,
     ) : FakeApiResponse
+}
+
+private class StubTodayActionsApi : TodayActionsApi {
+    override suspend fun completeChore(id: Int): ChoreMutationDto = ChoreMutationDto(id, "completed")
+
+    override suspend fun skipChore(id: Int): ChoreMutationDto = ChoreMutationDto(id, "skipped")
+
+    override suspend fun completeTask(id: Int): TaskMutationDto = TaskMutationDto(id, "completed")
+
+    override suspend fun skipTask(id: Int): TaskMutationDto = TaskMutationDto(id, "skipped")
+
+    override suspend fun startTask(id: Int): TaskMutationDto = TaskMutationDto(id, "in_progress")
+
+    override suspend fun takeDose(id: Int): DoseMutationDto = DoseMutationDto(id, "taken")
+
+    override suspend fun skipDose(id: Int): DoseMutationDto = DoseMutationDto(id, "skipped")
+
+    override suspend fun updatePlannedItem(
+        id: Int,
+        request: PlannedItemUpdateDto,
+    ): PlannedTodayItemDto = PlannedTodayItemDto(id, request.title, request.isDone)
+
+    override suspend fun deletePlannedItem(id: Int) = Unit
+
+    override suspend fun createPlannedItem(request: PlannedItemCreateDto): PlannedTodayItemDto =
+        PlannedTodayItemDto(0, request.title, false)
 }

--- a/android/app/src/test/java/com/daynest/android/data/today/TodayRepositoryTest.kt
+++ b/android/app/src/test/java/com/daynest/android/data/today/TodayRepositoryTest.kt
@@ -36,11 +36,12 @@ class TodayRepositoryTest {
                         ),
                     )
                 }
-            val repository = TodayRepository(
-                todayApi = api,
-                todayActionsApi = StubTodayActionsApi(),
-                todaySummaryDao = dao,
-            )
+            val repository =
+                TodayRepository(
+                    todayApi = api,
+                    todayActionsApi = StubTodayActionsApi(),
+                    todaySummaryDao = dao,
+                )
 
             repository.observeTodaySummary().test {
                 assertNull(awaitItem())
@@ -80,11 +81,12 @@ class TodayRepositoryTest {
                 FakeTodayApi().apply {
                     enqueueError(RuntimeException("network unavailable"))
                 }
-            val repository = TodayRepository(
-                todayApi = api,
-                todayActionsApi = StubTodayActionsApi(),
-                todaySummaryDao = dao,
-            )
+            val repository =
+                TodayRepository(
+                    todayApi = api,
+                    todayActionsApi = StubTodayActionsApi(),
+                    todaySummaryDao = dao,
+                )
 
             repository.observeTodaySummary().test {
                 val cached = awaitItem()
@@ -107,11 +109,12 @@ class TodayRepositoryTest {
                 FakeTodayApi().apply {
                     enqueueError(RuntimeException("no connection"))
                 }
-            val repository = TodayRepository(
-                todayApi = api,
-                todayActionsApi = StubTodayActionsApi(),
-                todaySummaryDao = dao,
-            )
+            val repository =
+                TodayRepository(
+                    todayApi = api,
+                    todayActionsApi = StubTodayActionsApi(),
+                    todaySummaryDao = dao,
+                )
 
             repository.observeTodaySummary().test {
                 assertNull(awaitItem())

--- a/android/app/src/test/java/com/daynest/android/data/today/TodayRepositoryTest.kt
+++ b/android/app/src/test/java/com/daynest/android/data/today/TodayRepositoryTest.kt
@@ -36,7 +36,11 @@ class TodayRepositoryTest {
                         ),
                     )
                 }
-            val repository = TodayRepository(todayApi = api, todayActionsApi = StubTodayActionsApi(), todaySummaryDao = dao)
+            val repository = TodayRepository(
+                todayApi = api,
+                todayActionsApi = StubTodayActionsApi(),
+                todaySummaryDao = dao,
+            )
 
             repository.observeTodaySummary().test {
                 assertNull(awaitItem())
@@ -76,7 +80,11 @@ class TodayRepositoryTest {
                 FakeTodayApi().apply {
                     enqueueError(RuntimeException("network unavailable"))
                 }
-            val repository = TodayRepository(todayApi = api, todayActionsApi = StubTodayActionsApi(), todaySummaryDao = dao)
+            val repository = TodayRepository(
+                todayApi = api,
+                todayActionsApi = StubTodayActionsApi(),
+                todaySummaryDao = dao,
+            )
 
             repository.observeTodaySummary().test {
                 val cached = awaitItem()
@@ -99,7 +107,11 @@ class TodayRepositoryTest {
                 FakeTodayApi().apply {
                     enqueueError(RuntimeException("no connection"))
                 }
-            val repository = TodayRepository(todayApi = api, todayActionsApi = StubTodayActionsApi(), todaySummaryDao = dao)
+            val repository = TodayRepository(
+                todayApi = api,
+                todayActionsApi = StubTodayActionsApi(),
+                todaySummaryDao = dao,
+            )
 
             repository.observeTodaySummary().test {
                 assertNull(awaitItem())

--- a/android/app/src/test/java/com/daynest/android/feature/home/HomeViewModelTest.kt
+++ b/android/app/src/test/java/com/daynest/android/feature/home/HomeViewModelTest.kt
@@ -2,16 +2,16 @@ package com.daynest.android.feature.home
 
 import com.daynest.android.core.database.today.TodaySummaryDao
 import com.daynest.android.core.database.today.TodaySummaryEntity
+import com.daynest.android.data.today.ChoreMutationDto
+import com.daynest.android.data.today.DoseMutationDto
 import com.daynest.android.data.today.DueTodayItemDto
 import com.daynest.android.data.today.MedicationHistoryItemDto
 import com.daynest.android.data.today.MedicationTodayItemDto
 import com.daynest.android.data.today.OverdueTodayItemDto
-import com.daynest.android.data.today.PlannedTodayItemDto
-import com.daynest.android.data.today.RoutineTodayItemDto
-import com.daynest.android.data.today.ChoreMutationDto
-import com.daynest.android.data.today.DoseMutationDto
 import com.daynest.android.data.today.PlannedItemCreateDto
 import com.daynest.android.data.today.PlannedItemUpdateDto
+import com.daynest.android.data.today.PlannedTodayItemDto
+import com.daynest.android.data.today.RoutineTodayItemDto
 import com.daynest.android.data.today.TaskMutationDto
 import com.daynest.android.data.today.TodayActionsApi
 import com.daynest.android.data.today.TodayApi

--- a/android/app/src/test/java/com/daynest/android/feature/home/HomeViewModelTest.kt
+++ b/android/app/src/test/java/com/daynest/android/feature/home/HomeViewModelTest.kt
@@ -111,7 +111,11 @@ class HomeViewModelTest {
                     enqueueError(IllegalStateException("initial load failure"))
                     enqueueSuccess(todayResponse(), gate = loadGate)
                 }
-            val repository = TodayRepository(todayApi = api, todayActionsApi = StubTodayActionsApi(), todaySummaryDao = FakeTodaySummaryDao())
+            val repository = TodayRepository(
+                todayApi = api,
+                todayActionsApi = StubTodayActionsApi(),
+                todaySummaryDao = FakeTodaySummaryDao(),
+            )
             val viewModel = HomeViewModel(repository = repository)
 
             advanceUntilIdle()
@@ -137,7 +141,13 @@ class HomeViewModelTest {
                     enqueueSuccess(todayResponse())
                     enqueueError(IllegalStateException("network gone"))
                 }
-            val viewModel = HomeViewModel(repository = TodayRepository(todayApi = api, todayActionsApi = StubTodayActionsApi(), todaySummaryDao = dao))
+            val viewModel = HomeViewModel(
+                repository = TodayRepository(
+                    todayApi = api,
+                    todayActionsApi = StubTodayActionsApi(),
+                    todaySummaryDao = dao,
+                ),
+            )
 
             advanceUntilIdle()
             assertTrue(viewModel.uiState.value is HomeUiState.Content)

--- a/android/app/src/test/java/com/daynest/android/feature/home/HomeViewModelTest.kt
+++ b/android/app/src/test/java/com/daynest/android/feature/home/HomeViewModelTest.kt
@@ -111,11 +111,12 @@ class HomeViewModelTest {
                     enqueueError(IllegalStateException("initial load failure"))
                     enqueueSuccess(todayResponse(), gate = loadGate)
                 }
-            val repository = TodayRepository(
-                todayApi = api,
-                todayActionsApi = StubTodayActionsApi(),
-                todaySummaryDao = FakeTodaySummaryDao(),
-            )
+            val repository =
+                TodayRepository(
+                    todayApi = api,
+                    todayActionsApi = StubTodayActionsApi(),
+                    todaySummaryDao = FakeTodaySummaryDao(),
+                )
             val viewModel = HomeViewModel(repository = repository)
 
             advanceUntilIdle()
@@ -141,13 +142,15 @@ class HomeViewModelTest {
                     enqueueSuccess(todayResponse())
                     enqueueError(IllegalStateException("network gone"))
                 }
-            val viewModel = HomeViewModel(
-                repository = TodayRepository(
-                    todayApi = api,
-                    todayActionsApi = StubTodayActionsApi(),
-                    todaySummaryDao = dao,
-                ),
-            )
+            val viewModel =
+                HomeViewModel(
+                    repository =
+                        TodayRepository(
+                            todayApi = api,
+                            todayActionsApi = StubTodayActionsApi(),
+                            todaySummaryDao = dao,
+                        ),
+                )
 
             advanceUntilIdle()
             assertTrue(viewModel.uiState.value is HomeUiState.Content)

--- a/android/app/src/test/java/com/daynest/android/feature/home/HomeViewModelTest.kt
+++ b/android/app/src/test/java/com/daynest/android/feature/home/HomeViewModelTest.kt
@@ -8,6 +8,12 @@ import com.daynest.android.data.today.MedicationTodayItemDto
 import com.daynest.android.data.today.OverdueTodayItemDto
 import com.daynest.android.data.today.PlannedTodayItemDto
 import com.daynest.android.data.today.RoutineTodayItemDto
+import com.daynest.android.data.today.ChoreMutationDto
+import com.daynest.android.data.today.DoseMutationDto
+import com.daynest.android.data.today.PlannedItemCreateDto
+import com.daynest.android.data.today.PlannedItemUpdateDto
+import com.daynest.android.data.today.TaskMutationDto
+import com.daynest.android.data.today.TodayActionsApi
 import com.daynest.android.data.today.TodayApi
 import com.daynest.android.data.today.TodayRepository
 import com.daynest.android.data.today.TodayResponseDto
@@ -56,6 +62,7 @@ class HomeViewModelTest {
                                 FakeTodayApi().apply {
                                     enqueueSuccess(todayResponse())
                                 },
+                            todayActionsApi = StubTodayActionsApi(),
                             todaySummaryDao = FakeTodaySummaryDao(),
                         ),
                 )
@@ -82,6 +89,7 @@ class HomeViewModelTest {
                                 FakeTodayApi().apply {
                                     enqueueError(IllegalStateException("boom"))
                                 },
+                            todayActionsApi = StubTodayActionsApi(),
                             todaySummaryDao = FakeTodaySummaryDao(),
                         ),
                 )
@@ -103,7 +111,7 @@ class HomeViewModelTest {
                     enqueueError(IllegalStateException("initial load failure"))
                     enqueueSuccess(todayResponse(), gate = loadGate)
                 }
-            val repository = TodayRepository(todayApi = api, todaySummaryDao = FakeTodaySummaryDao())
+            val repository = TodayRepository(todayApi = api, todayActionsApi = StubTodayActionsApi(), todaySummaryDao = FakeTodaySummaryDao())
             val viewModel = HomeViewModel(repository = repository)
 
             advanceUntilIdle()
@@ -129,7 +137,7 @@ class HomeViewModelTest {
                     enqueueSuccess(todayResponse())
                     enqueueError(IllegalStateException("network gone"))
                 }
-            val viewModel = HomeViewModel(repository = TodayRepository(todayApi = api, todaySummaryDao = dao))
+            val viewModel = HomeViewModel(repository = TodayRepository(todayApi = api, todayActionsApi = StubTodayActionsApi(), todaySummaryDao = dao))
 
             advanceUntilIdle()
             assertTrue(viewModel.uiState.value is HomeUiState.Content)
@@ -218,3 +226,29 @@ private fun todayResponse() =
                 PlannedTodayItemDto(8, "Call insurance", isDone = true),
             ),
     )
+
+private class StubTodayActionsApi : TodayActionsApi {
+    override suspend fun completeChore(id: Int): ChoreMutationDto = ChoreMutationDto(id, "completed")
+
+    override suspend fun skipChore(id: Int): ChoreMutationDto = ChoreMutationDto(id, "skipped")
+
+    override suspend fun completeTask(id: Int): TaskMutationDto = TaskMutationDto(id, "completed")
+
+    override suspend fun skipTask(id: Int): TaskMutationDto = TaskMutationDto(id, "skipped")
+
+    override suspend fun startTask(id: Int): TaskMutationDto = TaskMutationDto(id, "in_progress")
+
+    override suspend fun takeDose(id: Int): DoseMutationDto = DoseMutationDto(id, "taken")
+
+    override suspend fun skipDose(id: Int): DoseMutationDto = DoseMutationDto(id, "skipped")
+
+    override suspend fun updatePlannedItem(
+        id: Int,
+        request: PlannedItemUpdateDto,
+    ): PlannedTodayItemDto = PlannedTodayItemDto(id, request.title, request.isDone)
+
+    override suspend fun deletePlannedItem(id: Int) = Unit
+
+    override suspend fun createPlannedItem(request: PlannedItemCreateDto): PlannedTodayItemDto =
+        PlannedTodayItemDto(0, request.title, false)
+}


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- **Today screen**: Replace count-only home screen with full item lists and action buttons — take/skip medication doses, complete/skip chores and routines, mark planned items done/undo, delete planned items
- **Calendar screen**: Functional month grid (day count badges, today highlight, prev/next navigation) + day detail view with full unified item list + inline "add planned item" dialog
- **Medication screen**: Active plans list with schedule info, full dose history with status colors, create-plan dialog
- **Templates screen**: Tabbed routines vs chores view, create/delete templates via dialog
- **Settings screen**: Account section with sign-out (wired to nav), integration clients list, create client with one-time API key display

## What changed

### New data layer
- `TodayActionsApi` — all mutation endpoints (complete/skip chores, tasks, doses; CRUD for planned items)
- `CalendarApi` + `CalendarRepository` — month summary and unified day detail
- `MedicationApi` + `MedicationRepository` — medication plans and dose history
- `TemplatesApi` + `TemplatesRepository` — routine and chore template CRUD
- `SettingsApi` + `SettingsRepository` — integration client management
- `NetworkDiModule` updated to register all new APIs

### Expanded TodayApi DTOs
Added `status`, `scheduledDate`, `overdueSince`, `notes`, `moduleKey`, etc. to all item DTOs (backward-compatible via default values and `ignoreUnknownKeys = true`).

### ViewModels
New `CalendarViewModel`, `MedicationViewModel`, `TemplatesViewModel`, `SettingsViewModel` — all follow the existing Loading / Content / Error state pattern.

### Updated tests
`TodayRepositoryTest` and `HomeViewModelTest` updated for the new `TodayActionsApi` constructor parameter (stub implementations added). `DaynestNavigationTest` fixed to provide complete interface implementations.

## Test plan

- [ ] `./gradlew :app:testDebugUnitTest` — all unit tests pass
- [ ] `./gradlew :app:detekt :app:ktlintCheck :app:lintDebug` — no new warnings
- [ ] Today screen shows medication, routine, chore, and planned item sections with action buttons when data is present
- [ ] Calendar month grid renders with correct day cells; tapping a day loads the day detail and shows the add-planned button
- [ ] Medication screen lists plans and history; create plan dialog saves and appears in the list
- [ ] Templates screen tabs between Routines and Chores; create/delete works on both
- [ ] Settings sign-out navigates back to auth screen; new integration client shows the one-time API key dialog

https://claude.ai/code/session_019VjUriK4gXS7zFcvfkvpw4
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_019VjUriK4gXS7zFcvfkvpw4)_