### PR TITLE
feat(mcp): Keycloak OIDC auth for MCP server

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,3 +1,5 @@
+from contextlib import asynccontextmanager
+
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.middleware.trustedhost import TrustedHostMiddleware
@@ -16,7 +18,19 @@ from app.mcp_server import create_mcp_server
 configure_logging()
 configure_error_tracking()
 
-app = FastAPI(title=settings.app_name, version=settings.version)
+_mcp = create_mcp_server() if settings.feature_mcp else None
+
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    if _mcp is not None:
+        async with _mcp.session_manager.run():
+            yield
+    else:
+        yield
+
+
+app = FastAPI(title=settings.app_name, version=settings.version, lifespan=lifespan)
 app.middleware("http")(observability_middleware)
 
 if settings.trusted_hosts:
@@ -39,8 +53,8 @@ app.include_router(home_assistant_router, prefix=settings.api_prefix)
 app.include_router(today_router, prefix=settings.api_prefix)
 app.include_router(medications_router, prefix=settings.api_prefix)
 app.include_router(templates_router, prefix=settings.api_prefix)
-if settings.feature_mcp:
-    app.mount("/mcp", create_mcp_server().streamable_http_app())
+if _mcp is not None:
+    app.mount("/mcp", _mcp.streamable_http_app())
 
 
 @app.get("/")

--- a/backend/app/mcp_server.py
+++ b/backend/app/mcp_server.py
@@ -97,9 +97,11 @@ class DaynestMcpBackend:
     def resolve_user(self, db: Session) -> User:
         access_token = get_access_token()
         if access_token is not None:
+            client_id = access_token.client_id
+
             # Integration key auth: client_id is an integer DB id
             try:
-                client_int_id = int(access_token.client_id)
+                client_int_id = int(client_id)
             except (TypeError, ValueError):
                 client_int_id = None
 
@@ -107,17 +109,17 @@ class DaynestMcpBackend:
                 # verify_token stores only an AccessToken in request context — re-query with joinedload.
                 stmt = select(IntegrationClient).where(IntegrationClient.id == client_int_id).options(joinedload(IntegrationClient.user))
                 client = db.scalar(stmt)
-                if client is None or not client.is_active:
-                    raise ValueError("Authenticated MCP integration client is inactive or missing")
-                if client.user is None or not client.user.is_active:
-                    raise ValueError("Authenticated integration owner not found or inactive")
-                return client.user
+                if client is not None and client.is_active:
+                    if client.user is None or not client.user.is_active:
+                        raise ValueError("Authenticated integration owner not found or inactive")
+                    return client.user
 
             # OIDC auth: client_id is the OIDC subject (sub)
-            subject = access_token.client_id
-            user = db.scalar(select(User).where(User.oidc_subject == subject).where(User.is_active.is_(True)))
+            if not client_id:
+                raise ValueError("Authenticated MCP access token is missing a client ID")
+            user = db.scalar(select(User).where(User.oidc_subject == client_id).where(User.is_active.is_(True)))
             if user is None:
-                raise ValueError(f"No active user found for OIDC subject: {subject}")
+                raise ValueError(f"No active user or integration found for client ID: {client_id}")
             return user
 
         configured_email = self.user_email or os.getenv(DAYNEST_USER_EMAIL_ENV)

--- a/backend/app/mcp_server.py
+++ b/backend/app/mcp_server.py
@@ -95,11 +95,30 @@ class DaynestMcpBackend:
             session.close()
 
     def resolve_user(self, db: Session) -> User:
-        integration_client = self._resolve_authenticated_integration_client(db)
-        if integration_client is not None:
-            if integration_client.user is None or not integration_client.user.is_active:
-                raise ValueError("Authenticated integration owner not found or inactive")
-            return integration_client.user
+        access_token = get_access_token()
+        if access_token is not None:
+            # Integration key auth: client_id is an integer DB id
+            try:
+                client_int_id = int(access_token.client_id)
+            except (TypeError, ValueError):
+                client_int_id = None
+
+            if client_int_id is not None:
+                # verify_token stores only an AccessToken in request context — re-query with joinedload.
+                stmt = select(IntegrationClient).where(IntegrationClient.id == client_int_id).options(joinedload(IntegrationClient.user))
+                client = db.scalar(stmt)
+                if client is None or not client.is_active:
+                    raise ValueError("Authenticated MCP integration client is inactive or missing")
+                if client.user is None or not client.user.is_active:
+                    raise ValueError("Authenticated integration owner not found or inactive")
+                return client.user
+
+            # OIDC auth: client_id is the OIDC subject (sub)
+            subject = access_token.client_id
+            user = db.scalar(select(User).where(User.oidc_subject == subject).where(User.is_active.is_(True)))
+            if user is None:
+                raise ValueError(f"No active user found for OIDC subject: {subject}")
+            return user
 
         configured_email = self.user_email or os.getenv(DAYNEST_USER_EMAIL_ENV)
         if configured_email:
@@ -124,27 +143,6 @@ class DaynestMcpBackend:
                 f"Set {DAYNEST_USER_EMAIL_ENV} to the correct account or inspect active users locally."
             )
         return active_users[0]
-
-    @staticmethod
-    def _resolve_authenticated_integration_client(db: Session) -> IntegrationClient | None:
-        # verify_token stores only an AccessToken (client_id, scopes, resource) in the request
-        # context — it does not retain the IntegrationClient ORM object or its related User.
-        # We must re-query IntegrationClient here (with joinedload of user) to get a
-        # fully-populated, session-bound instance for this request's DB session.
-        access_token = get_access_token()
-        if access_token is None:
-            return None
-
-        try:
-            client_id = int(access_token.client_id)
-        except (TypeError, ValueError) as exc:
-            raise ValueError("Authenticated MCP client id is invalid") from exc
-
-        stmt = select(IntegrationClient).where(IntegrationClient.id == client_id).options(joinedload(IntegrationClient.user))
-        client = db.scalar(stmt)
-        if client is None or not client.is_active:
-            raise ValueError("Authenticated MCP integration client is inactive or missing")
-        return client
 
     def _with_service(self, operation: Callable[[Session, User, TodayService], T]) -> T:
         with self._session_scope() as db:
@@ -322,6 +320,59 @@ class IntegrationKeyTokenVerifier(TokenVerifier):
             session.close()
 
 
+class OIDCMcpTokenVerifier(TokenVerifier):
+    """Validates Keycloak-issued OIDC tokens for MCP access."""
+
+    def __init__(self, session_factory: Callable[[], Session], *, resource_server_url: str | None = None) -> None:
+        self.session_factory = session_factory
+        self.resource_server_url = resource_server_url
+
+    async def verify_token(self, token: str) -> AccessToken | None:
+        from app.core.oidc import OIDCTokenError, decode_oidc_token, get_or_create_local_user
+
+        try:
+            claims = await decode_oidc_token(token)
+        except OIDCTokenError as exc:
+            logger.debug("OIDC token validation failed: %s", exc)
+            return None
+
+        subject: str | None = claims.get("sub")
+        if not subject:
+            return None
+
+        session = self.session_factory()
+        try:
+            user = get_or_create_local_user(subject, claims, session)
+            if not user.is_active:
+                return None
+        except Exception as exc:
+            logger.warning("Failed to resolve MCP user for subject %s: %s", subject, exc)
+            return None
+        finally:
+            session.close()
+
+        return AccessToken(
+            token=token,
+            client_id=subject,
+            scopes=["mcp:read"],
+            resource=self.resource_server_url,
+        )
+
+
+class ComposedTokenVerifier(TokenVerifier):
+    """Tries each verifier in order; returns the first successful result."""
+
+    def __init__(self, *verifiers: TokenVerifier) -> None:
+        self._verifiers = verifiers
+
+    async def verify_token(self, token: str) -> AccessToken | None:
+        for verifier in self._verifiers:
+            result = await verifier.verify_token(token)
+            if result is not None:
+                return result
+        return None
+
+
 def _build_auth_settings(resource_server_url: str) -> AuthSettings:
     issuer_url = os.getenv(DAYNEST_MCP_ISSUER_URL_ENV, resource_server_url)
     return AuthSettings(
@@ -347,7 +398,10 @@ def create_mcp_server(backend: DaynestMcpBackend | None = None) -> FastMCP:
         "Daynest",
         json_response=True,
         streamable_http_path="/",  # mounted at /mcp in FastAPI; prefix is stripped before the sub-app sees it
-        token_verifier=IntegrationKeyTokenVerifier(SessionLocal, resource_server_url=resource_server_url),
+        token_verifier=ComposedTokenVerifier(
+            OIDCMcpTokenVerifier(SessionLocal, resource_server_url=resource_server_url),
+            IntegrationKeyTokenVerifier(SessionLocal, resource_server_url=resource_server_url),
+        ),
         auth=_build_auth_settings(resource_server_url),
         transport_security=_build_transport_security(),
     )

--- a/backend/app/mcp_server.py
+++ b/backend/app/mcp_server.py
@@ -7,7 +7,7 @@ import sys
 from collections.abc import Callable
 from contextlib import contextmanager
 from datetime import date, datetime
-from typing import Any, TypeVar
+from typing import Any, Literal, TypeVar
 
 from anyio import to_thread
 from fastapi import HTTPException
@@ -46,6 +46,7 @@ DAYNEST_MCP_ALLOWED_ORIGINS_ENV = "DAYNEST_MCP_ALLOWED_ORIGINS"
 DAYNEST_MCP_ALLOWED_HOSTS_ENV = "DAYNEST_MCP_ALLOWED_HOSTS"
 
 T = TypeVar("T")
+MCP_READ_SCOPE = "mcp:read"
 
 
 def _parse_date(value: str | None) -> date:
@@ -97,30 +98,34 @@ class DaynestMcpBackend:
     def resolve_user(self, db: Session) -> User:
         access_token = get_access_token()
         if access_token is not None:
-            client_id = access_token.client_id
+            auth_source = getattr(access_token, "auth_source", None)
 
-            # Integration key auth: client_id is an integer DB id
-            try:
-                client_int_id = int(client_id)
-            except (TypeError, ValueError):
-                client_int_id = None
-
-            if client_int_id is not None:
+            if auth_source == "integration":
+                integration_client_id = getattr(access_token, "integration_client_id", None)
+                if integration_client_id is None:
+                    raise ValueError("Authenticated MCP integration token is missing a client ID")
                 # verify_token stores only an AccessToken in request context — re-query with joinedload.
-                stmt = select(IntegrationClient).where(IntegrationClient.id == client_int_id).options(joinedload(IntegrationClient.user))
+                stmt = select(IntegrationClient).where(IntegrationClient.id == integration_client_id).options(joinedload(IntegrationClient.user))
                 client = db.scalar(stmt)
-                if client is not None and client.is_active:
-                    if client.user is None or not client.user.is_active:
-                        raise ValueError("Authenticated integration owner not found or inactive")
-                    return client.user
+                if client is None or not client.is_active:
+                    raise ValueError("Authenticated MCP integration client is inactive or missing")
+                if client.user is None or not client.user.is_active:
+                    raise ValueError("Authenticated integration owner not found or inactive")
+                return client.user
 
-            # OIDC auth: client_id is the OIDC subject (sub)
+            if auth_source == "oidc":
+                oidc_subject = getattr(access_token, "oidc_subject", None)
+                if not oidc_subject:
+                    raise ValueError("Authenticated MCP OIDC token is missing a subject")
+                user = db.scalar(select(User).where(User.oidc_subject == oidc_subject).where(User.is_active.is_(True)))
+                if user is None:
+                    raise ValueError(f"No active user found for OIDC subject: {oidc_subject}")
+                return user
+
+            client_id = access_token.client_id
             if not client_id:
                 raise ValueError("Authenticated MCP access token is missing a client ID")
-            user = db.scalar(select(User).where(User.oidc_subject == client_id).where(User.is_active.is_(True)))
-            if user is None:
-                raise ValueError(f"No active user or integration found for client ID: {client_id}")
-            return user
+            raise ValueError(f"Unsupported MCP access token source for client ID: {client_id}")
 
         configured_email = self.user_email or os.getenv(DAYNEST_USER_EMAIL_ENV)
         if configured_email:
@@ -287,7 +292,7 @@ class DaynestMcpBackend:
 
 
 class IntegrationKeyTokenVerifier(TokenVerifier):
-    REQUIRED_SCOPE = "mcp:read"
+    REQUIRED_SCOPE = MCP_READ_SCOPE
 
     def __init__(self, session_factory: Callable[[], Session], *, resource_server_url: str | None = None) -> None:
         self.session_factory = session_factory
@@ -312,14 +317,50 @@ class IntegrationKeyTokenVerifier(TokenVerifier):
                 return None
 
             scopes = [scope.strip() for scope in client.scopes_csv.split(",") if scope.strip()]
-            return AccessToken(
+            return DaynestMcpAccessToken(
                 token=token,
                 client_id=str(client.id),
                 scopes=scopes,
                 resource=self.resource_server_url,
+                auth_source="integration",
+                integration_client_id=client.id,
             )
         finally:
             session.close()
+
+
+class DaynestMcpAccessToken(AccessToken):
+    auth_source: Literal["integration", "oidc"]
+    integration_client_id: int | None = None
+    oidc_subject: str | None = None
+
+
+def _claim_strings(value: Any) -> list[str]:
+    if isinstance(value, str):
+        return [item for item in value.split() if item]
+    if isinstance(value, list):
+        return [str(item) for item in value if item is not None]
+    return []
+
+
+def _dedupe(values: list[str]) -> list[str]:
+    return list(dict.fromkeys(values))
+
+
+def _matches_resource_audience(audience: Any, resource_server_url: str | None) -> bool:
+    if not resource_server_url:
+        return False
+    expected = resource_server_url.rstrip("/")
+    return any(value.rstrip("/") == expected for value in _claim_strings(audience))
+
+
+def _authorized_mcp_scopes(claims: dict[str, Any], resource_server_url: str | None) -> list[str] | None:
+    scopes = _dedupe([*_claim_strings(claims.get("scope")), *_claim_strings(claims.get("scp"))])
+    if MCP_READ_SCOPE in scopes:
+        return scopes
+    if _matches_resource_audience(claims.get("aud"), resource_server_url):
+        return [*scopes, MCP_READ_SCOPE]
+    return None
 
 
 class OIDCMcpTokenVerifier(TokenVerifier):
@@ -341,6 +382,10 @@ class OIDCMcpTokenVerifier(TokenVerifier):
         subject: str | None = claims.get("sub")
         if not subject:
             return None
+        scopes = _authorized_mcp_scopes(claims, self.resource_server_url)
+        if scopes is None:
+            logger.debug("OIDC token for subject %s does not authorize MCP access", subject)
+            return None
 
         session = self.session_factory()
         try:
@@ -353,11 +398,13 @@ class OIDCMcpTokenVerifier(TokenVerifier):
         finally:
             session.close()
 
-        return AccessToken(
+        return DaynestMcpAccessToken(
             token=token,
             client_id=subject,
-            scopes=["mcp:read"],
+            scopes=scopes,
             resource=self.resource_server_url,
+            auth_source="oidc",
+            oidc_subject=subject,
         )
 
 
@@ -401,8 +448,8 @@ def create_mcp_server(backend: DaynestMcpBackend | None = None) -> FastMCP:
         json_response=True,
         streamable_http_path="/",  # mounted at /mcp in FastAPI; prefix is stripped before the sub-app sees it
         token_verifier=ComposedTokenVerifier(
-            OIDCMcpTokenVerifier(SessionLocal, resource_server_url=resource_server_url),
-            IntegrationKeyTokenVerifier(SessionLocal, resource_server_url=resource_server_url),
+            OIDCMcpTokenVerifier(daynest.session_factory, resource_server_url=resource_server_url),
+            IntegrationKeyTokenVerifier(daynest.session_factory, resource_server_url=resource_server_url),
         ),
         auth=_build_auth_settings(resource_server_url),
         transport_security=_build_transport_security(),

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,4 +1,5 @@
 from collections.abc import Generator
+from contextlib import asynccontextmanager
 
 import pytest
 from fastapi.testclient import TestClient
@@ -9,6 +10,11 @@ from sqlalchemy.pool import StaticPool
 from app.db.base import Base
 from app.db.session import get_db
 from app.main import app
+
+
+@asynccontextmanager
+async def _skip_lifespan(app):
+    yield
 
 
 @pytest.fixture()
@@ -37,7 +43,11 @@ def client(db_session: Session) -> Generator[TestClient, None, None]:
 
     app.dependency_overrides[get_db] = override_get_db
 
-    with TestClient(app, base_url="http://localhost") as test_client:
-        yield test_client
-
-    app.dependency_overrides.pop(get_db, None)
+    original_lifespan_context = app.router.lifespan_context
+    app.router.lifespan_context = _skip_lifespan
+    try:
+        with TestClient(app, base_url="http://localhost") as test_client:
+            yield test_client
+    finally:
+        app.router.lifespan_context = original_lifespan_context
+        app.dependency_overrides.pop(get_db, None)

--- a/backend/tests/test_mcp_server.py
+++ b/backend/tests/test_mcp_server.py
@@ -165,3 +165,32 @@ def test_mcp_backend_uses_authenticated_integration_owner(db_session: Session, m
     whoami = backend.whoami()
 
     assert whoami["email"] == "auth-owner@example.com"
+
+
+def test_mcp_backend_falls_back_to_oidc_for_numeric_subject(db_session: Session, monkeypatch) -> None:
+    user = _create_user(db_session, "numeric-oidc@example.com")
+    user.oidc_subject = "123456"
+    db_session.commit()
+    backend = DaynestMcpBackend(_session_factory(db_session))
+
+    class AccessTokenStub:
+        client_id = "123456"
+
+    monkeypatch.setattr("app.mcp_server.get_access_token", lambda: AccessTokenStub())
+
+    whoami = backend.whoami()
+
+    assert whoami["email"] == "numeric-oidc@example.com"
+
+
+def test_mcp_backend_rejects_authenticated_token_without_client_id(db_session: Session, monkeypatch) -> None:
+    _create_user(db_session, "missing-subject@example.com")
+    backend = DaynestMcpBackend(_session_factory(db_session))
+
+    class AccessTokenStub:
+        client_id = None
+
+    monkeypatch.setattr("app.mcp_server.get_access_token", lambda: AccessTokenStub())
+
+    with pytest.raises(ValueError, match="missing a client ID"):
+        backend.whoami()

--- a/backend/tests/test_mcp_server.py
+++ b/backend/tests/test_mcp_server.py
@@ -6,7 +6,7 @@ import pytest
 from sqlalchemy.orm import Session, sessionmaker
 
 from app.api.dependencies.integration_auth import hash_integration_key
-from app.mcp_server import DaynestMcpBackend, IntegrationKeyTokenVerifier
+from app.mcp_server import DaynestMcpAccessToken, DaynestMcpBackend, IntegrationKeyTokenVerifier, OIDCMcpTokenVerifier, create_mcp_server
 from app.models.chore_template import ChoreTemplate
 from app.models.integration_client import IntegrationClient
 from app.models.medication_plan import MedicationPlan
@@ -138,6 +138,8 @@ def test_integration_key_token_verifier_accepts_mcp_scoped_key(db_session: Sessi
 
     assert token is not None
     assert token.client_id == str(client.id)
+    assert token.auth_source == "integration"
+    assert token.integration_client_id == client.id
     assert "mcp:read" in token.scopes
     assert token.resource == "https://daynest.example.com/mcp"
 
@@ -156,27 +158,35 @@ def test_mcp_backend_uses_authenticated_integration_owner(db_session: Session, m
     user = _create_user(db_session, "auth-owner@example.com")
     client = _create_integration_client(db_session, user, raw_key="daynest_auth_owner")
     backend = DaynestMcpBackend(_session_factory(db_session))
+    access_token = DaynestMcpAccessToken(
+        token="token",
+        client_id=str(client.id),
+        scopes=["mcp:read"],
+        auth_source="integration",
+        integration_client_id=client.id,
+    )
 
-    class AccessTokenStub:
-        client_id = str(client.id)
-
-    monkeypatch.setattr("app.mcp_server.get_access_token", lambda: AccessTokenStub())
+    monkeypatch.setattr("app.mcp_server.get_access_token", lambda: access_token)
 
     whoami = backend.whoami()
 
     assert whoami["email"] == "auth-owner@example.com"
 
 
-def test_mcp_backend_falls_back_to_oidc_for_numeric_subject(db_session: Session, monkeypatch) -> None:
+def test_mcp_backend_resolves_oidc_numeric_subject(db_session: Session, monkeypatch) -> None:
     user = _create_user(db_session, "numeric-oidc@example.com")
     user.oidc_subject = "123456"
     db_session.commit()
     backend = DaynestMcpBackend(_session_factory(db_session))
+    access_token = DaynestMcpAccessToken(
+        token="token",
+        client_id="123456",
+        scopes=["mcp:read"],
+        auth_source="oidc",
+        oidc_subject="123456",
+    )
 
-    class AccessTokenStub:
-        client_id = "123456"
-
-    monkeypatch.setattr("app.mcp_server.get_access_token", lambda: AccessTokenStub())
+    monkeypatch.setattr("app.mcp_server.get_access_token", lambda: access_token)
 
     whoami = backend.whoami()
 
@@ -187,10 +197,74 @@ def test_mcp_backend_rejects_authenticated_token_without_client_id(db_session: S
     _create_user(db_session, "missing-subject@example.com")
     backend = DaynestMcpBackend(_session_factory(db_session))
 
-    class AccessTokenStub:
-        client_id = None
+    access_token = DaynestMcpAccessToken(token="token", client_id="", scopes=["mcp:read"], auth_source="oidc")
 
-    monkeypatch.setattr("app.mcp_server.get_access_token", lambda: AccessTokenStub())
+    monkeypatch.setattr("app.mcp_server.get_access_token", lambda: access_token)
 
-    with pytest.raises(ValueError, match="missing a client ID"):
+    with pytest.raises(ValueError, match="missing a subject"):
         backend.whoami()
+
+
+def test_oidc_mcp_token_verifier_uses_scope_claim(db_session: Session, monkeypatch) -> None:
+    async def decode_oidc_token(_token: str) -> dict[str, str]:
+        return {
+            "sub": "oidc-subject",
+            "email": "oidc@example.com",
+            "scope": "openid profile mcp:read",
+        }
+
+    monkeypatch.setattr("app.core.oidc.decode_oidc_token", decode_oidc_token)
+    verifier = OIDCMcpTokenVerifier(_session_factory(db_session), resource_server_url="https://daynest.example.com/mcp")
+
+    token = asyncio.run(verifier.verify_token("oidc-token"))
+
+    assert token is not None
+    assert token.auth_source == "oidc"
+    assert token.oidc_subject == "oidc-subject"
+    assert token.scopes == ["openid", "profile", "mcp:read"]
+
+
+def test_oidc_mcp_token_verifier_accepts_resource_audience(db_session: Session, monkeypatch) -> None:
+    async def decode_oidc_token(_token: str) -> dict[str, str | list[str]]:
+        return {
+            "sub": "aud-subject",
+            "email": "aud@example.com",
+            "scp": ["openid"],
+            "aud": ["https://daynest.example.com/mcp"],
+        }
+
+    monkeypatch.setattr("app.core.oidc.decode_oidc_token", decode_oidc_token)
+    verifier = OIDCMcpTokenVerifier(_session_factory(db_session), resource_server_url="https://daynest.example.com/mcp")
+
+    token = asyncio.run(verifier.verify_token("oidc-token"))
+
+    assert token is not None
+    assert token.scopes == ["openid", "mcp:read"]
+
+
+def test_oidc_mcp_token_verifier_rejects_unscoped_token(db_session: Session, monkeypatch) -> None:
+    async def decode_oidc_token(_token: str) -> dict[str, str]:
+        return {
+            "sub": "unscoped-subject",
+            "email": "unscoped@example.com",
+            "scope": "openid profile",
+            "aud": "daynest",
+        }
+
+    monkeypatch.setattr("app.core.oidc.decode_oidc_token", decode_oidc_token)
+    verifier = OIDCMcpTokenVerifier(_session_factory(db_session), resource_server_url="https://daynest.example.com/mcp")
+
+    token = asyncio.run(verifier.verify_token("oidc-token"))
+
+    assert token is None
+
+
+def test_create_mcp_server_uses_backend_session_factory(db_session: Session) -> None:
+    session_factory = _session_factory(db_session)
+    backend = DaynestMcpBackend(session_factory)
+
+    mcp = create_mcp_server(backend)
+
+    token_verifier = mcp._token_verifier  # noqa: SLF001
+    assert token_verifier is not None
+    assert [verifier.session_factory for verifier in token_verifier._verifiers] == [session_factory, session_factory]  # noqa: SLF001

--- a/frontend/.env.production
+++ b/frontend/.env.production
@@ -1,0 +1,2 @@
+VITE_OIDC_AUTHORITY=https://auth.tjor.im/realms/daynest
+VITE_OIDC_CLIENT_ID=daynest


### PR DESCRIPTION
## Summary

- Adds `OIDCMcpTokenVerifier` that validates Keycloak-issued tokens for MCP access, using the same `decode_oidc_token` / `get_or_create_local_user` pipeline as the REST API
- Adds `ComposedTokenVerifier` that tries OIDC first, falls back to integration keys — preserving backward compatibility for existing static-key clients (e.g. Home Assistant)
- Wires the FastMCP `StreamableHTTPSessionManager` lifespan into FastAPI's lifespan context, fixing `RuntimeError: Task group is not initialized` on every MCP request
- Adds `.env.production` so Vite bakes the correct Keycloak authority (`auth.tjor.im`) into the frontend bundle instead of `localhost:8080`

## Test plan

- [ ] Claude.ai MCP connector authenticates via Keycloak OAuth flow and connects successfully
- [ ] Existing integration key tokens still work for MCP access
- [ ] Frontend login redirects to Keycloak instead of local auth form
- [ ] `GET /api/v1/auth/me` returns 200 after Keycloak login (token `aud` claim contains `daynest`)

## Related

- Keycloak bootstrap changes (infra repo): `daynest` and `daynest-mcp` clients, `mcp:read` scope, audience mappers, Trusted Hosts policy

🤖 Generated with [Claude Code](https://claude.com/claude-code)