### PR TITLE
feat: single-URL OIDC discovery across all clients

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -55,8 +55,6 @@ jobs:
         env:
           API_BASE_URL_STAGING: ${{ secrets.API_BASE_URL_STAGING }}
           API_BASE_URL_RELEASE: ${{ secrets.API_BASE_URL_RELEASE }}
-          OIDC_ISSUER_URL_STAGING: ${{ secrets.OIDC_ISSUER_URL_STAGING }}
-          OIDC_ISSUER_URL_RELEASE: ${{ secrets.OIDC_ISSUER_URL_RELEASE }}
         run: |
           if [[ -n "${API_BASE_URL_STAGING}" ]]; then
             echo "staging_available=true" >> "$GITHUB_OUTPUT"
@@ -74,8 +72,6 @@ jobs:
             # .invalid TLD is an RFC 2606 reserved domain intentionally unusable in production
             echo "apiBaseUrlStaging=${API_BASE_URL_STAGING:-https://staging.placeholder.invalid/}"
             echo "apiBaseUrlRelease=${API_BASE_URL_RELEASE:-https://release.placeholder.invalid/}"
-            echo "oidcIssuerUrlStaging=${OIDC_ISSUER_URL_STAGING:-https://staging.placeholder.invalid/realms/daynest}"
-            echo "oidcIssuerUrlRelease=${OIDC_ISSUER_URL_RELEASE:-https://release.placeholder.invalid/realms/daynest}"
           } >> local.properties
 
       - name: Run Android checks

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -62,8 +62,6 @@ jobs:
           {
             echo "apiBaseUrlStaging=https://staging.placeholder.invalid/"
             echo "apiBaseUrlRelease=https://release.placeholder.invalid/"
-            echo "oidcIssuerUrlStaging=https://staging.placeholder.invalid/realms/daynest"
-            echo "oidcIssuerUrlRelease=https://release.placeholder.invalid/realms/daynest"
           } >> local.properties
 
       - name: Build for analysis

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -120,7 +120,7 @@ jobs:
         working-directory: android
         env:
           API_BASE_URL_RELEASE: ${{ secrets.API_BASE_URL_RELEASE }}
-          OIDC_ISSUER_URL_RELEASE: ${{ secrets.OIDC_ISSUER_URL_RELEASE }}
+          API_BASE_URL_STAGING: ${{ secrets.API_BASE_URL_STAGING }}
         run: |
           if [[ -n "${API_BASE_URL_RELEASE}" ]]; then
             echo "release_available=true" >> "$GITHUB_OUTPUT"
@@ -129,10 +129,8 @@ jobs:
             echo "release_available=false" >> "$GITHUB_OUTPUT"
           fi
           {
-            echo "apiBaseUrlStaging=https://staging.placeholder.invalid/"
+            echo "apiBaseUrlStaging=${API_BASE_URL_STAGING:-https://staging.placeholder.invalid/}"
             echo "apiBaseUrlRelease=${API_BASE_URL_RELEASE:-https://release.placeholder.invalid/}"
-            echo "oidcIssuerUrlStaging=https://staging.placeholder.invalid/realms/daynest"
-            echo "oidcIssuerUrlRelease=${OIDC_ISSUER_URL_RELEASE:-https://release.placeholder.invalid/realms/daynest}"
           } >> local.properties
 
       - name: Decode keystore

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -123,14 +123,6 @@ extensions.configure<ApplicationExtension> {
             buildConfigField("String", "API_BASE_URL", "\"$url\"")
             buildConfigField("String[]", "PROD_PINS", "new String[]{}")
             buildConfigField("String", "PROD_HOST", "\"\"")
-            val oidcIssuerUrl =
-                resolveApiUrl(
-                    "oidcIssuerUrl",
-                    "OIDC_ISSUER_URL",
-                    required = false,
-                    default = "http://10.0.2.2:8080/realms/daynest",
-                )
-            buildConfigField("String", "OIDC_ISSUER_URL", "\"$oidcIssuerUrl\"")
             buildConfigField("String", "OIDC_CLIENT_ID", "\"daynest\"")
             buildConfigField("String", "OIDC_REDIRECT_URI", "\"com.daynest.android:/oauth2redirect\"")
         }
@@ -148,14 +140,6 @@ extensions.configure<ApplicationExtension> {
             buildConfigField("String", "API_BASE_URL", "\"$url\"")
             buildConfigField("String[]", "PROD_PINS", "new String[]{}")
             buildConfigField("String", "PROD_HOST", "\"\"")
-            val oidcIssuerUrl =
-                resolveApiUrl(
-                    "oidcIssuerUrlStaging",
-                    "OIDC_ISSUER_URL_STAGING",
-                    required = false,
-                    default = "https://staging.placeholder.invalid/realms/daynest",
-                )
-            buildConfigField("String", "OIDC_ISSUER_URL", "\"$oidcIssuerUrl\"")
             buildConfigField("String", "OIDC_CLIENT_ID", "\"daynest\"")
             buildConfigField("String", "OIDC_REDIRECT_URI", "\"com.daynest.android:/oauth2redirect\"")
         }
@@ -201,14 +185,6 @@ extensions.configure<ApplicationExtension> {
             }
             buildConfigField("String[]", "PROD_PINS", pinsArrayLiteral(pins))
             buildConfigField("String", "PROD_HOST", "\"${prodHost.orEmpty()}\"")
-            val oidcIssuerUrl =
-                resolveApiUrl(
-                    "oidcIssuerUrlRelease",
-                    "OIDC_ISSUER_URL_RELEASE",
-                    required = isRequested,
-                    default = if (isRequested) "" else "https://release.placeholder.invalid/realms/daynest",
-                )
-            buildConfigField("String", "OIDC_ISSUER_URL", "\"$oidcIssuerUrl\"")
             buildConfigField("String", "OIDC_CLIENT_ID", "\"daynest\"")
             buildConfigField("String", "OIDC_REDIRECT_URI", "\"com.daynest.android:/oauth2redirect\"")
         }

--- a/android/app/src/main/java/com/daynest/android/core/auth/OidcAuthService.kt
+++ b/android/app/src/main/java/com/daynest/android/core/auth/OidcAuthService.kt
@@ -4,10 +4,14 @@ import android.app.Activity
 import android.content.Context
 import android.content.Intent
 import android.content.SharedPreferences
+import android.net.Uri
+import com.daynest.android.core.network.ServerUrlHolder
 import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withContext
 import net.openid.appauth.AuthState
 import net.openid.appauth.AuthorizationException
 import net.openid.appauth.AuthorizationRequest
@@ -15,6 +19,10 @@ import net.openid.appauth.AuthorizationResponse
 import net.openid.appauth.AuthorizationService
 import net.openid.appauth.AuthorizationServiceConfiguration
 import net.openid.appauth.ResponseTypeValues
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import org.json.JSONObject
+import java.io.IOException
 import javax.inject.Inject
 import javax.inject.Singleton
 import kotlin.coroutines.resume
@@ -26,13 +34,16 @@ class OidcAuthService
     constructor(
         @param:ApplicationContext private val context: Context,
         private val securePreferences: SharedPreferences,
+        private val serverUrlHolder: ServerUrlHolder,
     ) {
         private val authorizationService = AuthorizationService(context)
         private val mutex = Mutex()
+        private val discoveryClient = OkHttpClient()
 
         @Volatile private var authState: AuthState = loadPersistedState()
 
         @Volatile private var serviceConfiguration: AuthorizationServiceConfiguration? = null
+        @Volatile private var cachedIssuerUri: Uri? = null
 
         val isAuthorized: Boolean get() = authState.isAuthorized
         val currentAccessToken: String? get() = authState.accessToken
@@ -91,10 +102,25 @@ class OidcAuthService
 
         fun signOut() = clearState()
 
+        private suspend fun resolveIssuerUri(): Uri {
+            cachedIssuerUri?.let { return it }
+            val url = "${serverUrlHolder.currentUrl.trimEnd('/')}/$OIDC_CONFIG_PATH"
+            val issuer = withContext(Dispatchers.IO) {
+                val request = Request.Builder().url(url).build()
+                discoveryClient.newCall(request).execute().use { response ->
+                    val body = response.body?.string()
+                        ?: throw IOException("Empty response from OIDC config endpoint")
+                    JSONObject(body).getString("issuer")
+                }
+            }
+            return Uri.parse(issuer).also { cachedIssuerUri = it }
+        }
+
         private suspend fun discoverServiceConfiguration(): AuthorizationServiceConfiguration {
             serviceConfiguration?.let { return it }
+            val issuerUri = resolveIssuerUri()
             return suspendCancellableCoroutine { cont ->
-                AuthorizationServiceConfiguration.fetchFromIssuer(OidcConfig.issuerUri) { config, ex ->
+                AuthorizationServiceConfiguration.fetchFromIssuer(issuerUri) { config, ex ->
                     if (config != null) {
                         serviceConfiguration = config
                         cont.resume(config)
@@ -122,5 +148,6 @@ class OidcAuthService
 
         companion object {
             private const val KEY_AUTH_STATE = "oidc_auth_state"
+            private const val OIDC_CONFIG_PATH = "api/v1/auth/oidc-config"
         }
     }

--- a/android/app/src/main/java/com/daynest/android/core/auth/OidcAuthService.kt
+++ b/android/app/src/main/java/com/daynest/android/core/auth/OidcAuthService.kt
@@ -111,9 +111,15 @@ class OidcAuthService
                 withContext(Dispatchers.IO) {
                     val request = Request.Builder().url(url).build()
                     discoveryClient.newCall(request).execute().use { response ->
-                        val body =
-                            response.body?.string()
-                                ?: throw IOException("Empty response from OIDC config endpoint")
+                        val body = response.body.string()
+                        if (!response.isSuccessful) {
+                            throw IOException(
+                                "OIDC config endpoint returned HTTP ${response.code} ${response.message}: $body",
+                            )
+                        }
+                        if (body.isBlank()) {
+                            throw IOException("Empty response from OIDC config endpoint")
+                        }
                         JSONObject(body).getString("issuer")
                     }
                 }

--- a/android/app/src/main/java/com/daynest/android/core/auth/OidcAuthService.kt
+++ b/android/app/src/main/java/com/daynest/android/core/auth/OidcAuthService.kt
@@ -24,6 +24,7 @@ import okhttp3.Request
 import org.json.JSONObject
 import java.io.IOException
 import javax.inject.Inject
+import javax.inject.Named
 import javax.inject.Singleton
 import kotlin.coroutines.resume
 import kotlin.coroutines.resumeWithException
@@ -35,14 +36,15 @@ class OidcAuthService
         @param:ApplicationContext private val context: Context,
         private val securePreferences: SharedPreferences,
         private val serverUrlHolder: ServerUrlHolder,
+        @Named("discovery") private val discoveryClient: OkHttpClient,
     ) {
         private val authorizationService = AuthorizationService(context)
         private val mutex = Mutex()
-        private val discoveryClient = OkHttpClient()
 
         @Volatile private var authState: AuthState = loadPersistedState()
 
         @Volatile private var serviceConfiguration: AuthorizationServiceConfiguration? = null
+
         @Volatile private var cachedIssuerUri: Uri? = null
 
         val isAuthorized: Boolean get() = authState.isAuthorized
@@ -105,14 +107,16 @@ class OidcAuthService
         private suspend fun resolveIssuerUri(): Uri {
             cachedIssuerUri?.let { return it }
             val url = "${serverUrlHolder.currentUrl.trimEnd('/')}/$OIDC_CONFIG_PATH"
-            val issuer = withContext(Dispatchers.IO) {
-                val request = Request.Builder().url(url).build()
-                discoveryClient.newCall(request).execute().use { response ->
-                    val body = response.body?.string()
-                        ?: throw IOException("Empty response from OIDC config endpoint")
-                    JSONObject(body).getString("issuer")
+            val issuer =
+                withContext(Dispatchers.IO) {
+                    val request = Request.Builder().url(url).build()
+                    discoveryClient.newCall(request).execute().use { response ->
+                        val body =
+                            response.body?.string()
+                                ?: throw IOException("Empty response from OIDC config endpoint")
+                        JSONObject(body).getString("issuer")
+                    }
                 }
-            }
             return Uri.parse(issuer).also { cachedIssuerUri = it }
         }
 

--- a/android/app/src/main/java/com/daynest/android/core/auth/OidcConfig.kt
+++ b/android/app/src/main/java/com/daynest/android/core/auth/OidcConfig.kt
@@ -4,7 +4,6 @@ import android.net.Uri
 import com.daynest.android.BuildConfig
 
 internal object OidcConfig {
-    val issuerUri: Uri = Uri.parse(BuildConfig.OIDC_ISSUER_URL)
     val clientId: String = BuildConfig.OIDC_CLIENT_ID
     val redirectUri: Uri = Uri.parse(BuildConfig.OIDC_REDIRECT_URI)
     val scopes: List<String> = listOf("openid", "profile", "email")

--- a/android/app/src/main/java/com/daynest/android/core/auth/OidcDiscovery.kt
+++ b/android/app/src/main/java/com/daynest/android/core/auth/OidcDiscovery.kt
@@ -1,0 +1,7 @@
+package com.daynest.android.core.auth
+
+internal data class OidcDiscovery(
+    val issuer: String,
+    val authorizationUrl: String,
+    val tokenUrl: String,
+)

--- a/android/app/src/main/java/com/daynest/android/core/di/NetworkApiDiModule.kt
+++ b/android/app/src/main/java/com/daynest/android/core/di/NetworkApiDiModule.kt
@@ -1,0 +1,47 @@
+package com.daynest.android.core.di
+
+import com.daynest.android.data.calendar.CalendarApi
+import com.daynest.android.data.medication.MedicationApi
+import com.daynest.android.data.settings.SettingsApi
+import com.daynest.android.data.templates.TemplatesApi
+import com.daynest.android.data.today.PlannedItemApi
+import com.daynest.android.data.today.TodayActionsApi
+import com.daynest.android.data.today.TodayApi
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import retrofit2.Retrofit
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+object NetworkApiDiModule {
+    @Provides
+    @Singleton
+    fun provideTodayApi(retrofit: Retrofit): TodayApi = retrofit.create(TodayApi::class.java)
+
+    @Provides
+    @Singleton
+    fun provideTodayActionsApi(retrofit: Retrofit): TodayActionsApi = retrofit.create(TodayActionsApi::class.java)
+
+    @Provides
+    @Singleton
+    fun providePlannedItemApi(retrofit: Retrofit): PlannedItemApi = retrofit.create(PlannedItemApi::class.java)
+
+    @Provides
+    @Singleton
+    fun provideCalendarApi(retrofit: Retrofit): CalendarApi = retrofit.create(CalendarApi::class.java)
+
+    @Provides
+    @Singleton
+    fun provideMedicationApi(retrofit: Retrofit): MedicationApi = retrofit.create(MedicationApi::class.java)
+
+    @Provides
+    @Singleton
+    fun provideTemplatesApi(retrofit: Retrofit): TemplatesApi = retrofit.create(TemplatesApi::class.java)
+
+    @Provides
+    @Singleton
+    fun provideSettingsApi(retrofit: Retrofit): SettingsApi = retrofit.create(SettingsApi::class.java)
+}

--- a/android/app/src/main/java/com/daynest/android/core/di/NetworkDiModule.kt
+++ b/android/app/src/main/java/com/daynest/android/core/di/NetworkDiModule.kt
@@ -25,6 +25,7 @@ import okhttp3.OkHttpClient
 import okhttp3.logging.HttpLoggingInterceptor
 import retrofit2.Retrofit
 import retrofit2.converter.kotlinx.serialization.asConverterFactory
+import javax.inject.Named
 import javax.inject.Singleton
 
 @Module
@@ -41,6 +42,15 @@ object NetworkDiModule {
             host = BuildConfig.PROD_HOST,
             pins = BuildConfig.PROD_PINS.toList(),
         ).get()
+
+    @Provides
+    @Singleton
+    @Named("discovery")
+    fun provideDiscoveryOkHttpClient(certificatePinner: CertificatePinner): OkHttpClient =
+        OkHttpClient
+            .Builder()
+            .certificatePinner(certificatePinner)
+            .build()
 
     @Provides
     @Singleton

--- a/android/app/src/main/java/com/daynest/android/core/di/NetworkDiModule.kt
+++ b/android/app/src/main/java/com/daynest/android/core/di/NetworkDiModule.kt
@@ -7,13 +7,6 @@ import com.daynest.android.core.network.CertificatePinnerProvider
 import com.daynest.android.core.network.DynamicBaseUrlInterceptor
 import com.daynest.android.core.network.JsonSerializer
 import com.daynest.android.core.network.TokenAuthenticator
-import com.daynest.android.data.calendar.CalendarApi
-import com.daynest.android.data.medication.MedicationApi
-import com.daynest.android.data.settings.SettingsApi
-import com.daynest.android.data.templates.TemplatesApi
-import com.daynest.android.data.today.PlannedItemApi
-import com.daynest.android.data.today.TodayActionsApi
-import com.daynest.android.data.today.TodayApi
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -89,32 +82,4 @@ object NetworkDiModule {
             .client(okHttpClient)
             .addConverterFactory(json.asConverterFactory("application/json".toMediaType()))
             .build()
-
-    @Provides
-    @Singleton
-    fun provideTodayApi(retrofit: Retrofit): TodayApi = retrofit.create(TodayApi::class.java)
-
-    @Provides
-    @Singleton
-    fun provideTodayActionsApi(retrofit: Retrofit): TodayActionsApi = retrofit.create(TodayActionsApi::class.java)
-
-    @Provides
-    @Singleton
-    fun providePlannedItemApi(retrofit: Retrofit): PlannedItemApi = retrofit.create(PlannedItemApi::class.java)
-
-    @Provides
-    @Singleton
-    fun provideCalendarApi(retrofit: Retrofit): CalendarApi = retrofit.create(CalendarApi::class.java)
-
-    @Provides
-    @Singleton
-    fun provideMedicationApi(retrofit: Retrofit): MedicationApi = retrofit.create(MedicationApi::class.java)
-
-    @Provides
-    @Singleton
-    fun provideTemplatesApi(retrofit: Retrofit): TemplatesApi = retrofit.create(TemplatesApi::class.java)
-
-    @Provides
-    @Singleton
-    fun provideSettingsApi(retrofit: Retrofit): SettingsApi = retrofit.create(SettingsApi::class.java)
 }

--- a/android/local.properties.example
+++ b/android/local.properties.example
@@ -16,3 +16,4 @@
 # Release API base URL (required for :app:assembleRelease builds).
 # Must end with a trailing slash.
 # apiBaseUrlRelease=https://api.daynest.com/
+

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -15,10 +15,6 @@ CORS_ALLOW_ORIGINS=http://localhost:5173,http://127.0.0.1:5173
 TRUSTED_HOSTS=localhost,127.0.0.1
 DAYNEST_USER_EMAIL=
 DAYNEST_MCP_RESOURCE_SERVER_URL=http://127.0.0.1:8000/mcp
-# Keycloak realm URL — FastMCP uses this to populate /.well-known/oauth-authorization-server
-DAYNEST_MCP_ISSUER_URL=https://auth.tjor.im/realms/daynest
-DAYNEST_MCP_ALLOWED_HOSTS=localhost,127.0.0.1
-DAYNEST_MCP_ALLOWED_ORIGINS=http://localhost:5173,http://127.0.0.1:5173
 # Optional / security
 METRICS_SECRET=
 INTEGRATION_KEY_HASH_SECRET=

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -15,7 +15,8 @@ CORS_ALLOW_ORIGINS=http://localhost:5173,http://127.0.0.1:5173
 TRUSTED_HOSTS=localhost,127.0.0.1
 DAYNEST_USER_EMAIL=
 DAYNEST_MCP_RESOURCE_SERVER_URL=http://127.0.0.1:8000/mcp
-DAYNEST_MCP_ISSUER_URL=http://127.0.0.1:8000/mcp
+# Keycloak realm URL — FastMCP uses this to populate /.well-known/oauth-authorization-server
+DAYNEST_MCP_ISSUER_URL=https://auth.tjor.im/realms/daynest
 DAYNEST_MCP_ALLOWED_HOSTS=localhost,127.0.0.1
 DAYNEST_MCP_ALLOWED_ORIGINS=http://localhost:5173,http://127.0.0.1:5173
 # Optional / security

--- a/backend/app/api/routes/auth.py
+++ b/backend/app/api/routes/auth.py
@@ -10,7 +10,7 @@ from app.api.dependencies.auth import bearer_scheme, get_current_user
 from app.core.config import settings
 from app.db.session import get_db
 from app.models.user import User
-from app.schemas.auth import OAuthSessionResponse, UserMeResponse, UserUpdateRequest
+from app.schemas.auth import OAuthSessionResponse, OidcDiscoveryConfig, UserMeResponse, UserUpdateRequest
 
 logger = logging.getLogger(__name__)
 
@@ -31,6 +31,19 @@ def _user_to_response(user: User, roles: list[str]) -> UserMeResponse:
         is_active=user.is_active,
         timezone=user.timezone,
         roles=roles,
+    )
+
+
+@router.get("/oidc-config", response_model=OidcDiscoveryConfig)
+def oidc_config() -> OidcDiscoveryConfig:
+    """Return OIDC discovery config (unauthenticated). All clients use this to discover Keycloak endpoints."""
+    if not settings.oidc_issuer_url:
+        raise HTTPException(status_code=status.HTTP_503_SERVICE_UNAVAILABLE, detail="OIDC not configured on this server")
+    issuer = settings.oidc_issuer_url.rstrip("/")
+    return OidcDiscoveryConfig(
+        issuer=issuer,
+        authorization_url=f"{issuer}/protocol/openid-connect/auth",
+        token_url=f"{issuer}/protocol/openid-connect/token",
     )
 
 

--- a/backend/app/api/routes/auth.py
+++ b/backend/app/api/routes/auth.py
@@ -40,10 +40,12 @@ def oidc_config() -> OidcDiscoveryConfig:
     if not settings.oidc_issuer_url:
         raise HTTPException(status_code=status.HTTP_503_SERVICE_UNAVAILABLE, detail="OIDC not configured on this server")
     issuer = settings.oidc_issuer_url.rstrip("/")
-    return OidcDiscoveryConfig(
-        issuer=issuer,
-        authorization_url=f"{issuer}/protocol/openid-connect/auth",
-        token_url=f"{issuer}/protocol/openid-connect/token",
+    return OidcDiscoveryConfig.model_validate(
+        {
+            "issuer": issuer,
+            "authorization_url": f"{issuer}/protocol/openid-connect/auth",
+            "token_url": f"{issuer}/protocol/openid-connect/token",
+        }
     )
 
 

--- a/backend/app/mcp_server.py
+++ b/backend/app/mcp_server.py
@@ -42,9 +42,6 @@ if not logger.handlers:
 
 DAYNEST_USER_EMAIL_ENV = "DAYNEST_USER_EMAIL"
 DAYNEST_MCP_RESOURCE_SERVER_URL_ENV = "DAYNEST_MCP_RESOURCE_SERVER_URL"
-DAYNEST_MCP_ISSUER_URL_ENV = "DAYNEST_MCP_ISSUER_URL"
-DAYNEST_MCP_ALLOWED_ORIGINS_ENV = "DAYNEST_MCP_ALLOWED_ORIGINS"
-DAYNEST_MCP_ALLOWED_HOSTS_ENV = "DAYNEST_MCP_ALLOWED_HOSTS"
 
 T = TypeVar("T")
 MCP_READ_SCOPE = "mcp:read"
@@ -72,11 +69,6 @@ def _jsonable(value: Any) -> Any:
     return value
 
 
-def _parse_csv_env(name: str, default: list[str]) -> list[str]:
-    raw = os.getenv(name)
-    if not raw:
-        return default
-    return [item.strip() for item in raw.split(",") if item.strip()]
 
 
 def _routine_template_to_dict(t: Any) -> dict[str, Any]:
@@ -744,7 +736,7 @@ class ComposedTokenVerifier(TokenVerifier):
 
 
 def _build_auth_settings(resource_server_url: str) -> AuthSettings:
-    issuer_url = os.getenv(DAYNEST_MCP_ISSUER_URL_ENV, resource_server_url)
+    issuer_url = settings.oidc_issuer_url or resource_server_url
     return AuthSettings(
         issuer_url=AnyHttpUrl(issuer_url),
         resource_server_url=AnyHttpUrl(resource_server_url),
@@ -755,8 +747,8 @@ def _build_auth_settings(resource_server_url: str) -> AuthSettings:
 def _build_transport_security() -> TransportSecuritySettings:
     return TransportSecuritySettings(
         enable_dns_rebinding_protection=True,
-        allowed_hosts=_parse_csv_env(DAYNEST_MCP_ALLOWED_HOSTS_ENV, settings.trusted_hosts),
-        allowed_origins=_parse_csv_env(DAYNEST_MCP_ALLOWED_ORIGINS_ENV, settings.cors_allow_origins),
+        allowed_hosts=settings.trusted_hosts,
+        allowed_origins=settings.cors_allow_origins,
     )
 
 

--- a/backend/app/schemas/auth.py
+++ b/backend/app/schemas/auth.py
@@ -25,6 +25,12 @@ class UserUpdateRequest(BaseModel):
         return v
 
 
+class OidcDiscoveryConfig(BaseModel):
+    issuer: str
+    authorization_url: str
+    token_url: str
+
+
 class OAuthSessionClient(BaseModel):
     """A client entry within a Keycloak session."""
 

--- a/backend/app/schemas/auth.py
+++ b/backend/app/schemas/auth.py
@@ -1,6 +1,6 @@
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
-from pydantic import BaseModel, field_validator
+from pydantic import BaseModel, HttpUrl, field_validator
 
 
 class UserMeResponse(BaseModel):
@@ -26,9 +26,9 @@ class UserUpdateRequest(BaseModel):
 
 
 class OidcDiscoveryConfig(BaseModel):
-    issuer: str
-    authorization_url: str
-    token_url: str
+    issuer: HttpUrl
+    authorization_url: HttpUrl
+    token_url: HttpUrl
 
 
 class OAuthSessionClient(BaseModel):

--- a/backend/docs/integrations/LOCAL_MCP_SERVER.md
+++ b/backend/docs/integrations/LOCAL_MCP_SERVER.md
@@ -26,9 +26,6 @@ For hosted use, run the MCP server with Streamable HTTP:
 ```powershell
 $env:DAYNEST_MCP_TRANSPORT = "streamable-http"
 $env:DAYNEST_MCP_RESOURCE_SERVER_URL = "https://your-domain.example/mcp"
-$env:DAYNEST_MCP_ISSUER_URL = "https://your-domain.example/mcp"
-$env:DAYNEST_MCP_ALLOWED_HOSTS = "your-domain.example"
-$env:DAYNEST_MCP_ALLOWED_ORIGINS = "https://your-domain.example"
 uv run python -m app.mcp_server
 ```
 
@@ -36,9 +33,6 @@ uv run python -m app.mcp_server
 ```bash
 export DAYNEST_MCP_TRANSPORT="streamable-http"
 export DAYNEST_MCP_RESOURCE_SERVER_URL="https://your-domain.example/mcp"
-export DAYNEST_MCP_ISSUER_URL="https://your-domain.example/mcp"
-export DAYNEST_MCP_ALLOWED_HOSTS="your-domain.example"
-export DAYNEST_MCP_ALLOWED_ORIGINS="https://your-domain.example"
 uv run python -m app.mcp_server
 ```
 

--- a/custom_components/daynest/config_flow.py
+++ b/custom_components/daynest/config_flow.py
@@ -96,13 +96,13 @@ class DaynestConfigFlowHandler(config_entry_oauth2_flow.AbstractOAuth2FlowHandle
 
     async def _async_fetch_oidc_config(self, base_url: str) -> tuple[str, str, str] | None:
         """Fetch OIDC endpoints from the Daynest backend. Returns (authorization_url, token_url, client_id) or None on failure."""
-        url = f"{base_url}/api/v1/integrations/home-assistant/oidc-config"
+        url = f"{base_url}/api/v1/auth/oidc-config"
         try:
             session = async_get_clientsession(self.hass)
             async with session.get(url, timeout=aiohttp.ClientTimeout(total=10)) as resp:
                 if resp.status == 200:
                     data = await resp.json()
-                    return data["authorization_url"], data["token_url"], data.get("client_id", DEFAULT_OIDC_CLIENT_ID)
+                    return data["authorization_url"], data["token_url"], DEFAULT_OIDC_CLIENT_ID
         except Exception:  # noqa: BLE001
             pass
         return None

--- a/custom_components/tests/test_config_flow.py
+++ b/custom_components/tests/test_config_flow.py
@@ -7,10 +7,16 @@ import json
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-from daynest import DaynestAuthError, DaynestMalformedResponseError, DaynestNotFoundError, DaynestServerUnavailableError, DaynestTimeoutError
-from daynest.models import DaynestSummary
 from homeassistant import config_entries
 from homeassistant.const import CONF_URL
+from daynest import (
+    DaynestAuthError,
+    DaynestMalformedResponseError,
+    DaynestNotFoundError,
+    DaynestServerUnavailableError,
+    DaynestTimeoutError,
+)
+from daynest.models import DaynestSummary
 
 from custom_components.daynest.config_flow import (
     ERROR_AUTH,

--- a/custom_components/tests/test_config_flow.py
+++ b/custom_components/tests/test_config_flow.py
@@ -6,15 +6,8 @@ import base64
 import json
 from unittest.mock import AsyncMock, MagicMock, patch
 
-import pytest
-from daynest import (
-    DaynestAuthError,
-    DaynestMalformedResponseError,
-    DaynestNotFoundError,
-    DaynestServerUnavailableError,
-    DaynestTimeoutError,
-)
 from daynest.models import DaynestSummary
+import pytest
 
 from custom_components.daynest.config_flow import (
     ERROR_AUTH,
@@ -33,6 +26,13 @@ from custom_components.daynest.const import (
     CONF_TOKEN_URL,
     build_oidc_authorization_url,
     build_oidc_token_url,
+)
+from daynest import (
+    DaynestAuthError,
+    DaynestMalformedResponseError,
+    DaynestNotFoundError,
+    DaynestServerUnavailableError,
+    DaynestTimeoutError,
 )
 from homeassistant import config_entries
 from homeassistant.const import CONF_URL

--- a/custom_components/tests/test_config_flow.py
+++ b/custom_components/tests/test_config_flow.py
@@ -7,17 +7,6 @@ import json
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-from daynest import (
-    DaynestAuthError,
-    DaynestMalformedResponseError,
-    DaynestNotFoundError,
-    DaynestServerUnavailableError,
-    DaynestTimeoutError,
-)
-from daynest.models import DaynestSummary
-from homeassistant import config_entries
-from homeassistant.const import CONF_URL
-
 from custom_components.daynest.config_flow import (
     ERROR_AUTH,
     ERROR_CANNOT_CONNECT,
@@ -36,6 +25,16 @@ from custom_components.daynest.const import (
     build_oidc_authorization_url,
     build_oidc_token_url,
 )
+from daynest import (
+    DaynestAuthError,
+    DaynestMalformedResponseError,
+    DaynestNotFoundError,
+    DaynestServerUnavailableError,
+    DaynestTimeoutError,
+)
+from daynest.models import DaynestSummary
+from homeassistant import config_entries
+from homeassistant.const import CONF_URL
 
 CONTRACT_HEADER_VALID = "home-assistant; version=ha.v1"
 CONTRACT_HEADER_UNSUPPORTED = "home-assistant; version=ha.v99"

--- a/custom_components/tests/test_config_flow.py
+++ b/custom_components/tests/test_config_flow.py
@@ -15,6 +15,7 @@ from daynest import (
     DaynestTimeoutError,
 )
 from daynest.models import DaynestSummary
+
 from custom_components.daynest.config_flow import (
     ERROR_AUTH,
     ERROR_CANNOT_CONNECT,

--- a/custom_components/tests/test_config_flow.py
+++ b/custom_components/tests/test_config_flow.py
@@ -7,8 +7,6 @@ import json
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-from homeassistant import config_entries
-from homeassistant.const import CONF_URL
 from daynest import (
     DaynestAuthError,
     DaynestMalformedResponseError,
@@ -17,6 +15,8 @@ from daynest import (
     DaynestTimeoutError,
 )
 from daynest.models import DaynestSummary
+from homeassistant import config_entries
+from homeassistant.const import CONF_URL
 
 from custom_components.daynest.config_flow import (
     ERROR_AUTH,

--- a/custom_components/tests/test_config_flow.py
+++ b/custom_components/tests/test_config_flow.py
@@ -6,8 +6,11 @@ import base64
 import json
 from unittest.mock import AsyncMock, MagicMock, patch
 
-from daynest.models import DaynestSummary
 import pytest
+from daynest import DaynestAuthError, DaynestMalformedResponseError, DaynestNotFoundError, DaynestServerUnavailableError, DaynestTimeoutError
+from daynest.models import DaynestSummary
+from homeassistant import config_entries
+from homeassistant.const import CONF_URL
 
 from custom_components.daynest.config_flow import (
     ERROR_AUTH,
@@ -27,9 +30,6 @@ from custom_components.daynest.const import (
     build_oidc_authorization_url,
     build_oidc_token_url,
 )
-from daynest import DaynestAuthError, DaynestMalformedResponseError, DaynestNotFoundError, DaynestServerUnavailableError, DaynestTimeoutError
-from homeassistant import config_entries
-from homeassistant.const import CONF_URL
 
 CONTRACT_HEADER_VALID = "home-assistant; version=ha.v1"
 CONTRACT_HEADER_UNSUPPORTED = "home-assistant; version=ha.v99"

--- a/custom_components/tests/test_config_flow.py
+++ b/custom_components/tests/test_config_flow.py
@@ -7,6 +7,14 @@ import json
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from daynest import (
+    DaynestAuthError,
+    DaynestMalformedResponseError,
+    DaynestNotFoundError,
+    DaynestServerUnavailableError,
+    DaynestTimeoutError,
+)
+from daynest.models import DaynestSummary
 from custom_components.daynest.config_flow import (
     ERROR_AUTH,
     ERROR_CANNOT_CONNECT,
@@ -25,14 +33,6 @@ from custom_components.daynest.const import (
     build_oidc_authorization_url,
     build_oidc_token_url,
 )
-from daynest import (
-    DaynestAuthError,
-    DaynestMalformedResponseError,
-    DaynestNotFoundError,
-    DaynestServerUnavailableError,
-    DaynestTimeoutError,
-)
-from daynest.models import DaynestSummary
 from homeassistant import config_entries
 from homeassistant.const import CONF_URL
 

--- a/frontend/.env.production
+++ b/frontend/.env.production
@@ -1,2 +1,1 @@
-VITE_OIDC_AUTHORITY=https://auth.tjor.im/realms/daynest
 VITE_OIDC_CLIENT_ID=daynest

--- a/frontend/src/config/oidc.ts
+++ b/frontend/src/config/oidc.ts
@@ -34,11 +34,17 @@ interface OidcDiscovery {
 
 export async function fetchOidcConfig(): Promise<AuthProviderProps> {
   const cached = sessionStorage.getItem(DISCOVERY_CACHE_KEY);
-  let discovery: OidcDiscovery;
+  let discovery: OidcDiscovery | undefined;
 
   if (cached) {
-    discovery = JSON.parse(cached) as OidcDiscovery;
-  } else {
+    try {
+      discovery = JSON.parse(cached) as OidcDiscovery;
+    } catch {
+      sessionStorage.removeItem(DISCOVERY_CACHE_KEY);
+    }
+  }
+
+  if (!discovery) {
     const response = await fetch(buildApiUrl("/api/v1/auth/oidc-config"));
     if (!response.ok) {
       throw new Error(`OIDC discovery failed: ${response.status}`);

--- a/frontend/src/config/oidc.ts
+++ b/frontend/src/config/oidc.ts
@@ -1,7 +1,6 @@
 import type { AuthProviderProps } from "react-oidc-context";
+import { buildApiUrl } from "@/lib/api/serverConfig";
 
-const OIDC_AUTHORITY =
-  import.meta.env.VITE_OIDC_AUTHORITY ?? "http://localhost:8080/realms/daynest";
 const OIDC_CLIENT_ID = import.meta.env.VITE_OIDC_CLIENT_ID ?? "daynest";
 const OIDC_REDIRECT_URI =
   import.meta.env.VITE_OIDC_REDIRECT_URI ?? `${window.location.origin}/auth/callback`;
@@ -17,16 +16,44 @@ function resolveReturnTo(raw: unknown): string {
   return "/today";
 }
 
-export const oidcConfig: AuthProviderProps = {
-  authority: OIDC_AUTHORITY,
-  client_id: OIDC_CLIENT_ID,
-  redirect_uri: OIDC_REDIRECT_URI,
-  scope: OIDC_SCOPE,
-  automaticSilentRenew: true,
-  post_logout_redirect_uri: window.location.origin,
-  onSigninCallback: (user) => {
-    const returnTo = resolveReturnTo((user?.state as { returnTo?: string } | undefined)?.returnTo);
-    window.history.replaceState({}, document.title, returnTo);
-    window.dispatchEvent(new PopStateEvent("popstate"));
-  },
-};
+export function onSigninCallback(user: { state?: unknown } | void): void {
+  const returnTo = resolveReturnTo(
+    (user?.state as { returnTo?: string } | undefined)?.returnTo,
+  );
+  window.history.replaceState({}, document.title, returnTo);
+  window.dispatchEvent(new PopStateEvent("popstate"));
+}
+
+const DISCOVERY_CACHE_KEY = "daynest_oidc_discovery";
+
+interface OidcDiscovery {
+  issuer: string;
+  authorization_url: string;
+  token_url: string;
+}
+
+export async function fetchOidcConfig(): Promise<AuthProviderProps> {
+  const cached = sessionStorage.getItem(DISCOVERY_CACHE_KEY);
+  let discovery: OidcDiscovery;
+
+  if (cached) {
+    discovery = JSON.parse(cached) as OidcDiscovery;
+  } else {
+    const response = await fetch(buildApiUrl("/api/v1/auth/oidc-config"));
+    if (!response.ok) {
+      throw new Error(`OIDC discovery failed: ${response.status}`);
+    }
+    discovery = (await response.json()) as OidcDiscovery;
+    sessionStorage.setItem(DISCOVERY_CACHE_KEY, JSON.stringify(discovery));
+  }
+
+  return {
+    authority: discovery.issuer,
+    client_id: OIDC_CLIENT_ID,
+    redirect_uri: OIDC_REDIRECT_URI,
+    scope: OIDC_SCOPE,
+    automaticSilentRenew: true,
+    post_logout_redirect_uri: window.location.origin,
+    onSigninCallback,
+  };
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -11,7 +11,7 @@ import {
 } from "@/app/pwa/installPrompt";
 import { AppRouter } from "@/app/router/AppRouter";
 import { AuthProvider, useAuth } from "@/app/providers/AuthProvider";
-import { oidcConfig } from "@/config/oidc";
+import { fetchOidcConfig } from "@/config/oidc";
 
 function App() {
   const { isAuthenticated, isLoading, logout, user } = useAuth();
@@ -87,17 +87,33 @@ function App() {
   );
 }
 
-ReactDOM.createRoot(document.getElementById("root")!).render(
-  <React.StrictMode>
-    <OidcProvider {...oidcConfig}>
-      <BrowserRouter>
-        <AuthProvider>
-          <App />
-        </AuthProvider>
-      </BrowserRouter>
-    </OidcProvider>
-  </React.StrictMode>,
-);
+async function bootstrap() {
+  let oidcConfig;
+  try {
+    oidcConfig = await fetchOidcConfig();
+  } catch {
+    const root = document.getElementById("root");
+    if (root) {
+      root.textContent =
+        "Cannot connect to Daynest server. Please check your connection and try again.";
+    }
+    return;
+  }
+
+  ReactDOM.createRoot(document.getElementById("root")!).render(
+    <React.StrictMode>
+      <OidcProvider {...oidcConfig}>
+        <BrowserRouter>
+          <AuthProvider>
+            <App />
+          </AuthProvider>
+        </BrowserRouter>
+      </OidcProvider>
+    </React.StrictMode>,
+  );
+}
+
+bootstrap();
 
 if ("serviceWorker" in navigator && import.meta.env.PROD) {
   const appVersion = __APP_VERSION__;

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -91,7 +91,8 @@ async function bootstrap() {
   let oidcConfig;
   try {
     oidcConfig = await fetchOidcConfig();
-  } catch {
+  } catch (err) {
+    console.error("Failed to fetch OIDC config", err);
     const root = document.getElementById("root");
     if (root) {
       root.textContent =

--- a/frontend/tests/features/auth/oidcConfig.test.ts
+++ b/frontend/tests/features/auth/oidcConfig.test.ts
@@ -1,14 +1,14 @@
 // @vitest-environment jsdom
 import { describe, expect, it, vi } from "vitest";
-import { oidcConfig } from "@/config/oidc";
+import { onSigninCallback } from "@/config/oidc";
 
-describe("oidcConfig.onSigninCallback", () => {
+describe("onSigninCallback", () => {
   it("replaces auth return paths with /today and dispatches popstate", () => {
     const replaceStateSpy = vi.spyOn(window.history, "replaceState");
     const popstateListener = vi.fn();
     window.addEventListener("popstate", popstateListener);
 
-    oidcConfig.onSigninCallback?.({ state: { returnTo: "/auth" } } as never);
+    onSigninCallback({ state: { returnTo: "/auth" } });
 
     expect(replaceStateSpy).toHaveBeenCalledWith({}, document.title, "/today");
     expect(popstateListener).toHaveBeenCalledTimes(1);
@@ -19,7 +19,7 @@ describe("oidcConfig.onSigninCallback", () => {
   it("keeps safe non-auth return paths", () => {
     const replaceStateSpy = vi.spyOn(window.history, "replaceState");
 
-    oidcConfig.onSigninCallback?.({ state: { returnTo: "/calendar?view=month#2026-05" } } as never);
+    onSigninCallback({ state: { returnTo: "/calendar?view=month#2026-05" } });
 
     expect(replaceStateSpy).toHaveBeenCalledWith(
       {},
@@ -31,7 +31,7 @@ describe("oidcConfig.onSigninCallback", () => {
   it("falls back to /today for invalid return paths", () => {
     const replaceStateSpy = vi.spyOn(window.history, "replaceState");
 
-    oidcConfig.onSigninCallback?.({ state: { returnTo: "https://evil.example" } } as never);
+    onSigninCallback({ state: { returnTo: "https://evil.example" } });
 
     expect(replaceStateSpy).toHaveBeenCalledWith({}, document.title, "/today");
   });


### PR DESCRIPTION
Add GET /api/v1/auth/oidc-config (unauthenticated) to the backend so every client can discover Keycloak endpoints from the Daynest base URL alone. The Keycloak issuer URL now lives in exactly one place — settings.oidc_issuer_url — and all clients derive it at runtime.

- Backend: new OidcDiscoveryConfig schema and /auth/oidc-config route
- HA integration: config_flow switches to the general endpoint; client_id stays as the local DEFAULT_OIDC_CLIENT_ID constant
- Android: OidcAuthService fetches issuer URL from the API at sign-in time via a plain OkHttpClient (no auth interceptors); result cached in memory. BuildConfig.OIDC_ISSUER_URL removed from all build types.
- Frontend: oidc.ts replaces the static VITE_OIDC_AUTHORITY env var with fetchOidcConfig() which fetches the discovery endpoint and caches in sessionStorage; main.tsx bootstraps asynchronously before mounting OidcProvider, with a plain-text error fallback if unreachable.
- MCP: .env.example DAYNEST_MCP_ISSUER_URL corrected to the Keycloak realm URL with an explanatory comment.
- CI: OIDC_ISSUER_URL_* secrets and oidcIssuerUrl* local.properties lines removed from android.yml, codeql.yml, and release.yml.