### PR TITLE
Treat frontend as first-class citizen and expand HA integration

### DIFF
--- a/android/app/src/main/java/com/daynest/android/data/today/TodayRepository.kt
+++ b/android/app/src/main/java/com/daynest/android/data/today/TodayRepository.kt
@@ -50,27 +50,27 @@ class TodayRepository
 
         @Suppress("TooGenericExceptionCaught")
         suspend fun completeChore(choreInstanceId: Int): Result<ChoreMutationDto> =
-            runCatching { todayActionsApi.completeChore(choreInstanceId) }
+            safeApiCall { todayActionsApi.completeChore(choreInstanceId) }
 
         @Suppress("TooGenericExceptionCaught", "ktlint:standard:function-signature")
         suspend fun skipChore(choreInstanceId: Int): Result<ChoreMutationDto> =
-            runCatching { todayActionsApi.skipChore(choreInstanceId) }
+            safeApiCall { todayActionsApi.skipChore(choreInstanceId) }
 
         @Suppress("TooGenericExceptionCaught")
         suspend fun completeTask(taskInstanceId: Int): Result<TaskMutationDto> =
-            runCatching { todayActionsApi.completeTask(taskInstanceId) }
+            safeApiCall { todayActionsApi.completeTask(taskInstanceId) }
 
         @Suppress("TooGenericExceptionCaught", "ktlint:standard:function-signature")
         suspend fun skipTask(taskInstanceId: Int): Result<TaskMutationDto> =
-            runCatching { todayActionsApi.skipTask(taskInstanceId) }
+            safeApiCall { todayActionsApi.skipTask(taskInstanceId) }
 
         @Suppress("TooGenericExceptionCaught", "ktlint:standard:function-signature")
         suspend fun takeDose(doseInstanceId: Int): Result<DoseMutationDto> =
-            runCatching { todayActionsApi.takeDose(doseInstanceId) }
+            safeApiCall { todayActionsApi.takeDose(doseInstanceId) }
 
         @Suppress("TooGenericExceptionCaught", "ktlint:standard:function-signature")
         suspend fun skipDose(doseInstanceId: Int): Result<DoseMutationDto> =
-            runCatching { todayActionsApi.skipDose(doseInstanceId) }
+            safeApiCall { todayActionsApi.skipDose(doseInstanceId) }
 
         @Suppress("TooGenericExceptionCaught")
         suspend fun markPlannedDone(
@@ -78,7 +78,7 @@ class TodayRepository
             item: PlannedTodayItemDto,
             isDone: Boolean,
         ): Result<PlannedTodayItemDto> =
-            runCatching {
+            safeApiCall {
                 todayActionsApi.updatePlannedItem(
                     id,
                     PlannedItemUpdateDto(
@@ -93,11 +93,11 @@ class TodayRepository
             }
 
         @Suppress("TooGenericExceptionCaught")
-        suspend fun deletePlannedItem(id: Int): Result<Unit> = runCatching { todayActionsApi.deletePlannedItem(id) }
+        suspend fun deletePlannedItem(id: Int): Result<Unit> = safeApiCall { todayActionsApi.deletePlannedItem(id) }
 
         @Suppress("TooGenericExceptionCaught")
         suspend fun createPlannedItem(request: PlannedItemCreateDto): Result<PlannedTodayItemDto> =
-            runCatching { todayActionsApi.createPlannedItem(request) }
+            safeApiCall { todayActionsApi.createPlannedItem(request) }
 
         private fun TodaySummaryEntity.toDomain() =
             TodaySummary(
@@ -106,4 +106,14 @@ class TodayRepository
                 medicationsCount = medicationsCount,
                 plannedPendingCount = plannedPendingCount,
             )
+
+        @Suppress("TooGenericExceptionCaught")
+        private suspend fun <T> safeApiCall(call: suspend () -> T): Result<T> =
+            try {
+                Result.success(call())
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                Result.failure(e)
+            }
     }

--- a/android/app/src/main/java/com/daynest/android/feature/calendar/CalendarRoute.kt
+++ b/android/app/src/main/java/com/daynest/android/feature/calendar/CalendarRoute.kt
@@ -266,9 +266,9 @@ private fun MonthGrid(
     val firstWeekday = remember(firstDayOfMonth) { firstDayOfMonth.dayOfWeek.value % DAYS_IN_WEEK }
     val dayLabels =
         remember {
+            val firstDayOfWeek = DayOfWeek.SUNDAY
             (0 until DAYS_IN_WEEK).map { offset ->
-                val dayValue = (DayOfWeek.SUNDAY.value - 1 + offset) % DAYS_IN_WEEK + 1
-                DayOfWeek.of(dayValue).getDisplayName(TextStyle.SHORT, Locale.getDefault())
+                firstDayOfWeek.plus(offset.toLong()).getDisplayName(TextStyle.SHORT, Locale.getDefault())
             }
         }
 

--- a/backend/app/api/routes/integrations/home_assistant.py
+++ b/backend/app/api/routes/integrations/home_assistant.py
@@ -138,8 +138,8 @@ def home_assistant_skip_task(
 ) -> HAActionResult:
     """Skip a chore instance via Home Assistant automation."""
     service = TodayService(TodayRepository(db))
-    service.skip_chore(user_id=integration_user.id, chore_instance_id=request.task_id)
-    return HAActionResult(success=True, detail=f"Task {request.task_id} skipped")
+    service.skip_chore(user_id=integration_user.id, chore_instance_id=request.chore_instance_id)
+    return HAActionResult(success=True, detail=f"Task {request.chore_instance_id} skipped")
 
 
 @router.post("/actions/skip-medication", response_model=HAActionResult)

--- a/backend/app/api/routes/integrations/home_assistant.py
+++ b/backend/app/api/routes/integrations/home_assistant.py
@@ -19,6 +19,8 @@ from app.schemas.integrations import (
     HAActionResult,
     HomeAssistantEntity,
     MarkMedicationTakenRequest,
+    SkipMedicationRequest,
+    SkipTaskRequest,
     SnoozeTaskRequest,
 )
 from app.services.today_service import TodayService
@@ -126,3 +128,31 @@ def home_assistant_mark_medication_taken(
         action="take",
     )
     return HAActionResult(success=True, detail=f"Medication dose {request.medication_dose_id} marked as taken")
+
+
+@router.post("/actions/skip-task", response_model=HAActionResult)
+def home_assistant_skip_task(
+    request: SkipTaskRequest,
+    db: Session = Depends(get_db),
+    integration_user: User = Depends(require_integration_scope("ha:write")),
+) -> HAActionResult:
+    """Skip a chore instance via Home Assistant automation."""
+    service = TodayService(TodayRepository(db))
+    service.skip_chore(user_id=integration_user.id, chore_instance_id=request.task_id)
+    return HAActionResult(success=True, detail=f"Task {request.task_id} skipped")
+
+
+@router.post("/actions/skip-medication", response_model=HAActionResult)
+def home_assistant_skip_medication(
+    request: SkipMedicationRequest,
+    db: Session = Depends(get_db),
+    integration_user: User = Depends(require_integration_scope("ha:write")),
+) -> HAActionResult:
+    """Skip a medication dose via Home Assistant automation."""
+    service = TodayService(TodayRepository(db))
+    service.mutate_medication_status(
+        user_id=integration_user.id,
+        medication_dose_instance_id=request.medication_dose_id,
+        action="skip",
+    )
+    return HAActionResult(success=True, detail=f"Medication dose {request.medication_dose_id} skipped")

--- a/backend/app/schemas/integrations.py
+++ b/backend/app/schemas/integrations.py
@@ -23,6 +23,14 @@ class MarkMedicationTakenRequest(BaseModel):
     medication_dose_id: int = Field(gt=0, description="The medication dose instance ID to mark as taken")
 
 
+class SkipTaskRequest(BaseModel):
+    task_id: int = Field(gt=0, description="The chore instance ID to skip")
+
+
+class SkipMedicationRequest(BaseModel):
+    medication_dose_id: int = Field(gt=0, description="The medication dose instance ID to skip")
+
+
 class HAActionResult(BaseModel):
     success: bool
     detail: str
@@ -65,3 +73,4 @@ class DashboardReadModel(BaseModel):
     medication_due_count: int
     completion_ratio: float
     next_medication: str | None = None
+    routines_open_count: int = 0

--- a/backend/app/schemas/integrations.py
+++ b/backend/app/schemas/integrations.py
@@ -24,7 +24,7 @@ class MarkMedicationTakenRequest(BaseModel):
 
 
 class SkipTaskRequest(BaseModel):
-    task_id: int = Field(gt=0, description="The chore instance ID to skip")
+    chore_instance_id: int = Field(gt=0, description="The chore instance ID to skip")
 
 
 class SkipMedicationRequest(BaseModel):

--- a/backend/app/services/today_service.py
+++ b/backend/app/services/today_service.py
@@ -104,6 +104,7 @@ class TodayService:
             medication_due_count=len([item for item in data.medication if item.status == MedicationDoseStatus.scheduled]),
             completion_ratio=round(completed_count / total if total else 0.0, 3),
             next_medication=self._format_next_medication(data.medication),
+            routines_open_count=len([item for item in data.routines if item.status in (TaskStatus.pending, TaskStatus.in_progress)]),
         )
 
     def get_today(self, user_id: int, for_date: date) -> TodayResponse:

--- a/backend/tests/test_integration_adapters.py
+++ b/backend/tests/test_integration_adapters.py
@@ -212,6 +212,7 @@ def test_home_assistant_dashboard_contract_is_stable(
         "medication_due_count",
         "completion_ratio",
         "next_medication",
+        "routines_open_count",
     }
     assert isinstance(dashboard_payload["for_date"], str)
     assert isinstance(dashboard_payload["overdue_count"], int)

--- a/custom_components/daynest/api/client.py
+++ b/custom_components/daynest/api/client.py
@@ -171,7 +171,7 @@ class DaynestApiClient:
         """Skip a chore instance via the HA write endpoint."""
         return await self._post_action(
             path="/api/v1/integrations/home-assistant/actions/skip-task",
-            payload={"task_id": task_id},
+            payload={"chore_instance_id": task_id},
         )
 
     async def async_skip_medication(self, medication_dose_id: int) -> dict[str, Any]:

--- a/custom_components/daynest/api/client.py
+++ b/custom_components/daynest/api/client.py
@@ -167,6 +167,20 @@ class DaynestApiClient:
             payload={"medication_dose_id": medication_dose_id},
         )
 
+    async def async_skip_task(self, task_id: int) -> dict[str, Any]:
+        """Skip a chore instance via the HA write endpoint."""
+        return await self._post_action(
+            path="/api/v1/integrations/home-assistant/actions/skip-task",
+            payload={"task_id": task_id},
+        )
+
+    async def async_skip_medication(self, medication_dose_id: int) -> dict[str, Any]:
+        """Skip a medication dose via the HA write endpoint."""
+        return await self._post_action(
+            path="/api/v1/integrations/home-assistant/actions/skip-medication",
+            payload={"medication_dose_id": medication_dose_id},
+        )
+
     async def _request_model(
         self,
         path: str,

--- a/custom_components/daynest/coordinator.py
+++ b/custom_components/daynest/coordinator.py
@@ -77,6 +77,7 @@ class DaynestDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             "medication_due_count": max(0, _safe_int(payload.get("medication_due_count"), default=0)),
             "completion_ratio": completion_ratio,
             "next_medication": next_medication,
+            "routines_open_count": max(0, _safe_int(payload.get("routines_open_count"), default=0)),
             "integration_contract": contract,
         }
 

--- a/custom_components/daynest/sensor/__init__.py
+++ b/custom_components/daynest/sensor/__init__.py
@@ -72,6 +72,13 @@ ENTITY_DESCRIPTIONS: tuple[DaynestSensorEntityDescription, ...] = (
         icon="mdi:clock-time-eight-outline",
         value_key="next_medication",
     ),
+    DaynestSensorEntityDescription(
+        key="routines_open_count",
+        translation_key="routines_open_count",
+        icon="mdi:clipboard-list-outline",
+        state_class=SensorStateClass.MEASUREMENT,
+        value_key="routines_open_count",
+    ),
 )
 
 

--- a/custom_components/daynest/services.py
+++ b/custom_components/daynest/services.py
@@ -20,6 +20,8 @@ SERVICE_REFRESH = "refresh"
 SERVICE_COMPLETE_TASK = "complete_task"
 SERVICE_SNOOZE_TASK = "snooze_task"
 SERVICE_MARK_MEDICATION_TAKEN = "mark_medication_taken"
+SERVICE_SKIP_TASK = "skip_task"
+SERVICE_SKIP_MEDICATION = "skip_medication"
 
 ATTR_TASK_ID = "task_id"
 ATTR_MEDICATION_DOSE_ID = "medication_dose_id"
@@ -39,6 +41,18 @@ SERVICE_SNOOZE_TASK_SCHEMA = vol.Schema(
 )
 
 SERVICE_MARK_MEDICATION_TAKEN_SCHEMA = vol.Schema(
+    {
+        vol.Required(ATTR_MEDICATION_DOSE_ID): vol.All(int, vol.Range(min=1)),
+    }
+)
+
+SERVICE_SKIP_TASK_SCHEMA = vol.Schema(
+    {
+        vol.Required(ATTR_TASK_ID): vol.All(int, vol.Range(min=1)),
+    }
+)
+
+SERVICE_SKIP_MEDICATION_SCHEMA = vol.Schema(
     {
         vol.Required(ATTR_MEDICATION_DOSE_ID): vol.All(int, vol.Range(min=1)),
     }
@@ -151,6 +165,66 @@ async def async_setup_services(hass: HomeAssistant) -> None:
         LOGGER.debug("daynest.mark_medication_taken: dose %s marked as taken", medication_dose_id)
         await entry.runtime_data.coordinator.async_refresh()
 
+    async def handle_skip_task(call: ServiceCall) -> None:
+        """Skip a chore instance."""
+        task_id: int = call.data[ATTR_TASK_ID]
+        entries = _get_entries(hass)
+        if not entries:
+            LOGGER.warning("daynest.skip_task called but no Daynest entries are loaded")
+            return
+        if len(entries) != 1:
+            LOGGER.warning(
+                "daynest.skip_task: multiple Daynest entries loaded; specify an entry_id to target"
+            )
+            return
+        entry = entries[0]
+        try:
+            await entry.runtime_data.client.async_skip_task(task_id=task_id)
+        except DaynestApiClientAuthenticationError as err:
+            LOGGER.error("daynest.skip_task: authentication error for task %s", task_id)
+            raise HomeAssistantError(f"Authentication error skipping task {task_id}") from err
+        except DaynestApiClientCommunicationError as err:
+            LOGGER.error("daynest.skip_task: communication error for task %s: %s", task_id, err)
+            raise HomeAssistantError(f"Communication error skipping task {task_id}") from err
+        except DaynestApiClientError as err:
+            LOGGER.error("daynest.skip_task: unexpected error for task %s: %s", task_id, err)
+            raise HomeAssistantError(f"Error skipping task {task_id}") from err
+        LOGGER.debug("daynest.skip_task: task %s skipped", task_id)
+        await entry.runtime_data.coordinator.async_refresh()
+
+    async def handle_skip_medication(call: ServiceCall) -> None:
+        """Skip a medication dose."""
+        medication_dose_id: int = call.data[ATTR_MEDICATION_DOSE_ID]
+        entries = _get_entries(hass)
+        if not entries:
+            LOGGER.warning("daynest.skip_medication called but no Daynest entries are loaded")
+            return
+        if len(entries) != 1:
+            LOGGER.warning(
+                "daynest.skip_medication: multiple Daynest entries loaded; specify an entry_id to target"
+            )
+            return
+        entry = entries[0]
+        try:
+            await entry.runtime_data.client.async_skip_medication(medication_dose_id=medication_dose_id)
+        except DaynestApiClientAuthenticationError as err:
+            LOGGER.error(
+                "daynest.skip_medication: authentication error for dose %s", medication_dose_id
+            )
+            raise HomeAssistantError(f"Authentication error skipping dose {medication_dose_id}") from err
+        except DaynestApiClientCommunicationError as err:
+            LOGGER.error(
+                "daynest.skip_medication: communication error for dose %s: %s", medication_dose_id, err
+            )
+            raise HomeAssistantError(f"Communication error skipping dose {medication_dose_id}") from err
+        except DaynestApiClientError as err:
+            LOGGER.error(
+                "daynest.skip_medication: unexpected error for dose %s: %s", medication_dose_id, err
+            )
+            raise HomeAssistantError(f"Error skipping dose {medication_dose_id}") from err
+        LOGGER.debug("daynest.skip_medication: dose %s skipped", medication_dose_id)
+        await entry.runtime_data.coordinator.async_refresh()
+
     hass.services.async_register(DOMAIN, SERVICE_REFRESH, handle_refresh)
     hass.services.async_register(
         DOMAIN, SERVICE_COMPLETE_TASK, handle_complete_task, schema=SERVICE_COMPLETE_TASK_SCHEMA
@@ -161,6 +235,12 @@ async def async_setup_services(hass: HomeAssistant) -> None:
     hass.services.async_register(
         DOMAIN, SERVICE_MARK_MEDICATION_TAKEN, handle_mark_medication_taken, schema=SERVICE_MARK_MEDICATION_TAKEN_SCHEMA
     )
+    hass.services.async_register(
+        DOMAIN, SERVICE_SKIP_TASK, handle_skip_task, schema=SERVICE_SKIP_TASK_SCHEMA
+    )
+    hass.services.async_register(
+        DOMAIN, SERVICE_SKIP_MEDICATION, handle_skip_medication, schema=SERVICE_SKIP_MEDICATION_SCHEMA
+    )
 
 
 def async_unload_services(hass: HomeAssistant) -> None:
@@ -169,6 +249,8 @@ def async_unload_services(hass: HomeAssistant) -> None:
     hass.services.async_remove(DOMAIN, SERVICE_COMPLETE_TASK)
     hass.services.async_remove(DOMAIN, SERVICE_SNOOZE_TASK)
     hass.services.async_remove(DOMAIN, SERVICE_MARK_MEDICATION_TAKEN)
+    hass.services.async_remove(DOMAIN, SERVICE_SKIP_TASK)
+    hass.services.async_remove(DOMAIN, SERVICE_SKIP_MEDICATION)
 
 
 __all__ = [
@@ -178,6 +260,8 @@ __all__ = [
     "SERVICE_COMPLETE_TASK",
     "SERVICE_MARK_MEDICATION_TAKEN",
     "SERVICE_REFRESH",
+    "SERVICE_SKIP_MEDICATION",
+    "SERVICE_SKIP_TASK",
     "SERVICE_SNOOZE_TASK",
     "async_setup_services",
     "async_unload_services",

--- a/custom_components/daynest/services.py
+++ b/custom_components/daynest/services.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from functools import partial
 from typing import TYPE_CHECKING
 
 import voluptuous as vol
@@ -64,182 +65,155 @@ def _get_entries(hass: HomeAssistant) -> list[DaynestConfigEntry]:
     return hass.config_entries.async_entries(DOMAIN)  # type: ignore[return-value]
 
 
+def _get_single_entry(hass: HomeAssistant, service_name: str) -> DaynestConfigEntry | None:
+    """Return the single loaded Daynest entry, or None if zero or multiple are loaded."""
+    entries = _get_entries(hass)
+    if not entries:
+        LOGGER.warning("daynest.%s called but no Daynest entries are loaded", service_name)
+        return None
+    if len(entries) != 1:
+        LOGGER.warning(
+            "daynest.%s: multiple Daynest entries loaded; specify an entry_id to target",
+            service_name,
+        )
+        return None
+    return entries[0]
+
+
+async def _handle_refresh(hass: HomeAssistant, call: ServiceCall) -> None:
+    """Trigger an immediate coordinator refresh for all Daynest entries."""
+    entries = _get_entries(hass)
+    if not entries:
+        LOGGER.warning("daynest.refresh called but no Daynest entries are loaded")
+        return
+    for entry in entries:
+        LOGGER.debug("Refreshing Daynest coordinator for entry %s", entry.entry_id)
+        await entry.runtime_data.coordinator.async_refresh()
+
+
+async def _handle_complete_task(hass: HomeAssistant, call: ServiceCall) -> None:
+    """Mark a chore instance as complete."""
+    task_id: int = call.data[ATTR_TASK_ID]
+    entry = _get_single_entry(hass, "complete_task")
+    if entry is None:
+        return
+    try:
+        await entry.runtime_data.client.async_complete_task(task_id=task_id)
+    except DaynestApiClientAuthenticationError as err:
+        LOGGER.error("daynest.complete_task: authentication error for task %s", task_id)
+        raise HomeAssistantError(f"Authentication error completing task {task_id}") from err
+    except DaynestApiClientCommunicationError as err:
+        LOGGER.error("daynest.complete_task: communication error for task %s: %s", task_id, err)
+        raise HomeAssistantError(f"Communication error completing task {task_id}") from err
+    except DaynestApiClientError as err:
+        LOGGER.error("daynest.complete_task: unexpected error for task %s: %s", task_id, err)
+        raise HomeAssistantError(f"Error completing task {task_id}") from err
+    LOGGER.debug("daynest.complete_task: task %s marked as complete", task_id)
+    await entry.runtime_data.coordinator.async_refresh()
+
+
+async def _handle_snooze_task(hass: HomeAssistant, call: ServiceCall) -> None:
+    """Reschedule a chore instance N days into the future."""
+    task_id: int = call.data[ATTR_TASK_ID]
+    days: int = call.data[ATTR_DAYS]
+    entry = _get_single_entry(hass, "snooze_task")
+    if entry is None:
+        return
+    try:
+        await entry.runtime_data.client.async_snooze_task(task_id=task_id, days=days)
+    except DaynestApiClientAuthenticationError as err:
+        LOGGER.error("daynest.snooze_task: authentication error for task %s", task_id)
+        raise HomeAssistantError(f"Authentication error snoozing task {task_id}") from err
+    except DaynestApiClientCommunicationError as err:
+        LOGGER.error("daynest.snooze_task: communication error for task %s: %s", task_id, err)
+        raise HomeAssistantError(f"Communication error snoozing task {task_id}") from err
+    except DaynestApiClientError as err:
+        LOGGER.error("daynest.snooze_task: unexpected error for task %s: %s", task_id, err)
+        raise HomeAssistantError(f"Error snoozing task {task_id}") from err
+    LOGGER.debug("daynest.snooze_task: task %s snoozed by %s day(s)", task_id, days)
+    await entry.runtime_data.coordinator.async_refresh()
+
+
+async def _handle_mark_medication_taken(hass: HomeAssistant, call: ServiceCall) -> None:
+    """Mark a medication dose as taken."""
+    medication_dose_id: int = call.data[ATTR_MEDICATION_DOSE_ID]
+    entry = _get_single_entry(hass, "mark_medication_taken")
+    if entry is None:
+        return
+    try:
+        await entry.runtime_data.client.async_mark_medication_taken(medication_dose_id=medication_dose_id)
+    except DaynestApiClientAuthenticationError as err:
+        LOGGER.error("daynest.mark_medication_taken: authentication error for dose %s", medication_dose_id)
+        raise HomeAssistantError(f"Authentication error marking dose {medication_dose_id} taken") from err
+    except DaynestApiClientCommunicationError as err:
+        LOGGER.error("daynest.mark_medication_taken: communication error for dose %s: %s", medication_dose_id, err)
+        raise HomeAssistantError(f"Communication error marking dose {medication_dose_id} taken") from err
+    except DaynestApiClientError as err:
+        LOGGER.error("daynest.mark_medication_taken: unexpected error for dose %s: %s", medication_dose_id, err)
+        raise HomeAssistantError(f"Error marking dose {medication_dose_id} taken") from err
+    LOGGER.debug("daynest.mark_medication_taken: dose %s marked as taken", medication_dose_id)
+    await entry.runtime_data.coordinator.async_refresh()
+
+
+async def _handle_skip_task(hass: HomeAssistant, call: ServiceCall) -> None:
+    """Skip a chore instance."""
+    task_id: int = call.data[ATTR_TASK_ID]
+    entry = _get_single_entry(hass, "skip_task")
+    if entry is None:
+        return
+    try:
+        await entry.runtime_data.client.async_skip_task(task_id=task_id)
+    except DaynestApiClientAuthenticationError as err:
+        LOGGER.error("daynest.skip_task: authentication error for task %s", task_id)
+        raise HomeAssistantError(f"Authentication error skipping task {task_id}") from err
+    except DaynestApiClientCommunicationError as err:
+        LOGGER.error("daynest.skip_task: communication error for task %s: %s", task_id, err)
+        raise HomeAssistantError(f"Communication error skipping task {task_id}") from err
+    except DaynestApiClientError as err:
+        LOGGER.error("daynest.skip_task: unexpected error for task %s: %s", task_id, err)
+        raise HomeAssistantError(f"Error skipping task {task_id}") from err
+    LOGGER.debug("daynest.skip_task: task %s skipped", task_id)
+    await entry.runtime_data.coordinator.async_refresh()
+
+
+async def _handle_skip_medication(hass: HomeAssistant, call: ServiceCall) -> None:
+    """Skip a medication dose."""
+    medication_dose_id: int = call.data[ATTR_MEDICATION_DOSE_ID]
+    entry = _get_single_entry(hass, "skip_medication")
+    if entry is None:
+        return
+    try:
+        await entry.runtime_data.client.async_skip_medication(medication_dose_id=medication_dose_id)
+    except DaynestApiClientAuthenticationError as err:
+        LOGGER.error("daynest.skip_medication: authentication error for dose %s", medication_dose_id)
+        raise HomeAssistantError(f"Authentication error skipping dose {medication_dose_id}") from err
+    except DaynestApiClientCommunicationError as err:
+        LOGGER.error("daynest.skip_medication: communication error for dose %s: %s", medication_dose_id, err)
+        raise HomeAssistantError(f"Communication error skipping dose {medication_dose_id}") from err
+    except DaynestApiClientError as err:
+        LOGGER.error("daynest.skip_medication: unexpected error for dose %s: %s", medication_dose_id, err)
+        raise HomeAssistantError(f"Error skipping dose {medication_dose_id}") from err
+    LOGGER.debug("daynest.skip_medication: dose %s skipped", medication_dose_id)
+    await entry.runtime_data.coordinator.async_refresh()
+
+
 async def async_setup_services(hass: HomeAssistant) -> None:
     """Register Daynest Home Assistant services."""
-
-    async def handle_refresh(call: ServiceCall) -> None:
-        """Trigger an immediate coordinator refresh for all Daynest entries."""
-        entries = _get_entries(hass)
-        if not entries:
-            LOGGER.warning("daynest.refresh called but no Daynest entries are loaded")
-            return
-        for entry in entries:
-            LOGGER.debug("Refreshing Daynest coordinator for entry %s", entry.entry_id)
-            await entry.runtime_data.coordinator.async_refresh()
-
-    async def handle_complete_task(call: ServiceCall) -> None:
-        """Mark a chore instance as complete."""
-        task_id: int = call.data[ATTR_TASK_ID]
-        entries = _get_entries(hass)
-        if not entries:
-            LOGGER.warning("daynest.complete_task called but no Daynest entries are loaded")
-            return
-        if len(entries) != 1:
-            LOGGER.warning(
-                "daynest.complete_task: multiple Daynest entries loaded; specify an entry_id to target"
-            )
-            return
-        entry = entries[0]
-        try:
-            await entry.runtime_data.client.async_complete_task(task_id=task_id)
-        except DaynestApiClientAuthenticationError as err:
-            LOGGER.error("daynest.complete_task: authentication error for task %s", task_id)
-            raise HomeAssistantError(f"Authentication error completing task {task_id}") from err
-        except DaynestApiClientCommunicationError as err:
-            LOGGER.error("daynest.complete_task: communication error for task %s: %s", task_id, err)
-            raise HomeAssistantError(f"Communication error completing task {task_id}") from err
-        except DaynestApiClientError as err:
-            LOGGER.error("daynest.complete_task: unexpected error for task %s: %s", task_id, err)
-            raise HomeAssistantError(f"Error completing task {task_id}") from err
-        LOGGER.debug("daynest.complete_task: task %s marked as complete", task_id)
-        await entry.runtime_data.coordinator.async_refresh()
-
-    async def handle_snooze_task(call: ServiceCall) -> None:
-        """Reschedule a chore instance N days into the future."""
-        task_id: int = call.data[ATTR_TASK_ID]
-        days: int = call.data[ATTR_DAYS]
-        entries = _get_entries(hass)
-        if not entries:
-            LOGGER.warning("daynest.snooze_task called but no Daynest entries are loaded")
-            return
-        if len(entries) != 1:
-            LOGGER.warning(
-                "daynest.snooze_task: multiple Daynest entries loaded; specify an entry_id to target"
-            )
-            return
-        entry = entries[0]
-        try:
-            await entry.runtime_data.client.async_snooze_task(task_id=task_id, days=days)
-        except DaynestApiClientAuthenticationError as err:
-            LOGGER.error("daynest.snooze_task: authentication error for task %s", task_id)
-            raise HomeAssistantError(f"Authentication error snoozing task {task_id}") from err
-        except DaynestApiClientCommunicationError as err:
-            LOGGER.error("daynest.snooze_task: communication error for task %s: %s", task_id, err)
-            raise HomeAssistantError(f"Communication error snoozing task {task_id}") from err
-        except DaynestApiClientError as err:
-            LOGGER.error("daynest.snooze_task: unexpected error for task %s: %s", task_id, err)
-            raise HomeAssistantError(f"Error snoozing task {task_id}") from err
-        LOGGER.debug("daynest.snooze_task: task %s snoozed by %s day(s)", task_id, days)
-        await entry.runtime_data.coordinator.async_refresh()
-
-    async def handle_mark_medication_taken(call: ServiceCall) -> None:
-        """Mark a medication dose as taken."""
-        medication_dose_id: int = call.data[ATTR_MEDICATION_DOSE_ID]
-        entries = _get_entries(hass)
-        if not entries:
-            LOGGER.warning("daynest.mark_medication_taken called but no Daynest entries are loaded")
-            return
-        if len(entries) != 1:
-            LOGGER.warning(
-                "daynest.mark_medication_taken: multiple Daynest entries loaded; specify an entry_id to target"
-            )
-            return
-        entry = entries[0]
-        try:
-            await entry.runtime_data.client.async_mark_medication_taken(medication_dose_id=medication_dose_id)
-        except DaynestApiClientAuthenticationError as err:
-            LOGGER.error(
-                "daynest.mark_medication_taken: authentication error for dose %s", medication_dose_id
-            )
-            raise HomeAssistantError(f"Authentication error marking dose {medication_dose_id} taken") from err
-        except DaynestApiClientCommunicationError as err:
-            LOGGER.error(
-                "daynest.mark_medication_taken: communication error for dose %s: %s", medication_dose_id, err
-            )
-            raise HomeAssistantError(f"Communication error marking dose {medication_dose_id} taken") from err
-        except DaynestApiClientError as err:
-            LOGGER.error(
-                "daynest.mark_medication_taken: unexpected error for dose %s: %s", medication_dose_id, err
-            )
-            raise HomeAssistantError(f"Error marking dose {medication_dose_id} taken") from err
-        LOGGER.debug("daynest.mark_medication_taken: dose %s marked as taken", medication_dose_id)
-        await entry.runtime_data.coordinator.async_refresh()
-
-    async def handle_skip_task(call: ServiceCall) -> None:
-        """Skip a chore instance."""
-        task_id: int = call.data[ATTR_TASK_ID]
-        entries = _get_entries(hass)
-        if not entries:
-            LOGGER.warning("daynest.skip_task called but no Daynest entries are loaded")
-            return
-        if len(entries) != 1:
-            LOGGER.warning(
-                "daynest.skip_task: multiple Daynest entries loaded; specify an entry_id to target"
-            )
-            return
-        entry = entries[0]
-        try:
-            await entry.runtime_data.client.async_skip_task(task_id=task_id)
-        except DaynestApiClientAuthenticationError as err:
-            LOGGER.error("daynest.skip_task: authentication error for task %s", task_id)
-            raise HomeAssistantError(f"Authentication error skipping task {task_id}") from err
-        except DaynestApiClientCommunicationError as err:
-            LOGGER.error("daynest.skip_task: communication error for task %s: %s", task_id, err)
-            raise HomeAssistantError(f"Communication error skipping task {task_id}") from err
-        except DaynestApiClientError as err:
-            LOGGER.error("daynest.skip_task: unexpected error for task %s: %s", task_id, err)
-            raise HomeAssistantError(f"Error skipping task {task_id}") from err
-        LOGGER.debug("daynest.skip_task: task %s skipped", task_id)
-        await entry.runtime_data.coordinator.async_refresh()
-
-    async def handle_skip_medication(call: ServiceCall) -> None:
-        """Skip a medication dose."""
-        medication_dose_id: int = call.data[ATTR_MEDICATION_DOSE_ID]
-        entries = _get_entries(hass)
-        if not entries:
-            LOGGER.warning("daynest.skip_medication called but no Daynest entries are loaded")
-            return
-        if len(entries) != 1:
-            LOGGER.warning(
-                "daynest.skip_medication: multiple Daynest entries loaded; specify an entry_id to target"
-            )
-            return
-        entry = entries[0]
-        try:
-            await entry.runtime_data.client.async_skip_medication(medication_dose_id=medication_dose_id)
-        except DaynestApiClientAuthenticationError as err:
-            LOGGER.error(
-                "daynest.skip_medication: authentication error for dose %s", medication_dose_id
-            )
-            raise HomeAssistantError(f"Authentication error skipping dose {medication_dose_id}") from err
-        except DaynestApiClientCommunicationError as err:
-            LOGGER.error(
-                "daynest.skip_medication: communication error for dose %s: %s", medication_dose_id, err
-            )
-            raise HomeAssistantError(f"Communication error skipping dose {medication_dose_id}") from err
-        except DaynestApiClientError as err:
-            LOGGER.error(
-                "daynest.skip_medication: unexpected error for dose %s: %s", medication_dose_id, err
-            )
-            raise HomeAssistantError(f"Error skipping dose {medication_dose_id}") from err
-        LOGGER.debug("daynest.skip_medication: dose %s skipped", medication_dose_id)
-        await entry.runtime_data.coordinator.async_refresh()
-
-    hass.services.async_register(DOMAIN, SERVICE_REFRESH, handle_refresh)
+    hass.services.async_register(DOMAIN, SERVICE_REFRESH, partial(_handle_refresh, hass))
     hass.services.async_register(
-        DOMAIN, SERVICE_COMPLETE_TASK, handle_complete_task, schema=SERVICE_COMPLETE_TASK_SCHEMA
+        DOMAIN, SERVICE_COMPLETE_TASK, partial(_handle_complete_task, hass), schema=SERVICE_COMPLETE_TASK_SCHEMA
     )
     hass.services.async_register(
-        DOMAIN, SERVICE_SNOOZE_TASK, handle_snooze_task, schema=SERVICE_SNOOZE_TASK_SCHEMA
+        DOMAIN, SERVICE_SNOOZE_TASK, partial(_handle_snooze_task, hass), schema=SERVICE_SNOOZE_TASK_SCHEMA
     )
     hass.services.async_register(
-        DOMAIN, SERVICE_MARK_MEDICATION_TAKEN, handle_mark_medication_taken, schema=SERVICE_MARK_MEDICATION_TAKEN_SCHEMA
+        DOMAIN, SERVICE_MARK_MEDICATION_TAKEN, partial(_handle_mark_medication_taken, hass), schema=SERVICE_MARK_MEDICATION_TAKEN_SCHEMA
     )
     hass.services.async_register(
-        DOMAIN, SERVICE_SKIP_TASK, handle_skip_task, schema=SERVICE_SKIP_TASK_SCHEMA
+        DOMAIN, SERVICE_SKIP_TASK, partial(_handle_skip_task, hass), schema=SERVICE_SKIP_TASK_SCHEMA
     )
     hass.services.async_register(
-        DOMAIN, SERVICE_SKIP_MEDICATION, handle_skip_medication, schema=SERVICE_SKIP_MEDICATION_SCHEMA
+        DOMAIN, SERVICE_SKIP_MEDICATION, partial(_handle_skip_medication, hass), schema=SERVICE_SKIP_MEDICATION_SCHEMA
     )
 
 

--- a/custom_components/daynest/services.yaml
+++ b/custom_components/daynest/services.yaml
@@ -35,3 +35,21 @@ mark_medication_taken:
         number:
           min: 1
           mode: box
+
+skip_task:
+  fields:
+    task_id:
+      required: true
+      selector:
+        number:
+          min: 1
+          mode: box
+
+skip_medication:
+  fields:
+    medication_dose_id:
+      required: true
+      selector:
+        number:
+          min: 1
+          mode: box

--- a/custom_components/daynest/translations/en.json
+++ b/custom_components/daynest/translations/en.json
@@ -47,6 +47,9 @@
       },
       "next_medication": {
         "name": "Next Medication"
+      },
+      "routines_open_count": {
+        "name": "Open Routines"
       }
     }
   },
@@ -86,6 +89,26 @@
         "medication_dose_id": {
           "name": "Medication Dose ID",
           "description": "The numeric ID of the medication dose instance to mark as taken. Obtain this ID from the Daynest app or API."
+        }
+      }
+    },
+    "skip_task": {
+      "name": "Skip Task",
+      "description": "Skips a Daynest chore instance. Requires the integration API key to have the ha:write scope.",
+      "fields": {
+        "task_id": {
+          "name": "Task ID",
+          "description": "The numeric ID of the chore instance to skip."
+        }
+      }
+    },
+    "skip_medication": {
+      "name": "Skip Medication Dose",
+      "description": "Skips a scheduled medication dose. Requires the integration API key to have the ha:write scope.",
+      "fields": {
+        "medication_dose_id": {
+          "name": "Medication Dose ID",
+          "description": "The numeric ID of the medication dose instance to skip."
         }
       }
     }

--- a/frontend/src/features/calendar/CalendarPage.tsx
+++ b/frontend/src/features/calendar/CalendarPage.tsx
@@ -74,6 +74,7 @@ export function CalendarPage() {
   const [linkedSource, setLinkedSource] = useState("");
   const [linkedRef, setLinkedRef] = useState("");
   const [editingPlannedItemId, setEditingPlannedItemId] = useState<number | null>(null);
+  const [confirmDeleteId, setConfirmDeleteId] = useState<number | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [canRetry, setCanRetry] = useState(false);
@@ -220,9 +221,7 @@ export function CalendarPage() {
   };
 
   const removePlannedItem = async (itemId: number) => {
-    if (!window.confirm("Delete this planned item?")) {
-      return;
-    }
+    setConfirmDeleteId(null);
     setAddError(null);
     setIsAdding(true);
     setActionStatus(null);
@@ -735,14 +734,35 @@ export function CalendarPage() {
                         >
                           Edit
                         </button>
-                        <button
-                          type="button"
-                          className="btn btn-outline-danger btn-sm"
-                          disabled={isAdding}
-                          onClick={() => void removePlannedItem(item.id)}
-                        >
-                          Delete
-                        </button>
+                        {confirmDeleteId === item.id ? (
+                          <div className="d-flex gap-1">
+                            <button
+                              type="button"
+                              className="btn btn-danger btn-sm"
+                              disabled={isAdding}
+                              onClick={() => void removePlannedItem(item.id)}
+                            >
+                              Confirm
+                            </button>
+                            <button
+                              type="button"
+                              className="btn btn-outline-secondary btn-sm"
+                              disabled={isAdding}
+                              onClick={() => setConfirmDeleteId(null)}
+                            >
+                              Cancel
+                            </button>
+                          </div>
+                        ) : (
+                          <button
+                            type="button"
+                            className="btn btn-outline-danger btn-sm"
+                            disabled={isAdding}
+                            onClick={() => setConfirmDeleteId(item.id)}
+                          >
+                            Delete
+                          </button>
+                        )}
                       </div>
                     </div>
                   </li>

--- a/frontend/src/features/medication/MedicationPage.tsx
+++ b/frontend/src/features/medication/MedicationPage.tsx
@@ -216,12 +216,21 @@ export function MedicationPage() {
               ) : (
                 plans.map((plan) => (
                   <li key={plan.id} className="list-group-item py-2">
-                    <div className="fw-semibold">{plan.name}</div>
-                    <small className="text-muted d-block">
-                      Starts {formatDate(plan.start_date)} • {plan.schedule_time.slice(0, 5)} •
-                      every {plan.every_n_days} day{plan.every_n_days === 1 ? "" : "s"}
-                    </small>
-                    <small className="d-block mt-1">{plan.instructions}</small>
+                    <div className="d-flex justify-content-between align-items-start gap-3">
+                      <div>
+                        <div className="fw-semibold">{plan.name}</div>
+                        <small className="text-muted d-block">
+                          Starts {formatDate(plan.start_date)} • {plan.schedule_time.slice(0, 5)} •
+                          every {plan.every_n_days} day{plan.every_n_days === 1 ? "" : "s"}
+                        </small>
+                        <small className="d-block mt-1">{plan.instructions}</small>
+                      </div>
+                      <span
+                        className={`badge align-self-start ${plan.is_active ? "text-bg-success" : "text-bg-secondary"}`}
+                      >
+                        {plan.is_active ? "Active" : "Inactive"}
+                      </span>
+                    </div>
                   </li>
                 ))
               )}

--- a/frontend/src/features/settings/SettingsPage.tsx
+++ b/frontend/src/features/settings/SettingsPage.tsx
@@ -59,6 +59,8 @@ const HA_ENDPOINTS = [
   "POST /api/v1/integrations/home-assistant/actions/complete-task",
   "POST /api/v1/integrations/home-assistant/actions/snooze-task",
   "POST /api/v1/integrations/home-assistant/actions/mark-medication-taken",
+  "POST /api/v1/integrations/home-assistant/actions/skip-task",
+  "POST /api/v1/integrations/home-assistant/actions/skip-medication",
 ];
 
 export function SettingsPage() {
@@ -363,18 +365,13 @@ export function SettingsPage() {
                           {client.scopes.join(", ")} • {client.rate_limit_per_minute}/min
                         </small>
                         <small className="text-muted d-block mt-1">
-                          {client.scopes.includes("ha:read")
-                            ? "Home Assistant dashboard ready."
-                            : ""}
-                          {client.scopes.includes("ha:read") && client.scopes.includes("ha:write")
-                            ? " Actions enabled."
-                            : ""}
-                          {(client.scopes.includes("ha:read") ||
-                            client.scopes.includes("ha:write")) &&
-                          client.scopes.includes("mcp:read")
-                            ? " "
-                            : ""}
-                          {client.scopes.includes("mcp:read") ? "MCP adapter ready." : ""}
+                          {[
+                            client.scopes.includes("ha:read") && "Home Assistant dashboard ready.",
+                            client.scopes.includes("ha:write") && "HA actions enabled.",
+                            client.scopes.includes("mcp:read") && "MCP adapter ready.",
+                          ]
+                            .filter(Boolean)
+                            .join(" ")}
                         </small>
                       </div>
                       <span

--- a/frontend/src/features/templates/TemplatesPage.tsx
+++ b/frontend/src/features/templates/TemplatesPage.tsx
@@ -31,6 +31,8 @@ export function TemplatesPage() {
   const [routineDueTime, setRoutineDueTime] = useState("08:00");
   const [routineActive, setRoutineActive] = useState(true);
   const [editingRoutineId, setEditingRoutineId] = useState<number | null>(null);
+  const [confirmDeleteRoutineId, setConfirmDeleteRoutineId] = useState<number | null>(null);
+  const [confirmDeleteChoreId, setConfirmDeleteChoreId] = useState<number | null>(null);
 
   const [choreName, setChoreName] = useState("");
   const [choreDescription, setChoreDescription] = useState("");
@@ -167,9 +169,7 @@ export function TemplatesPage() {
   };
 
   const handleDeleteRoutine = async (routineId: number) => {
-    if (!window.confirm("Delete this routine template?")) {
-      return;
-    }
+    setConfirmDeleteRoutineId(null);
     setIsSubmitting(true);
     setSubmitError(null);
     setSuccessMessage(null);
@@ -186,9 +186,7 @@ export function TemplatesPage() {
   };
 
   const handleDeleteChore = async (choreId: number) => {
-    if (!window.confirm("Delete this chore template?")) {
-      return;
-    }
+    setConfirmDeleteChoreId(null);
     setIsSubmitting(true);
     setSubmitError(null);
     setSuccessMessage(null);
@@ -366,18 +364,40 @@ export function TemplatesPage() {
                             setRoutineEveryNDays(String(routine.every_n_days));
                             setRoutineDueTime(routine.due_time ? routine.due_time.slice(0, 5) : "");
                             setRoutineActive(routine.is_active);
+                            setConfirmDeleteRoutineId(null);
                             setSubmitError(null);
                           }}
                         >
                           Edit
                         </button>
-                        <button
-                          type="button"
-                          className="btn btn-outline-danger btn-sm"
-                          onClick={() => void handleDeleteRoutine(routine.id)}
-                        >
-                          Delete
-                        </button>
+                        {confirmDeleteRoutineId === routine.id ? (
+                          <div className="d-flex gap-1">
+                            <button
+                              type="button"
+                              className="btn btn-danger btn-sm"
+                              disabled={isSubmitting}
+                              onClick={() => void handleDeleteRoutine(routine.id)}
+                            >
+                              Confirm
+                            </button>
+                            <button
+                              type="button"
+                              className="btn btn-outline-secondary btn-sm"
+                              disabled={isSubmitting}
+                              onClick={() => setConfirmDeleteRoutineId(null)}
+                            >
+                              Cancel
+                            </button>
+                          </div>
+                        ) : (
+                          <button
+                            type="button"
+                            className="btn btn-outline-danger btn-sm"
+                            onClick={() => setConfirmDeleteRoutineId(routine.id)}
+                          >
+                            Delete
+                          </button>
+                        )}
                       </div>
                     </div>
                   </li>
@@ -498,18 +518,40 @@ export function TemplatesPage() {
                             setChoreStartDate(chore.start_date);
                             setChoreEveryNDays(String(chore.every_n_days));
                             setChoreActive(chore.is_active);
+                            setConfirmDeleteChoreId(null);
                             setSubmitError(null);
                           }}
                         >
                           Edit
                         </button>
-                        <button
-                          type="button"
-                          className="btn btn-outline-danger btn-sm"
-                          onClick={() => void handleDeleteChore(chore.id)}
-                        >
-                          Delete
-                        </button>
+                        {confirmDeleteChoreId === chore.id ? (
+                          <div className="d-flex gap-1">
+                            <button
+                              type="button"
+                              className="btn btn-danger btn-sm"
+                              disabled={isSubmitting}
+                              onClick={() => void handleDeleteChore(chore.id)}
+                            >
+                              Confirm
+                            </button>
+                            <button
+                              type="button"
+                              className="btn btn-outline-secondary btn-sm"
+                              disabled={isSubmitting}
+                              onClick={() => setConfirmDeleteChoreId(null)}
+                            >
+                              Cancel
+                            </button>
+                          </div>
+                        ) : (
+                          <button
+                            type="button"
+                            className="btn btn-outline-danger btn-sm"
+                            onClick={() => setConfirmDeleteChoreId(chore.id)}
+                          >
+                            Delete
+                          </button>
+                        )}
                       </div>
                     </div>
                   </li>

--- a/frontend/src/features/today/TodayPage.tsx
+++ b/frontend/src/features/today/TodayPage.tsx
@@ -1,7 +1,9 @@
 import { useEffect, useState } from "react";
+import type { FormEvent } from "react";
 import {
   completeRoutineTask,
   completeChore,
+  createPlannedItem,
   deletePlannedItem,
   fetchToday,
   isRetryableApiError,
@@ -228,7 +230,7 @@ function SummaryCard({
   tone: "primary" | "secondary" | "warning" | "success" | "info" | "danger";
 }) {
   return (
-    <div className="col-6 col-lg-3">
+    <div className="col-6 col-sm-4 col-lg">
       <div className="card h-100 border-0 summary-card shadow-sm">
         <div className="card-body py-3">
           <div className={`summary-pill text-bg-${tone}`}>{label}</div>
@@ -259,12 +261,12 @@ function WebFocusPanel({ sections }: { sections: TodaySection[] }) {
       <div className="card-body">
         <div className="d-flex flex-column flex-lg-row justify-content-between gap-3">
           <div>
-            <div className="text-uppercase text-muted small fw-semibold">Web focus</div>
+            <div className="text-uppercase text-muted small fw-semibold">Today's focus</div>
             <h3 className="h5 mb-1">{nextItem ? nextItem.title : "All clear for now"}</h3>
             <p className="text-muted mb-0">
               {nextItem
                 ? `${nextSection?.heading ?? "Today"} is the next section that needs attention.`
-                : "No open actions remain in today's web dashboard."}
+                : "No open actions remain for today."}
             </p>
           </div>
           <div className="focus-progress" aria-label={`${completionPercent}% complete`}>
@@ -699,6 +701,77 @@ function SectionCard({
   );
 }
 
+function QuickAddPlanned({ onRefresh }: { onRefresh: () => Promise<void> }) {
+  const [isOpen, setIsOpen] = useState(false);
+  const [title, setTitle] = useState("");
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [addError, setAddError] = useState<string | null>(null);
+
+  const todayDate = toIsoDate(dayjs());
+
+  const onSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!title.trim()) return;
+    setIsSubmitting(true);
+    setAddError(null);
+    try {
+      await createPlannedItem({ title: title.trim(), planned_for: todayDate });
+      setTitle("");
+      setIsOpen(false);
+      await onRefresh();
+    } catch (err) {
+      setAddError(err instanceof Error ? err.message : "Failed to add item.");
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  if (!isOpen) {
+    return (
+      <button
+        type="button"
+        className="btn btn-outline-secondary btn-sm"
+        onClick={() => setIsOpen(true)}
+      >
+        + Quick add
+      </button>
+    );
+  }
+
+  return (
+    <form className="d-flex gap-2 align-items-start flex-wrap" onSubmit={(e) => void onSubmit(e)}>
+      <input
+        className="form-control form-control-sm flex-grow-1"
+        style={{ minWidth: "12rem" }}
+        value={title}
+        autoFocus
+        placeholder="Plan title for today…"
+        disabled={isSubmitting}
+        onChange={(e) => {
+          setTitle(e.target.value);
+          setAddError(null);
+        }}
+      />
+      <button type="submit" className="btn btn-primary btn-sm" disabled={isSubmitting || !title.trim()}>
+        {isSubmitting ? "Adding…" : "Add"}
+      </button>
+      <button
+        type="button"
+        className="btn btn-outline-secondary btn-sm"
+        disabled={isSubmitting}
+        onClick={() => {
+          setIsOpen(false);
+          setTitle("");
+          setAddError(null);
+        }}
+      >
+        Cancel
+      </button>
+      {addError ? <small className="w-100 text-danger">{addError}</small> : null}
+    </form>
+  );
+}
+
 export function TodayPage() {
   const [today, setToday] = useState<TodayPayload | null>(null);
   const [isLoading, setIsLoading] = useState(true);
@@ -862,9 +935,10 @@ export function TodayPage() {
     <section>
       <div className="d-flex flex-column flex-md-row justify-content-between align-items-start align-items-md-center gap-2 mb-2">
         <h2 className="h4 mb-0">Today</h2>
-        <div className="d-flex gap-2 w-100 w-md-auto">
+        <div className="d-flex gap-2 align-items-start flex-wrap w-100 w-md-auto">
+          <QuickAddPlanned onRefresh={loadToday} />
           <button
-            className="btn btn-outline-primary btn-sm flex-grow-1 flex-md-grow-0"
+            className="btn btn-outline-primary btn-sm flex-md-grow-0"
             type="button"
             disabled={isLoading}
             onClick={() => void loadToday()}
@@ -874,7 +948,7 @@ export function TodayPage() {
         </div>
       </div>
       <p className="text-muted mb-3">
-        Medication, routines, chores, and planned tasks with fast mobile-friendly actions.
+        Medication, routines, chores, and planned tasks — everything due or active today.
       </p>
 
       {isLoading ? <div className="alert alert-info py-2">Loading today...</div> : null}

--- a/frontend/tests/features/today/TodayPage.test.tsx
+++ b/frontend/tests/features/today/TodayPage.test.tsx
@@ -92,7 +92,7 @@ describe("TodayPage", () => {
   it("shows the web focus panel with the next actionable item and progress", async () => {
     render(<TodayPage />);
 
-    expect(await screen.findByText("Web focus")).toBeInTheDocument();
+    expect(await screen.findByText("Today's focus")).toBeInTheDocument();
     expect(screen.getByRole("heading", { name: "Morning vitamin" })).toBeInTheDocument();
     expect(screen.getByLabelText("40% complete")).toBeInTheDocument();
     expect(screen.getByRole("progressbar", { name: "Today completion" })).toHaveAttribute(


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

### Frontend
- **Inline confirm dialogs** replace `window.confirm()` in CalendarPage (planned item delete) and TemplatesPage (routine and chore template delete) — no more browser modal interruptions
- **QuickAddPlanned** form added to TodayPage header: one-click expand, title input, adds a planned item for today without navigating to Calendar
- **Active badge** on medication plans in MedicationPage (matches chore/routine active/inactive display)
- **"Today's focus"** replaces "Web focus" in the focus panel header
- **SummaryCard grid fix**: changed from `col-6 col-lg-3` (4+1 awkward wrap) to `col-6 col-sm-4 col-lg` (even flex layout for 5 cards)
- **Simplified scope status text** in Settings client list (no more string concatenation with orphan spaces)

### Home Assistant integration
- **`skip_task` service** — skips a chore instance (backed by new `POST /actions/skip-task` endpoint)
- **`skip_medication` service** — skips a medication dose (backed by new `POST /actions/skip-medication` endpoint)
- **`routines_open_count` sensor** — exposes the count of open (pending/in_progress) routine tasks, sourced from an extended `DashboardReadModel` (new field with default=0, fully backward-compatible)
- Backend, HA client, coordinator, sensor description, services.yaml, and translations/en.json all updated consistently

## Test plan
- [ ] TodayPage: "Quick add" button appears → expands inline form → adding a title creates a planned item and refreshes → Cancel works
- [ ] CalendarPage: Delete on a planned item shows inline Confirm/Cancel instead of browser dialog
- [ ] TemplatesPage: Delete on a routine or chore template shows inline Confirm/Cancel
- [ ] MedicationPage: Active plans show a green "Active" badge, inactive show "Inactive"
- [ ] SettingsPage: Client list scope summary reads cleanly with no extra spaces
- [ ] HA: `daynest.skip_task` service available in HA developer tools
- [ ] HA: `daynest.skip_medication` service available in HA developer tools
- [ ] HA: `sensor.daynest_open_routines` entity appears and reports routine count

https://claude.ai/code/session_01Ue5LqBUQjUStMFn8nxELse
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ue5LqBUQjUStMFn8nxELse)_