### PR TITLE
refactor: remove integration client scopes + HA integration polish

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,16 +140,16 @@ This architecture keeps Daynest calm, lightweight, and practical while preservin
 ## Integration-ready API surface
 
 Daynest now exposes thin integration adapters over the existing `TodayService` read models,
-with scoped integration keys and per-client rate limits:
+with integration keys and per-client rate limits:
 
 - Integration client management (user bearer auth):
   - `POST /api/v1/integrations/clients` (returns one-time API key)
   - `GET /api/v1/integrations/clients`
-- Home Assistant adapter (requires `X-Integration-Key` + `ha:read` scope):
+- Home Assistant adapter (requires valid integration key or OIDC token):
   - `GET /api/v1/integrations/home-assistant/summary`
   - `GET /api/v1/integrations/home-assistant/entities`
   - `GET /api/v1/integrations/home-assistant/dashboard`
-- MCP adapter (requires `X-Integration-Key` + `mcp:read` scope):
+- MCP adapter (requires valid integration key or OIDC token):
   - `GET /api/v1/mcp/capabilities`
   - `GET /api/v1/mcp/today`
   - `GET /api/v1/mcp/calendar/day?date=YYYY-MM-DD`

--- a/android/app/src/main/java/com/daynest/android/data/settings/SettingsApi.kt
+++ b/android/app/src/main/java/com/daynest/android/data/settings/SettingsApi.kt
@@ -30,7 +30,6 @@ interface SettingsApi {
 data class IntegrationClientDto(
     val id: Int,
     val name: String,
-    val scopes: List<String>,
     @SerialName("rate_limit_per_minute")
     val rateLimitPerMinute: Int,
     @SerialName("is_active")
@@ -40,7 +39,6 @@ data class IntegrationClientDto(
 @Serializable
 data class IntegrationClientInputDto(
     val name: String,
-    val scopes: List<String>,
     @SerialName("rate_limit_per_minute")
     val rateLimitPerMinute: Int,
 )
@@ -61,7 +59,6 @@ data class OAuthSessionDto(
 data class IntegrationClientCreateResponseDto(
     val id: Int,
     val name: String,
-    val scopes: List<String>,
     @SerialName("rate_limit_per_minute")
     val rateLimitPerMinute: Int,
     @SerialName("is_active")

--- a/android/app/src/main/java/com/daynest/android/feature/settings/SettingsRoute.kt
+++ b/android/app/src/main/java/com/daynest/android/feature/settings/SettingsRoute.kt
@@ -2,7 +2,6 @@
 
 package com.daynest.android.feature.settings
 
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -43,46 +42,6 @@ import com.daynest.android.ui.ServerUrlPicker
 import java.time.Instant
 import java.time.ZoneId
 import java.time.format.DateTimeFormatter
-
-private data class IntegrationPreset(
-    val labelResId: Int,
-    val descriptionResId: Int,
-    val input: IntegrationClientInputDto,
-)
-
-private val INTEGRATION_PRESETS =
-    listOf(
-        IntegrationPreset(
-            labelResId = R.string.settings_preset_ha_dashboard,
-            descriptionResId = R.string.settings_preset_ha_dashboard_desc,
-            input =
-                IntegrationClientInputDto(
-                    name = "Home Assistant",
-                    scopes = listOf("ha:read"),
-                    rateLimitPerMinute = 120,
-                ),
-        ),
-        IntegrationPreset(
-            labelResId = R.string.settings_preset_ha_automations,
-            descriptionResId = R.string.settings_preset_ha_automations_desc,
-            input =
-                IntegrationClientInputDto(
-                    name = "Home Assistant Automations",
-                    scopes = listOf("ha:read", "ha:write"),
-                    rateLimitPerMinute = 120,
-                ),
-        ),
-        IntegrationPreset(
-            labelResId = R.string.settings_preset_mcp_readonly,
-            descriptionResId = R.string.settings_preset_mcp_readonly_desc,
-            input =
-                IntegrationClientInputDto(
-                    name = "MCP Adapter",
-                    scopes = listOf("mcp:read"),
-                    rateLimitPerMinute = 60,
-                ),
-        ),
-    )
 
 @Composable
 fun SettingsRoute(
@@ -204,35 +163,6 @@ private fun SettingsContent(
 
         item {
             HorizontalDivider(modifier = Modifier.padding(vertical = 4.dp))
-            Text(
-                text = stringResource(id = R.string.settings_presets_section),
-                style = MaterialTheme.typography.titleMedium,
-            )
-        }
-
-        items(INTEGRATION_PRESETS, key = { it.labelResId }) { preset ->
-            Card(
-                modifier =
-                    Modifier
-                        .fillMaxWidth()
-                        .clickable { onEvent(SettingsUiEvent.ShowCreateClientFormWithPreset(preset.input)) },
-            ) {
-                Column(modifier = Modifier.padding(12.dp)) {
-                    Text(
-                        text = stringResource(id = preset.labelResId),
-                        style = MaterialTheme.typography.bodyMedium,
-                    )
-                    Text(
-                        text = stringResource(id = preset.descriptionResId),
-                        style = MaterialTheme.typography.bodySmall,
-                        color = MaterialTheme.colorScheme.outline,
-                    )
-                }
-            }
-        }
-
-        item {
-            HorizontalDivider(modifier = Modifier.padding(vertical = 4.dp))
             Row(
                 modifier = Modifier.fillMaxWidth(),
                 verticalAlignment = Alignment.CenterVertically,
@@ -301,7 +231,6 @@ private fun SettingsContent(
 
     if (state.showCreateForm) {
         CreateClientDialog(
-            initialValues = state.createFormPreset,
             onConfirm = { onEvent(SettingsUiEvent.CreateClient(it)) },
             onDismiss = { onEvent(SettingsUiEvent.DismissCreateClientForm) },
         )
@@ -397,13 +326,6 @@ private fun IntegrationClientCard(client: IntegrationClientDto) {
                         },
                 )
             }
-            if (client.scopes.isNotEmpty()) {
-                Text(
-                    text = client.scopes.joinToString(", "),
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.outline,
-                )
-            }
             Text(
                 text =
                     stringResource(
@@ -419,13 +341,11 @@ private fun IntegrationClientCard(client: IntegrationClientDto) {
 
 @Composable
 private fun CreateClientDialog(
-    initialValues: IntegrationClientInputDto? = null,
     onConfirm: (IntegrationClientInputDto) -> Unit,
     onDismiss: () -> Unit,
 ) {
-    var name by remember(initialValues) { mutableStateOf(initialValues?.name ?: "") }
-    var scopes by remember(initialValues) { mutableStateOf(initialValues?.scopes?.joinToString(", ") ?: "") }
-    var rateLimit by remember(initialValues) { mutableStateOf(initialValues?.rateLimitPerMinute?.toString() ?: "60") }
+    var name by remember { mutableStateOf("") }
+    var rateLimit by remember { mutableStateOf("60") }
 
     AlertDialog(
         onDismissRequest = onDismiss,
@@ -436,12 +356,6 @@ private fun CreateClientDialog(
                     value = name,
                     onValueChange = { name = it },
                     label = { Text(text = stringResource(id = R.string.settings_client_name_label)) },
-                    singleLine = true,
-                )
-                OutlinedTextField(
-                    value = scopes,
-                    onValueChange = { scopes = it },
-                    label = { Text(text = stringResource(id = R.string.settings_client_scopes_label)) },
                     singleLine = true,
                 )
                 OutlinedTextField(
@@ -459,7 +373,6 @@ private fun CreateClientDialog(
                         onConfirm(
                             IntegrationClientInputDto(
                                 name = name.trim(),
-                                scopes = scopes.split(",").map { it.trim() }.filter { it.isNotBlank() },
                                 rateLimitPerMinute = rateLimit.toIntOrNull() ?: 60,
                             ),
                         )

--- a/android/app/src/main/java/com/daynest/android/feature/settings/SettingsViewModel.kt
+++ b/android/app/src/main/java/com/daynest/android/feature/settings/SettingsViewModel.kt
@@ -40,7 +40,6 @@ class SettingsViewModel
                 SettingsUiEvent.RetryClicked -> load()
                 SettingsUiEvent.SignOutClicked -> signOut()
                 SettingsUiEvent.ShowCreateClientForm -> showCreateForm()
-                is SettingsUiEvent.ShowCreateClientFormWithPreset -> showCreateFormWithPreset(event.preset)
                 SettingsUiEvent.DismissCreateClientForm -> dismissCreateForm()
                 SettingsUiEvent.DismissNewKeyDialog -> dismissNewKeyDialog()
                 is SettingsUiEvent.CreateClient -> createClient(event.input)
@@ -63,7 +62,6 @@ class SettingsViewModel
                         clients = clientsResult.getOrElse { emptyList() },
                         sessions = sessionsResult.getOrElse { emptyList() },
                         showCreateForm = false,
-                        createFormPreset = null,
                         newApiKey = null,
                         loadError = clientsResult.isFailure || sessionsResult.isFailure,
                         customServerUrl = prefs.customServerUrl,
@@ -75,17 +73,7 @@ class SettingsViewModel
         private fun showCreateForm() {
             _uiState.update { current ->
                 if (current is SettingsUiState.Content) {
-                    current.copy(showCreateForm = true, createFormPreset = null)
-                } else {
-                    current
-                }
-            }
-        }
-
-        private fun showCreateFormWithPreset(preset: IntegrationClientInputDto) {
-            _uiState.update { current ->
-                if (current is SettingsUiState.Content) {
-                    current.copy(showCreateForm = true, createFormPreset = preset)
+                    current.copy(showCreateForm = true)
                 } else {
                     current
                 }
@@ -95,7 +83,7 @@ class SettingsViewModel
         private fun dismissCreateForm() {
             _uiState.update { current ->
                 if (current is SettingsUiState.Content) {
-                    current.copy(showCreateForm = false, createFormPreset = null)
+                    current.copy(showCreateForm = false)
                 } else {
                     current
                 }
@@ -162,7 +150,6 @@ class SettingsViewModel
             IntegrationClientDto(
                 id = id,
                 name = name,
-                scopes = scopes,
                 rateLimitPerMinute = rateLimitPerMinute,
                 isActive = isActive,
             )
@@ -175,7 +162,6 @@ sealed interface SettingsUiState {
         val clients: List<IntegrationClientDto>,
         val sessions: List<OAuthSessionDto> = emptyList(),
         val showCreateForm: Boolean,
-        val createFormPreset: IntegrationClientInputDto?,
         val newApiKey: String?,
         val loadError: Boolean,
         val customServerUrl: String?,
@@ -191,10 +177,6 @@ sealed interface SettingsUiEvent {
     data object SignOutClicked : SettingsUiEvent
 
     data object ShowCreateClientForm : SettingsUiEvent
-
-    data class ShowCreateClientFormWithPreset(
-        val preset: IntegrationClientInputDto,
-    ) : SettingsUiEvent
 
     data object DismissCreateClientForm : SettingsUiEvent
 

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -136,13 +136,6 @@
     <string name="settings_account_section">Account</string>
     <string name="settings_session_active">Signed in</string>
     <string name="settings_sign_out">Sign out</string>
-    <string name="settings_presets_section">Integration presets</string>
-    <string name="settings_preset_ha_dashboard">Home Assistant dashboard</string>
-    <string name="settings_preset_ha_dashboard_desc">Sensors, dashboard metrics, setup validation, and entity reads.</string>
-    <string name="settings_preset_ha_automations">Home Assistant automations</string>
-    <string name="settings_preset_ha_automations_desc">Everything in dashboard mode plus write services for household automations.</string>
-    <string name="settings_preset_mcp_readonly">MCP read-only</string>
-    <string name="settings_preset_mcp_readonly_desc">Least-privilege read access for MCP consumers.</string>
     <string name="settings_integrations_section">Integration Clients</string>
     <string name="settings_new_client">+ New client</string>
     <string name="settings_no_clients">No integration clients configured.</string>
@@ -152,7 +145,6 @@
     <string name="settings_client_rate_limit">%1$d req/min</string>
     <string name="settings_create_client_title">New integration client</string>
     <string name="settings_client_name_label">Name</string>
-    <string name="settings_client_scopes_label">Scopes (comma-separated)</string>
     <string name="settings_client_rate_limit_label">Rate limit (per minute)</string>
     <string name="settings_new_key_title">API Key Created</string>
     <string name="settings_new_key_notice">Copy this key now — it will not be shown again.</string>

--- a/backend/alembic/versions/20260521_0001_drop_integration_client_scopes.py
+++ b/backend/alembic/versions/20260521_0001_drop_integration_client_scopes.py
@@ -1,0 +1,30 @@
+"""drop scopes_csv from integration_clients
+
+Integration clients are personal access tokens — any valid key grants full
+access, same as an OIDC session. Granular scope controls have been removed.
+
+Revision ID: 20260521_0001
+Revises: 20260517_0001
+Create Date: 2026-05-21 00:00:00.000000
+"""
+
+from typing import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "20260521_0001"
+down_revision: str | None = "20260517_0001"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.drop_column("integration_clients", "scopes_csv")
+
+
+def downgrade() -> None:
+    op.add_column(
+        "integration_clients",
+        sa.Column("scopes_csv", sa.String(255), nullable=False, server_default=""),
+    )

--- a/backend/app/api/dependencies/integration_auth.py
+++ b/backend/app/api/dependencies/integration_auth.py
@@ -41,12 +41,6 @@ def get_integration_client_by_token_hash(db: Session, token_hash: str) -> Integr
     return db.scalar(stmt)
 
 
-def ensure_integration_scope(client: IntegrationClient, scope: str) -> None:
-    scopes = {item.strip() for item in client.scopes_csv.split(",") if item.strip()}
-    if scope not in scopes:
-        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=f"Missing scope: {scope}")
-
-
 def enforce_integration_rate_limit(client: IntegrationClient) -> None:
     with _request_log_lock:
         now = datetime.now(timezone.utc)
@@ -59,7 +53,7 @@ def enforce_integration_rate_limit(client: IntegrationClient) -> None:
         bucket.append(now)
 
 
-def require_integration_scope(scope: str) -> Callable:
+def require_integration_auth() -> Callable:
     def dependency(
         authorization: str | None = Header(default=None, alias="Authorization"),
         x_integration_key: str | None = Header(default=None, alias="X-Integration-Key"),
@@ -76,11 +70,8 @@ def require_integration_scope(scope: str) -> Callable:
                         settings.resolved_integration_key_hash_secret,
                         algorithms=["HS256"],
                         issuer=_INTEGRATION_JWT_ISSUER,
-                        options={"require": ["exp", "iss", "sub", "scope"]},
+                        options={"require": ["exp", "iss", "sub"]},
                     )
-                    token_scopes = set(int_claims.get("scope", "").split())
-                    if scope not in token_scopes:
-                        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=f"Missing scope: {scope}")
                     try:
                         client_id_int = int(int_claims["sub"])
                     except (ValueError, KeyError):
@@ -106,9 +97,6 @@ def require_integration_scope(scope: str) -> Callable:
                     claims = from_thread.run(decode_oidc_token, raw_token)
                 except OIDCTokenError as exc:
                     raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid or expired OIDC token") from exc
-                token_scopes = set(claims.get("scope", "").split())
-                if scope not in token_scopes:
-                    raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=f"Missing scope: {scope}")
                 subject = claims.get("sub")
                 if not subject:
                     raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="OIDC token missing sub claim")
@@ -131,8 +119,6 @@ def require_integration_scope(scope: str) -> Callable:
         client = get_integration_client_by_token_hash(db, token_hash)
         if client is None or not client.is_active:
             raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid integration key")
-
-        ensure_integration_scope(client, scope)
 
         if client.user is None:
             raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Integration owner not found")

--- a/backend/app/api/routes/integrations/clients.py
+++ b/backend/app/api/routes/integrations/clients.py
@@ -30,7 +30,6 @@ def _create_integration_token(client: IntegrationClient) -> str:
     payload = {
         "iss": _INTEGRATION_JWT_ISSUER,
         "sub": str(client.id),
-        "scope": " ".join(s for s in client.scopes_csv.split(",") if s),
         "iat": now,
         "exp": now + timedelta(seconds=TOKEN_EXPIRES_IN_SECONDS),
     }
@@ -53,13 +52,10 @@ def _create_response(
     request: Request,
     client: IntegrationClient,
     raw_key: str,
-    *,
-    scopes: list[str],
 ) -> IntegrationClientCreateResponse:
     return IntegrationClientCreateResponse(
         id=client.id,
         name=client.name,
-        scopes=scopes,
         rate_limit_per_minute=client.rate_limit_per_minute,
         api_key=raw_key,
         client_id=_integration_client_id(client),
@@ -79,7 +75,6 @@ def list_integration_clients(
         IntegrationClientResponse(
             id=client.id,
             name=client.name,
-            scopes=[scope for scope in client.scopes_csv.split(",") if scope],
             rate_limit_per_minute=client.rate_limit_per_minute,
             is_active=client.is_active,
         )
@@ -94,19 +89,17 @@ def create_integration_client(
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ) -> IntegrationClientCreateResponse:
-    scopes = sorted({scope.strip() for scope in payload.scopes if scope.strip()})
     raw_key = f"daynest_{token_urlsafe(30)}"
     client = IntegrationClient(
         user_id=current_user.id,
         name=payload.name,
         key_hash=hash_integration_key(raw_key),
-        scopes_csv=",".join(scopes),
         rate_limit_per_minute=payload.rate_limit_per_minute,
     )
     db.add(client)
     db.commit()
     db.refresh(client)
-    return _create_response(request, client, raw_key, scopes=scopes)
+    return _create_response(request, client, raw_key)
 
 
 @router.post("/{client_id}/rotate", response_model=IntegrationClientCreateResponse)
@@ -128,12 +121,7 @@ def rotate_integration_client(
     client.key_hash = hash_integration_key(raw_key)
     db.commit()
     db.refresh(client)
-    return _create_response(
-        request,
-        client,
-        raw_key,
-        scopes=[scope for scope in client.scopes_csv.split(",") if scope],
-    )
+    return _create_response(request, client, raw_key)
 
 
 @router.post("/token", response_model=IntegrationClientTokenResponse, name="exchange_integration_client_token")
@@ -169,7 +157,6 @@ def exchange_integration_client_token(
     return IntegrationClientTokenResponse(
         access_token=_create_integration_token(client),
         expires_in=TOKEN_EXPIRES_IN_SECONDS,
-        scope=" ".join(scope for scope in client.scopes_csv.split(",") if scope),
     )
 
 

--- a/backend/app/api/routes/integrations/home_assistant.py
+++ b/backend/app/api/routes/integrations/home_assistant.py
@@ -2,7 +2,7 @@ from datetime import date, timedelta
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Response, status
 
-from app.api.dependencies.integration_auth import require_integration_scope
+from app.api.dependencies.integration_auth import require_integration_auth
 from app.api.dependencies.today import get_today_service
 from app.core.config import settings
 from app.models.user import User
@@ -56,7 +56,7 @@ def home_assistant_oidc_config() -> HomeAssistantOIDCConfig:
 @router.get("/summary")
 def home_assistant_summary(
     service: TodayService = Depends(get_today_service),
-    integration_user: User = Depends(require_integration_scope("ha:read")),
+    integration_user: User = Depends(require_integration_auth()),
     _: None = Depends(_set_ha_contract_header),
 ) -> dict[str, str | int | None]:
     read_model = service.get_dashboard_read_model(user_id=integration_user.id, for_date=date.today())
@@ -73,7 +73,7 @@ def home_assistant_summary(
 @router.get("/entities", response_model=list[HomeAssistantEntity])
 def home_assistant_entities(
     service: TodayService = Depends(get_today_service),
-    integration_user: User = Depends(require_integration_scope("ha:read")),
+    integration_user: User = Depends(require_integration_auth()),
     _: None = Depends(_set_ha_contract_header),
 ) -> list[HomeAssistantEntity]:
     read_model = service.get_dashboard_read_model(user_id=integration_user.id, for_date=date.today())
@@ -119,7 +119,7 @@ def home_assistant_entities(
 @router.get("/dashboard", response_model=DashboardReadModel)
 def home_assistant_dashboard(
     service: TodayService = Depends(get_today_service),
-    integration_user: User = Depends(require_integration_scope("ha:read")),
+    integration_user: User = Depends(require_integration_auth()),
     _: None = Depends(_set_ha_contract_header),
 ) -> DashboardReadModel:
     return service.get_dashboard_read_model(user_id=integration_user.id, for_date=date.today())
@@ -130,7 +130,7 @@ def home_assistant_calendar(
     start: date = Query(..., description="Inclusive start date in YYYY-MM-DD format"),
     end: date = Query(..., description="Inclusive end date in YYYY-MM-DD format"),
     service: TodayService = Depends(get_today_service),
-    integration_user: User = Depends(require_integration_scope("ha:read")),
+    integration_user: User = Depends(require_integration_auth()),
     _: None = Depends(_set_ha_contract_header),
 ) -> list[HACalendarEvent]:
     """Return all scheduled events (chores, routines, medication, planned) for a date range."""
@@ -141,7 +141,7 @@ def home_assistant_calendar(
 def home_assistant_complete_task(
     request: CompleteTaskRequest,
     service: TodayService = Depends(get_today_service),
-    integration_user: User = Depends(require_integration_scope("ha:write")),
+    integration_user: User = Depends(require_integration_auth()),
 ) -> HAActionResult:
     """Mark a chore instance as complete via Home Assistant automation."""
     service.complete_chore(user_id=integration_user.id, chore_instance_id=request.chore_instance_id)
@@ -152,7 +152,7 @@ def home_assistant_complete_task(
 def home_assistant_snooze_task(
     request: SnoozeTaskRequest,
     service: TodayService = Depends(get_today_service),
-    integration_user: User = Depends(require_integration_scope("ha:write")),
+    integration_user: User = Depends(require_integration_auth()),
 ) -> HAActionResult:
     """Reschedule a chore instance N days into the future via Home Assistant automation."""
     new_date = date.today() + timedelta(days=request.days)
@@ -164,7 +164,7 @@ def home_assistant_snooze_task(
 def home_assistant_mark_medication_taken(
     request: MarkMedicationTakenRequest,
     service: TodayService = Depends(get_today_service),
-    integration_user: User = Depends(require_integration_scope("ha:write")),
+    integration_user: User = Depends(require_integration_auth()),
 ) -> HAActionResult:
     """Mark a medication dose as taken via Home Assistant automation."""
     service.mutate_medication_status(
@@ -179,7 +179,7 @@ def home_assistant_mark_medication_taken(
 def home_assistant_skip_task(
     request: SkipTaskRequest,
     service: TodayService = Depends(get_today_service),
-    integration_user: User = Depends(require_integration_scope("ha:write")),
+    integration_user: User = Depends(require_integration_auth()),
 ) -> HAActionResult:
     """Skip a chore instance via Home Assistant automation."""
     service.skip_chore(user_id=integration_user.id, chore_instance_id=request.chore_instance_id)
@@ -190,7 +190,7 @@ def home_assistant_skip_task(
 def home_assistant_skip_medication(
     request: SkipMedicationRequest,
     service: TodayService = Depends(get_today_service),
-    integration_user: User = Depends(require_integration_scope("ha:write")),
+    integration_user: User = Depends(require_integration_auth()),
 ) -> HAActionResult:
     """Skip a medication dose via Home Assistant automation."""
     service.mutate_medication_status(
@@ -205,7 +205,7 @@ def home_assistant_skip_medication(
 def home_assistant_mark_planned_done(
     request: MarkPlannedDoneRequest,
     service: TodayService = Depends(get_today_service),
-    integration_user: User = Depends(require_integration_scope("ha:write")),
+    integration_user: User = Depends(require_integration_auth()),
 ) -> HAActionResult:
     """Mark a planned item as done via Home Assistant automation."""
     service.mark_planned_done(user_id=integration_user.id, planned_item_id=request.planned_item_id)
@@ -216,7 +216,7 @@ def home_assistant_mark_planned_done(
 def home_assistant_create_planned_item(
     request: PlannedItemCreateRequest,
     service: TodayService = Depends(get_today_service),
-    integration_user: User = Depends(require_integration_scope("ha:write")),
+    integration_user: User = Depends(require_integration_auth()),
 ) -> HAActionResult:
     """Create a planned item via Home Assistant automation."""
     created = service.create_planned_item(
@@ -231,7 +231,7 @@ def home_assistant_update_planned_item(
     planned_item_id: int,
     request: PlannedItemUpdateRequest,
     service: TodayService = Depends(get_today_service),
-    integration_user: User = Depends(require_integration_scope("ha:write")),
+    integration_user: User = Depends(require_integration_auth()),
 ) -> HAActionResult:
     """Update a planned item via Home Assistant automation."""
     service.update_planned_item(
@@ -246,7 +246,7 @@ def home_assistant_update_planned_item(
 def home_assistant_delete_planned_item(
     planned_item_id: int,
     service: TodayService = Depends(get_today_service),
-    integration_user: User = Depends(require_integration_scope("ha:write")),
+    integration_user: User = Depends(require_integration_auth()),
 ) -> HAActionResult:
     """Delete a planned item via Home Assistant automation."""
     service.delete_planned_item(user_id=integration_user.id, planned_item_id=planned_item_id)

--- a/backend/app/mcp_server.py
+++ b/backend/app/mcp_server.py
@@ -23,7 +23,6 @@ from sqlalchemy.orm import Session, joinedload
 
 from app.api.dependencies.integration_auth import (
     enforce_integration_rate_limit,
-    ensure_integration_scope,
     get_integration_client_by_token_hash,
     hash_integration_key,
 )
@@ -44,8 +43,6 @@ DAYNEST_USER_EMAIL_ENV = "DAYNEST_USER_EMAIL"
 DAYNEST_MCP_RESOURCE_SERVER_URL_ENV = "DAYNEST_MCP_RESOURCE_SERVER_URL"
 
 T = TypeVar("T")
-MCP_READ_SCOPE = "mcp:read"
-MCP_WRITE_SCOPE = "mcp:write"
 
 
 def _parse_date(value: str | None) -> date:
@@ -110,18 +107,9 @@ def _integration_client_to_dict(client: IntegrationClient) -> dict[str, Any]:
     return {
         "id": client.id,
         "name": client.name,
-        "scopes": [scope for scope in client.scopes_csv.split(",") if scope],
         "rate_limit_per_minute": client.rate_limit_per_minute,
         "is_active": client.is_active,
     }
-
-
-def _require_write_scope() -> None:
-    token = get_access_token()
-    if token is None:
-        return  # unauthenticated dev mode — no restrictions
-    if MCP_WRITE_SCOPE not in (token.scopes or []):
-        raise PermissionError(f"Missing scope: {MCP_WRITE_SCOPE}")
 
 
 class DaynestMcpBackend:
@@ -242,21 +230,12 @@ class DaynestMcpBackend:
     def create_integration_client(
         self,
         name: str,
-        scopes: list[str],
         rate_limit_per_minute: int = 120,
     ) -> dict[str, Any]:
-        _require_write_scope()
         access_token = get_access_token()
         if getattr(access_token, "auth_source", None) == "integration":
             raise PermissionError("Integration tokens cannot create new integration clients")
 
-        normalized_scopes = sorted({scope.strip() for scope in scopes if scope.strip()})
-        if not normalized_scopes:
-            raise ValueError("At least one integration client scope is required")
-        if access_token is not None:
-            caller_scopes = set(getattr(access_token, "scopes", []) or [])
-            if not set(normalized_scopes).issubset(caller_scopes):
-                raise PermissionError("Requested scopes must be a subset of the caller's scopes")
         if not isinstance(rate_limit_per_minute, int) or rate_limit_per_minute <= 0:
             raise ValueError("rate_limit_per_minute must be a positive integer")
         if rate_limit_per_minute > 600:
@@ -269,7 +248,6 @@ class DaynestMcpBackend:
                 user_id=user.id,
                 name=name,
                 key_hash=hash_integration_key(raw_key),
-                scopes_csv=",".join(normalized_scopes),
                 rate_limit_per_minute=rate_limit_per_minute,
                 is_active=True,
             )
@@ -306,7 +284,6 @@ class DaynestMcpBackend:
         linked_source: str | None = None,
         linked_ref: str | None = None,
     ) -> dict[str, Any]:
-        _require_write_scope()
         request = PlannedItemCreateRequest(
             title=title,
             planned_for=_parse_date(planned_for),
@@ -330,7 +307,6 @@ class DaynestMcpBackend:
         linked_source: str | None = None,
         linked_ref: str | None = None,
     ) -> dict[str, Any]:
-        _require_write_scope()
         request = PlannedItemUpdateRequest(
             title=title,
             planned_for=_parse_date(planned_for),
@@ -344,34 +320,27 @@ class DaynestMcpBackend:
         return self._with_service(lambda _db, user, service: _jsonable(service.update_planned_item(user.id, planned_item_id, request)))
 
     def delete_planned_item(self, planned_item_id: int) -> dict[str, Any]:
-        _require_write_scope()
         self._with_service(lambda _db, user, service: service.delete_planned_item(user.id, planned_item_id))
         return {"deleted": True, "planned_item_id": planned_item_id}
 
     def complete_chore(self, chore_instance_id: int) -> dict[str, Any]:
-        _require_write_scope()
         return self._with_service(lambda _db, user, service: _jsonable(service.complete_chore(user.id, chore_instance_id)))
 
     def skip_chore(self, chore_instance_id: int) -> dict[str, Any]:
-        _require_write_scope()
         return self._with_service(lambda _db, user, service: _jsonable(service.skip_chore(user.id, chore_instance_id)))
 
     def reschedule_chore(self, chore_instance_id: int, scheduled_date: str) -> dict[str, Any]:
-        _require_write_scope()
         return self._with_service(
             lambda _db, user, service: _jsonable(service.reschedule_chore(user.id, chore_instance_id, _parse_date(scheduled_date)))
         )
 
     def start_routine_task(self, task_instance_id: int) -> dict[str, Any]:
-        _require_write_scope()
         return self._with_service(lambda _db, user, service: _jsonable(service.start_routine_task(user.id, task_instance_id)))
 
     def complete_routine_task(self, task_instance_id: int) -> dict[str, Any]:
-        _require_write_scope()
         return self._with_service(lambda _db, user, service: _jsonable(service.complete_routine_task(user.id, task_instance_id)))
 
     def skip_routine_task(self, task_instance_id: int) -> dict[str, Any]:
-        _require_write_scope()
         return self._with_service(lambda _db, user, service: _jsonable(service.skip_routine_task(user.id, task_instance_id)))
 
     def list_routines(self) -> list[dict[str, Any]]:
@@ -388,7 +357,6 @@ class DaynestMcpBackend:
         due_time: str | None = None,
         is_active: bool = True,
     ) -> dict[str, Any]:
-        _require_write_scope()
         parsed_start = _parse_date(start_date)
         parsed_due_time = time.fromisoformat(due_time) if due_time and due_time.strip() else None
         return self._with_service(
@@ -415,7 +383,6 @@ class DaynestMcpBackend:
         due_time: str | None = None,
         is_active: bool | None = None,
     ) -> dict[str, Any]:
-        _require_write_scope()
         parsed_start = _parse_date(start_date)
         parsed_due_time = time.fromisoformat(due_time) if due_time and due_time.strip() else None
         return self._with_service(
@@ -434,7 +401,6 @@ class DaynestMcpBackend:
         )
 
     def delete_routine(self, routine_template_id: int) -> dict[str, Any]:
-        _require_write_scope()
         self._with_service(lambda _db, user, service: service.delete_routine_template(user.id, routine_template_id))
         return {"deleted": True, "routine_template_id": routine_template_id}
 
@@ -451,7 +417,6 @@ class DaynestMcpBackend:
         description: str | None = None,
         is_active: bool = True,
     ) -> dict[str, Any]:
-        _require_write_scope()
         parsed_start = _parse_date(start_date)
         return self._with_service(
             lambda _db, user, service: _chore_template_to_dict(
@@ -475,7 +440,6 @@ class DaynestMcpBackend:
         description: str | None = None,
         is_active: bool | None = None,
     ) -> dict[str, Any]:
-        _require_write_scope()
         parsed_start = _parse_date(start_date)
         return self._with_service(
             lambda _db, user, service: _chore_template_to_dict(
@@ -492,16 +456,13 @@ class DaynestMcpBackend:
         )
 
     def delete_chore_template(self, chore_template_id: int) -> dict[str, Any]:
-        _require_write_scope()
         self._with_service(lambda _db, user, service: service.delete_chore_template(user.id, chore_template_id))
         return {"deleted": True, "chore_template_id": chore_template_id}
 
     def take_medication_dose(self, medication_dose_instance_id: int) -> dict[str, Any]:
-        _require_write_scope()
         return self._mutate_medication(medication_dose_instance_id, "take")
 
     def skip_medication_dose(self, medication_dose_instance_id: int) -> dict[str, Any]:
-        _require_write_scope()
         return self._mutate_medication(medication_dose_instance_id, "skip")
 
     def list_medications(self) -> list[dict[str, Any]]:
@@ -517,7 +478,6 @@ class DaynestMcpBackend:
         schedule_time: str,
         every_n_days: int = 1,
     ) -> dict[str, Any]:
-        _require_write_scope()
         parsed_start = date.fromisoformat(start_date)
         parsed_time = time.fromisoformat(schedule_time)
         return self._with_service(
@@ -543,7 +503,6 @@ class DaynestMcpBackend:
         every_n_days: int | None = None,
         is_active: bool | None = None,
     ) -> dict[str, Any]:
-        _require_write_scope()
         parsed_start = date.fromisoformat(start_date)
         parsed_time = time.fromisoformat(schedule_time)
         return self._with_service(
@@ -562,7 +521,6 @@ class DaynestMcpBackend:
         )
 
     def delete_medication(self, medication_plan_id: int) -> dict[str, Any]:
-        _require_write_scope()
         self._with_service(lambda _db, user, service: service.delete_medication_plan(user.id, medication_plan_id))
         return {"deleted": True, "medication_plan_id": medication_plan_id}
 
@@ -605,8 +563,6 @@ class DaynestMcpBackend:
 
 
 class IntegrationKeyTokenVerifier(TokenVerifier):
-    REQUIRED_SCOPE = MCP_READ_SCOPE
-
     def __init__(self, session_factory: Callable[[], Session], *, resource_server_url: str | None = None) -> None:
         self.session_factory = session_factory
         self.resource_server_url = resource_server_url
@@ -620,20 +576,14 @@ class IntegrationKeyTokenVerifier(TokenVerifier):
                 return None
 
             try:
-                ensure_integration_scope(client, self.REQUIRED_SCOPE)
-            except HTTPException:
-                return None
-
-            try:
                 enforce_integration_rate_limit(client)
             except HTTPException:
                 return None
 
-            scopes = [scope.strip() for scope in client.scopes_csv.split(",") if scope.strip()]
             return DaynestMcpAccessToken(
                 token=token,
                 client_id=str(client.id),
-                scopes=scopes,
+                scopes=[],
                 resource=self.resource_server_url,
                 auth_source="integration",
                 integration_client_id=client.id,
@@ -646,34 +596,6 @@ class DaynestMcpAccessToken(AccessToken):
     auth_source: Literal["integration", "oidc"]
     integration_client_id: int | None = None
     oidc_subject: str | None = None
-
-
-def _claim_strings(value: Any) -> list[str]:
-    if isinstance(value, str):
-        return [item for item in value.split() if item]
-    if isinstance(value, list):
-        return [str(item) for item in value if item is not None]
-    return []
-
-
-def _dedupe(values: list[str]) -> list[str]:
-    return list(dict.fromkeys(values))
-
-
-def _matches_resource_audience(audience: Any, resource_server_url: str | None) -> bool:
-    if not resource_server_url:
-        return False
-    expected = resource_server_url.rstrip("/")
-    return any(value.rstrip("/") == expected for value in _claim_strings(audience))
-
-
-def _authorized_mcp_scopes(claims: dict[str, Any], resource_server_url: str | None) -> list[str] | None:
-    scopes = _dedupe([*_claim_strings(claims.get("scope")), *_claim_strings(claims.get("scp"))])
-    if MCP_READ_SCOPE in scopes:
-        return scopes
-    if _matches_resource_audience(claims.get("aud"), resource_server_url):
-        return [*scopes, MCP_READ_SCOPE]
-    return None
 
 
 class OIDCMcpTokenVerifier(TokenVerifier):
@@ -695,10 +617,6 @@ class OIDCMcpTokenVerifier(TokenVerifier):
         subject: str | None = claims.get("sub")
         if not subject:
             return None
-        scopes = _authorized_mcp_scopes(claims, self.resource_server_url)
-        if scopes is None:
-            logger.debug("OIDC token for subject %s does not authorize MCP access", subject)
-            return None
 
         session = self.session_factory()
         try:
@@ -714,7 +632,7 @@ class OIDCMcpTokenVerifier(TokenVerifier):
         return DaynestMcpAccessToken(
             token=token,
             client_id=subject,
-            scopes=scopes,
+            scopes=[],
             resource=self.resource_server_url,
             auth_source="oidc",
             oidc_subject=subject,
@@ -740,7 +658,6 @@ def _build_auth_settings(resource_server_url: str) -> AuthSettings:
     return AuthSettings(
         issuer_url=AnyHttpUrl(issuer_url),
         resource_server_url=AnyHttpUrl(resource_server_url),
-        required_scopes=["mcp:read"],
     )
 
 
@@ -790,12 +707,11 @@ def create_mcp_server(backend: DaynestMcpBackend | None = None) -> FastMCP:
     @mcp.tool()
     async def create_integration_client(
         name: str,
-        scopes: list[str],
         rate_limit_per_minute: int = 120,
     ) -> dict[str, Any]:
-        """Create an integration client and return its one-time API key."""
+        """Create a personal access token (integration client) and return its one-time API key."""
 
-        return await to_thread.run_sync(daynest.create_integration_client, name, scopes, rate_limit_per_minute)
+        return await to_thread.run_sync(daynest.create_integration_client, name, rate_limit_per_minute)
 
     @mcp.tool()
     async def get_today(for_date: str = "today") -> dict[str, Any]:

--- a/backend/app/models/integration_client.py
+++ b/backend/app/models/integration_client.py
@@ -20,7 +20,6 @@ class IntegrationClient(Base):
     user_id: Mapped[int] = mapped_column(ForeignKey("users.id", ondelete="CASCADE"), nullable=False, index=True)
     name: Mapped[str] = mapped_column(String(120), nullable=False)
     key_hash: Mapped[str] = mapped_column(String(128), nullable=False, unique=True, index=True)
-    scopes_csv: Mapped[str] = mapped_column(String(255), nullable=False)
     rate_limit_per_minute: Mapped[int] = mapped_column(Integer, nullable=False, default=120, server_default="120")
     is_active: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True, server_default=sa.text("true"))
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False, server_default=func.now())

--- a/backend/app/schemas/integrations.py
+++ b/backend/app/schemas/integrations.py
@@ -58,14 +58,12 @@ class HAActionResult(BaseModel):
 
 class IntegrationClientCreateRequest(BaseModel):
     name: str = Field(min_length=2, max_length=120)
-    scopes: list[str] = Field(min_length=1)
     rate_limit_per_minute: int = Field(default=120, ge=10, le=600)
 
 
 class IntegrationClientCreateResponse(BaseModel):
     id: int
     name: str
-    scopes: list[str]
     rate_limit_per_minute: int
     api_key: str
     client_id: str
@@ -77,13 +75,11 @@ class IntegrationClientTokenResponse(BaseModel):
     access_token: str
     token_type: str = "Bearer"
     expires_in: int
-    scope: str
 
 
 class IntegrationClientResponse(BaseModel):
     id: int
     name: str
-    scopes: list[str]
     rate_limit_per_minute: int
     is_active: bool
 

--- a/backend/docs/integrations/COMPATIBILITY_POLICY.md
+++ b/backend/docs/integrations/COMPATIBILITY_POLICY.md
@@ -30,7 +30,7 @@ For a given major contract version:
 - Existing response keys remain present.
 - Existing key types remain unchanged.
 - Existing endpoint paths remain available.
-- Authentication semantics (`X-Integration-Key` + scope checks) remain unchanged.
+- Authentication semantics (`X-Integration-Key` checks) remain unchanged.
 
 ## Client guidance
 

--- a/backend/docs/integrations/HOME_ASSISTANT_CONNECTION_GUIDE.md
+++ b/backend/docs/integrations/HOME_ASSISTANT_CONNECTION_GUIDE.md
@@ -9,10 +9,8 @@ This guide describes the backend contract expected by the Daynest Home Assistant
   - `/realms/daynest/protocol/openid-connect/auth`
   - `/realms/daynest/protocol/openid-connect/token`
 - The OAuth client ID used by the integration is `home-assistant` (PKCE flow).
-- The authenticated token must include:
-  - `ha:read`
-  - `ha:write` (required for write services/actions)
-- Legacy integration-client keys remain supported for older consumers through `X-Integration-Key` and the integration client token endpoint.
+- Any valid authenticated token (OIDC or integration key) grants full access to the user's own data.
+- Legacy integration-client keys remain supported through `X-Integration-Key` and the integration client token endpoint.
 
 ## Base URL Requirements
 
@@ -99,7 +97,7 @@ Write behavior:
 
 Used by the `daynest.complete_task` Home Assistant service.
 
-- Requires `ha:write` scope
+- Requires authenticated Daynest connection
 - Request body: `{"chore_instance_id": <int>}`
 - Returns `{"success": true, "detail": "..."}`
 
@@ -107,7 +105,7 @@ Used by the `daynest.complete_task` Home Assistant service.
 
 Used by the `daynest.snooze_task` Home Assistant service.
 
-- Requires `ha:write` scope
+- Requires authenticated Daynest connection
 - Request body: `{"chore_instance_id": <int>, "days": <int, 1–30, default 1>}`
 - Returns `{"success": true, "detail": "..."}`
 
@@ -115,7 +113,7 @@ Used by the `daynest.snooze_task` Home Assistant service.
 
 Used by the `daynest.mark_medication_taken` Home Assistant service.
 
-- Requires `ha:write` scope
+- Requires authenticated Daynest connection
 - Request body: `{"medication_dose_id": <int>}`
 - Returns `{"success": true, "detail": "..."}`
 
@@ -123,7 +121,7 @@ Used by the `daynest.mark_medication_taken` Home Assistant service.
 
 Used by the `daynest.skip_task` Home Assistant service.
 
-- Requires `ha:write` scope
+- Requires authenticated Daynest connection
 - Request body: `{"chore_instance_id": <int>}`
 - Returns `{"success": true, "detail": "..."}`
 
@@ -131,7 +129,7 @@ Used by the `daynest.skip_task` Home Assistant service.
 
 Used by the `daynest.skip_medication` Home Assistant service.
 
-- Requires `ha:write` scope
+- Requires authenticated Daynest connection
 - Request body: `{"medication_dose_id": <int>}`
 - Returns `{"success": true, "detail": "..."}`
 
@@ -139,7 +137,7 @@ Used by the `daynest.skip_medication` Home Assistant service.
 
 Used by the Home Assistant to-do create-item flow.
 
-- Requires `ha:write` scope
+- Requires authenticated Daynest connection
 - Request body: `{"title": <str>, "planned_for": <YYYY-MM-DD>, "notes": <str|null>, ...}`
 - Returns `{"success": true, "detail": "Planned item <id> created"}`
 
@@ -147,7 +145,7 @@ Used by the Home Assistant to-do create-item flow.
 
 Used by the Home Assistant to-do update-item flow for planned items.
 
-- Requires `ha:write` scope
+- Requires authenticated Daynest connection
 - Request body: `{"title": <str>, "planned_for": <YYYY-MM-DD>, "is_done": <bool>, ...}`
 - Returns `{"success": true, "detail": "Planned item <id> updated"}`
 
@@ -155,17 +153,8 @@ Used by the Home Assistant to-do update-item flow for planned items.
 
 Used by the Home Assistant to-do delete-item flow for planned items.
 
-- Requires `ha:write` scope
+- Requires authenticated Daynest connection
 - Returns `{"success": true, "detail": "Planned item <id> deleted"}`
-
-## Auth Scopes
-
-| Scope | Required for |
-|-------|-------------|
-| `ha:read` | All GET endpoints (summary, dashboard, entities); required for setup |
-| `ha:write` | All write action endpoints (complete-task, snooze-task, mark-medication-taken, skip-task, skip-medication, create/update/delete planned-item) |
-
-Use least-privilege: create a read-only key (`ha:read`) for sensor-only setups and add `ha:write` only when you need automation write support.
 
 ## Common Errors
 
@@ -183,8 +172,7 @@ Checks for the automatic OAuth redirect setup:
 Checks for the legacy/manual client credentials setup:
 
 1. Verify the client ID and secret are copied exactly.
-2. Verify the client includes `ha:read` (and `ha:write` for write services).
-3. Rotate the client secret in Daynest and update Home Assistant if needed.
+2. Rotate the client secret in Daynest and update Home Assistant if needed.
 
 ### Network Errors
 
@@ -214,10 +202,8 @@ Checks:
 
 ## Validation Checklist
 
-- OAuth client includes `ha:read`
 - base URL is reachable from Home Assistant
 - token URL is reachable from Home Assistant
 - `/summary` returns `200 OK`, the contract header, and required summary fields
 - `/dashboard` returns `200 OK`, the contract header, and the expected dashboard payload
 - the integration loads without entity availability errors
-- (optional) OAuth client includes `ha:write` for service automation support

--- a/backend/docs/integrations/HOME_ASSISTANT_CUSTOM_INTEGRATION_PLAN.md
+++ b/backend/docs/integrations/HOME_ASSISTANT_CUSTOM_INTEGRATION_PLAN.md
@@ -8,7 +8,7 @@ Daynest already exposes a thin Home Assistant adapter in the backend API:
 - `GET /api/v1/integrations/home-assistant/entities`
 - `GET /api/v1/integrations/home-assistant/dashboard`
 
-These routes already enforce scoped integration auth (`ha:read`) and emit a versioned contract header, which gives us a stable base to build a real Home Assistant custom integration on top of.
+These routes already enforce integration auth and emit a versioned contract header, which gives us a stable base to build a real Home Assistant custom integration on top of.
 
 ## Template review
 

--- a/backend/docs/integrations/LOCAL_MCP_SERVER.md
+++ b/backend/docs/integrations/LOCAL_MCP_SERVER.md
@@ -40,7 +40,7 @@ The MCP endpoint path is `/mcp`.
 
 Authentication for remote use is Bearer-token based and reuses Daynest integration client keys.
 
-Create an integration client with the `mcp:read` scope, then send:
+Create an integration client in the Daynest app, then send:
 
 ```http
 Authorization: Bearer daynest_...

--- a/backend/tests/test_integration_adapters.py
+++ b/backend/tests/test_integration_adapters.py
@@ -57,15 +57,13 @@ def _create_integration_key(
     db_session: Session,
     user_id: int,
     *,
-    scopes: str,
     rate_limit_per_minute: int = 120,
 ) -> str:
-    raw_key = f"daynest_test_{user_id}_{scopes.replace(':', '_')}"
+    raw_key = f"daynest_test_{user_id}"
     client = IntegrationClient(
         user_id=user_id,
         name="test-integration",
         key_hash=hash_integration_key(raw_key),
-        scopes_csv=scopes,
         rate_limit_per_minute=rate_limit_per_minute,
     )
     db_session.add(client)
@@ -117,14 +115,13 @@ def test_create_integration_client_and_list(client: TestClient, db_session: Sess
     try:
         create_response = client.post(
             "/api/v1/integrations/clients",
-            json={"name": "Home Assistant", "scopes": ["ha:read", "mcp:read"], "rate_limit_per_minute": 80},
+            json={"name": "Home Assistant", "rate_limit_per_minute": 80},
         )
         assert create_response.status_code == 200
         payload = create_response.json()
         assert payload["api_key"].startswith("daynest_")
         assert payload["client_secret"] == payload["api_key"]
         assert payload["token_url"].endswith("/api/v1/integrations/clients/token")
-        assert payload["scopes"] == ["ha:read", "mcp:read"]
 
         list_response = client.get("/api/v1/integrations/clients")
         assert list_response.status_code == 200
@@ -133,21 +130,20 @@ def test_create_integration_client_and_list(client: TestClient, db_session: Sess
         _clear_auth()
 
 
-def test_home_assistant_routes_enforce_ha_read_scope(
+def test_home_assistant_routes_reject_invalid_key(
     client: TestClient,
     db_session: Session,
     monkeypatch: MonkeyPatch,
 ) -> None:
     _freeze_route_today(monkeypatch, "app.api.routes.integrations.home_assistant")
-    user = _create_home_assistant_fixture(db_session, "ha-scope@example.com")
-    wrong_key = _create_integration_key(db_session, user.id, scopes="mcp:read")
+    _create_home_assistant_fixture(db_session, "ha-scope@example.com")
 
     for endpoint in HOME_ASSISTANT_ENDPOINTS:
         denied = client.get(
             f"/api/v1/integrations/home-assistant/{endpoint}",
-            headers={"X-Integration-Key": wrong_key},
+            headers={"X-Integration-Key": "daynest_invalid_key"},
         )
-        assert denied.status_code == 403
+        assert denied.status_code == 401
 
 
 def test_home_assistant_summary_contract_is_stable(
@@ -157,7 +153,7 @@ def test_home_assistant_summary_contract_is_stable(
 ) -> None:
     _freeze_route_today(monkeypatch, "app.api.routes.integrations.home_assistant")
     user = _create_home_assistant_fixture(db_session, "ha-summary-contract@example.com")
-    ha_key = _create_integration_key(db_session, user.id, scopes="ha:read")
+    ha_key = _create_integration_key(db_session, user.id)
     expected_contract = integration_contract_header(HOME_ASSISTANT_ADAPTER, HOME_ASSISTANT_CONTRACT_VERSION)
 
     summary = client.get("/api/v1/integrations/home-assistant/summary", headers={"X-Integration-Key": ha_key})
@@ -190,7 +186,7 @@ def test_home_assistant_entities_contract_is_stable(
 ) -> None:
     _freeze_route_today(monkeypatch, "app.api.routes.integrations.home_assistant")
     user = _create_home_assistant_fixture(db_session, "ha-entities-contract@example.com")
-    ha_key = _create_integration_key(db_session, user.id, scopes="ha:read")
+    ha_key = _create_integration_key(db_session, user.id)
     expected_contract = integration_contract_header(HOME_ASSISTANT_ADAPTER, HOME_ASSISTANT_CONTRACT_VERSION)
 
     entities = client.get("/api/v1/integrations/home-assistant/entities", headers={"X-Integration-Key": ha_key})
@@ -221,7 +217,7 @@ def test_home_assistant_dashboard_contract_is_stable(
 ) -> None:
     _freeze_route_today(monkeypatch, "app.api.routes.integrations.home_assistant")
     user = _create_home_assistant_fixture(db_session, "ha-dashboard-contract@example.com")
-    ha_key = _create_integration_key(db_session, user.id, scopes="ha:read")
+    ha_key = _create_integration_key(db_session, user.id)
     expected_contract = integration_contract_header(HOME_ASSISTANT_ADAPTER, HOME_ASSISTANT_CONTRACT_VERSION)
 
     dashboard = client.get("/api/v1/integrations/home-assistant/dashboard", headers={"X-Integration-Key": ha_key})
@@ -252,43 +248,6 @@ def test_home_assistant_dashboard_contract_is_stable(
     assert isinstance(dashboard_payload["planned"], list)
 
 
-def test_home_assistant_write_endpoints_require_ha_write_scope(
-    client: TestClient,
-    db_session: Session,
-    monkeypatch: MonkeyPatch,
-) -> None:
-    _freeze_route_today(monkeypatch, "app.api.routes.integrations.home_assistant")
-    user = _create_home_assistant_fixture(db_session, "ha-write-scope-denied@example.com")
-    read_only_key = _create_integration_key(db_session, user.id, scopes="ha:read")
-
-    for path, payload in [
-        ("/api/v1/integrations/home-assistant/actions/complete-task", {"chore_instance_id": 1}),
-        ("/api/v1/integrations/home-assistant/actions/snooze-task", {"chore_instance_id": 1}),
-        ("/api/v1/integrations/home-assistant/actions/mark-medication-taken", {"medication_dose_id": 1}),
-        ("/api/v1/integrations/home-assistant/actions/skip-task", {"chore_instance_id": 1}),
-        ("/api/v1/integrations/home-assistant/actions/skip-medication", {"medication_dose_id": 1}),
-        (
-            "/api/v1/integrations/home-assistant/actions/create-planned-item",
-            {"title": "Plan snacks", "planned_for": FIXED_TODAY.isoformat()},
-        ),
-    ]:
-        denied = client.post(path, json=payload, headers={"X-Integration-Key": read_only_key})
-        assert denied.status_code == 403, f"Expected 403 for {path} with ha:read scope"
-
-    denied_put = client.put(
-        "/api/v1/integrations/home-assistant/actions/update-planned-item/1",
-        json={"title": "Updated", "planned_for": FIXED_TODAY.isoformat(), "is_done": True},
-        headers={"X-Integration-Key": read_only_key},
-    )
-    assert denied_put.status_code == 403
-
-    denied_delete = client.delete(
-        "/api/v1/integrations/home-assistant/actions/delete-planned-item/1",
-        headers={"X-Integration-Key": read_only_key},
-    )
-    assert denied_delete.status_code == 403
-
-
 def test_home_assistant_complete_task_marks_chore_complete(
     client: TestClient,
     db_session: Session,
@@ -296,7 +255,7 @@ def test_home_assistant_complete_task_marks_chore_complete(
 ) -> None:
     _freeze_route_today(monkeypatch, "app.api.routes.integrations.home_assistant")
     user = _create_home_assistant_fixture(db_session, "ha-complete-task@example.com")
-    write_key = _create_integration_key(db_session, user.id, scopes="ha:write")
+    write_key = _create_integration_key(db_session, user.id)
 
     chore = db_session.query(ChoreInstance).filter_by(user_id=user.id).first()
     assert chore is not None
@@ -323,7 +282,7 @@ def test_home_assistant_snooze_task_reschedules_chore(
 ) -> None:
     _freeze_route_today(monkeypatch, "app.api.routes.integrations.home_assistant")
     user = _create_home_assistant_fixture(db_session, "ha-snooze-task@example.com")
-    write_key = _create_integration_key(db_session, user.id, scopes="ha:write")
+    write_key = _create_integration_key(db_session, user.id)
 
     chore = db_session.query(ChoreInstance).filter_by(user_id=user.id).first()
     assert chore is not None
@@ -354,7 +313,7 @@ def test_home_assistant_mark_medication_taken(
 
     _freeze_route_today(monkeypatch, "app.api.routes.integrations.home_assistant")
     user = _create_home_assistant_fixture(db_session, "ha-mark-medication@example.com")
-    write_key = _create_integration_key(db_session, user.id, scopes="ha:write")
+    write_key = _create_integration_key(db_session, user.id)
 
     # Retrieve the medication plan created by the fixture
     from app.models.medication_plan import MedicationPlan
@@ -398,7 +357,7 @@ def test_home_assistant_planned_item_crud_actions(
 ) -> None:
     _freeze_route_today(monkeypatch, "app.api.routes.integrations.home_assistant")
     user = _create_home_assistant_fixture(db_session, "ha-planned-crud@example.com")
-    write_key = _create_integration_key(db_session, user.id, scopes="ha:write")
+    write_key = _create_integration_key(db_session, user.id)
 
     create_response = client.post(
         "/api/v1/integrations/home-assistant/actions/create-planned-item",

--- a/backend/tests/test_integration_clients.py
+++ b/backend/tests/test_integration_clients.py
@@ -30,12 +30,11 @@ def _create_user(db_session: Session, email: str) -> User:
     return user
 
 
-def _create_client(db_session: Session, user_id: int, *, name: str = "Test", scopes: str = "ha:read") -> IntegrationClient:
+def _create_client(db_session: Session, user_id: int, *, name: str = "Test") -> IntegrationClient:
     ic = IntegrationClient(
         user_id=user_id,
         name=name,
         key_hash=hash_integration_key(f"daynest_testkey_{user_id}_{name}"),
-        scopes_csv=scopes,
         rate_limit_per_minute=60,
     )
     db_session.add(ic)
@@ -82,7 +81,7 @@ class TestCreateIntegrationClient:
 
         response = client.post(
             "/api/v1/integrations/clients",
-            json={"name": "New Client", "scopes": ["ha:read"], "rate_limit_per_minute": 120},
+            json={"name": "New Client", "rate_limit_per_minute": 120},
         )
 
         assert response.status_code == 200
@@ -92,7 +91,6 @@ class TestCreateIntegrationClient:
         assert body["client_id"]
         assert body["client_secret"] == body["api_key"]
         assert body["token_url"].endswith("/api/v1/integrations/clients/token")
-        assert "ha:read" in body["scopes"]
 
     def test_api_key_is_hashed_in_db(self, client: TestClient, db_session: Session) -> None:
         user = _create_user(db_session, "hash@example.com")
@@ -100,7 +98,7 @@ class TestCreateIntegrationClient:
 
         response = client.post(
             "/api/v1/integrations/clients",
-            json={"name": "Hashed", "scopes": ["mcp:read"], "rate_limit_per_minute": 60},
+            json={"name": "Hashed", "rate_limit_per_minute": 60},
         )
 
         raw_key = response.json()["api_key"]
@@ -192,7 +190,7 @@ class TestExchangeIntegrationClientToken:
 
         create_response = client.post(
             "/api/v1/integrations/clients",
-            json={"name": "OAuth Client", "scopes": ["ha:read"], "rate_limit_per_minute": 120},
+            json={"name": "OAuth Client", "rate_limit_per_minute": 120},
         )
         assert create_response.status_code == 200
         created = create_response.json()
@@ -210,7 +208,6 @@ class TestExchangeIntegrationClientToken:
         body = token_response.json()
         assert body["token_type"] == "Bearer"
         assert body["expires_in"] == 300
-        assert body["scope"] == "ha:read"
         # access_token must be a short-lived JWT, not the long-lived client_secret
         assert body["access_token"] != created["client_secret"]
         claims = jwt.decode(
@@ -218,9 +215,8 @@ class TestExchangeIntegrationClientToken:
             settings.resolved_integration_key_hash_secret,
             algorithms=["HS256"],
             issuer="daynest-integration",
-            options={"require": ["exp", "iss", "sub", "scope"]},
+            options={"require": ["exp", "iss", "sub"]},
         )
-        assert claims["scope"] == "ha:read"
         assert claims["sub"] == created["client_id"]
 
     def test_rejects_invalid_client_secret(self, client: TestClient, db_session: Session) -> None:
@@ -228,7 +224,7 @@ class TestExchangeIntegrationClientToken:
         _auth_as(user)
         created = client.post(
             "/api/v1/integrations/clients",
-            json={"name": "OAuth Client", "scopes": ["ha:read"], "rate_limit_per_minute": 120},
+            json={"name": "OAuth Client", "rate_limit_per_minute": 120},
         ).json()
 
         token_response = client.post(
@@ -247,7 +243,7 @@ class TestExchangeIntegrationClientToken:
         _auth_as(user)
         created = client.post(
             "/api/v1/integrations/clients",
-            json={"name": "OAuth Client", "scopes": ["ha:read"], "rate_limit_per_minute": 120},
+            json={"name": "OAuth Client", "rate_limit_per_minute": 120},
         ).json()
 
         token_response = client.post(
@@ -266,7 +262,7 @@ class TestExchangeIntegrationClientToken:
         _auth_as(user)
         created = client.post(
             "/api/v1/integrations/clients",
-            json={"name": "OAuth Client", "scopes": ["ha:read"], "rate_limit_per_minute": 120},
+            json={"name": "OAuth Client", "rate_limit_per_minute": 120},
         ).json()
 
         token_response = client.post(

--- a/backend/tests/test_integration_contracts.py
+++ b/backend/tests/test_integration_contracts.py
@@ -25,13 +25,12 @@ def _create_user(db_session: Session, email: str) -> User:
     return user
 
 
-def _create_integration_key(db_session: Session, user_id: int, *, scopes: str) -> str:
-    raw_key = f"daynest_contract_{user_id}_{scopes.replace(':', '_')}"
+def _create_integration_key(db_session: Session, user_id: int) -> str:
+    raw_key = f"daynest_contract_{user_id}"
     client = IntegrationClient(
         user_id=user_id,
         name="contract-test-client",
         key_hash=hash_integration_key(raw_key),
-        scopes_csv=scopes,
         rate_limit_per_minute=120,
     )
     db_session.add(client)
@@ -68,7 +67,7 @@ def test_home_assistant_contract_header_and_summary_shape(client: TestClient, db
     user = _create_user(db_session, "contract-ha@example.com")
     _setup_contract_chore(db_session, user, "Contract Chore")
 
-    key = _create_integration_key(db_session, user.id, scopes="ha:read")
+    key = _create_integration_key(db_session, user.id)
     response = client.get("/api/v1/integrations/home-assistant/summary", headers={"X-Integration-Key": key})
 
     assert response.status_code == 200
@@ -88,7 +87,7 @@ def test_home_assistant_contract_dashboard_shape(client: TestClient, db_session:
     user = _create_user(db_session, "contract-ha-dashboard@example.com")
     _setup_contract_chore(db_session, user, "Contract Dashboard Chore")
 
-    key = _create_integration_key(db_session, user.id, scopes="ha:read")
+    key = _create_integration_key(db_session, user.id)
     response = client.get("/api/v1/integrations/home-assistant/dashboard", headers={"X-Integration-Key": key})
 
     assert response.status_code == 200
@@ -113,7 +112,7 @@ def test_home_assistant_contract_entities_shape(client: TestClient, db_session: 
     user = _create_user(db_session, "contract-ha-entities@example.com")
     _setup_contract_chore(db_session, user, "Contract Entities Chore")
 
-    key = _create_integration_key(db_session, user.id, scopes="ha:read")
+    key = _create_integration_key(db_session, user.id)
     response = client.get("/api/v1/integrations/home-assistant/entities", headers={"X-Integration-Key": key})
 
     assert response.status_code == 200
@@ -138,7 +137,7 @@ def test_home_assistant_contract_calendar_shape(client: TestClient, db_session: 
     user = _create_user(db_session, "contract-ha-calendar@example.com")
     _setup_contract_chore(db_session, user, "Calendar Contract Chore")
 
-    key = _create_integration_key(db_session, user.id, scopes="ha:read")
+    key = _create_integration_key(db_session, user.id)
     today = date.today()
     response = client.get(
         "/api/v1/integrations/home-assistant/calendar",

--- a/backend/tests/test_mcp_server.py
+++ b/backend/tests/test_mcp_server.py
@@ -7,7 +7,7 @@ import pytest
 from sqlalchemy.orm import Session, sessionmaker
 
 from app.api.dependencies.integration_auth import hash_integration_key
-from app.mcp_server import MCP_WRITE_SCOPE, DaynestMcpAccessToken, DaynestMcpBackend, IntegrationKeyTokenVerifier, OIDCMcpTokenVerifier, create_mcp_server
+from app.mcp_server import DaynestMcpAccessToken, DaynestMcpBackend, IntegrationKeyTokenVerifier, OIDCMcpTokenVerifier, create_mcp_server
 from app.models.chore_template import ChoreTemplate
 from app.models.integration_client import IntegrationClient
 from app.models.medication_dose_instance import MedicationDoseInstance
@@ -34,14 +34,12 @@ def _create_integration_client(
     user: User,
     *,
     raw_key: str,
-    scopes: str = "mcp:read",
     rate_limit_per_minute: int = 50,
 ) -> IntegrationClient:
     client = IntegrationClient(
         user_id=user.id,
         name="MCP Client",
         key_hash=hash_integration_key(raw_key),
-        scopes_csv=scopes,
         rate_limit_per_minute=rate_limit_per_minute,
         is_active=True,
     )
@@ -279,14 +277,13 @@ def test_mcp_backend_delete_medication_raises_for_missing_plan(db_session: Sessi
 
 def test_mcp_backend_can_list_integration_clients(db_session: Session) -> None:
     user = _create_user(db_session, "integration-list@example.com")
-    _create_integration_client(db_session, user, raw_key="daynest_existing_key", scopes="mcp:read,ha:read")
+    _create_integration_client(db_session, user, raw_key="daynest_existing_key")
     backend = DaynestMcpBackend(_session_factory(db_session), user_email=user.email)
 
     clients = backend.list_integration_clients()
 
     assert len(clients) == 1
     assert clients[0]["name"] == "MCP Client"
-    assert clients[0]["scopes"] == ["mcp:read", "ha:read"]
     assert clients[0]["is_active"] is True
 
 
@@ -300,31 +297,18 @@ def test_mcp_backend_can_create_integration_client(db_session: Session) -> None:
     user = _create_user(db_session, "integration-create@example.com")
     backend = DaynestMcpBackend(_session_factory(db_session), user_email=user.email)
 
-    created = backend.create_integration_client(
-        name="Mobile automation",
-        scopes=["ha:write", "mcp:read", "ha:write"],
-        rate_limit_per_minute=120,
-    )
+    created = backend.create_integration_client(name="Mobile automation", rate_limit_per_minute=120)
     clients = backend.list_integration_clients()
     verifier = IntegrationKeyTokenVerifier(_session_factory(db_session))
     token = asyncio.run(verifier.verify_token(created["api_key"]))
 
     assert created["name"] == "Mobile automation"
-    assert created["scopes"] == ["ha:write", "mcp:read"]
     assert created["api_key"].startswith("daynest_")
     assert clients[0]["id"] == created["id"]
     assert token is not None
 
 
-def test_mcp_backend_create_integration_client_requires_scope(db_session: Session) -> None:
-    user = _create_user(db_session, "integration-create-missing-scope@example.com")
-    backend = DaynestMcpBackend(_session_factory(db_session), user_email=user.email)
-
-    with pytest.raises(ValueError, match="scope"):
-        backend.create_integration_client(name="No scopes", scopes=[])
-
-
-def test_integration_key_token_verifier_accepts_mcp_scoped_key(db_session: Session) -> None:
+def test_integration_key_token_verifier_accepts_valid_key(db_session: Session) -> None:
     user = _create_user(db_session, "token@example.com")
     client = _create_integration_client(db_session, user, raw_key="daynest_valid_key")
     verifier = IntegrationKeyTokenVerifier(_session_factory(db_session), resource_server_url="https://daynest.example.com/mcp")
@@ -335,18 +319,7 @@ def test_integration_key_token_verifier_accepts_mcp_scoped_key(db_session: Sessi
     assert token.client_id == str(client.id)
     assert token.auth_source == "integration"
     assert token.integration_client_id == client.id
-    assert "mcp:read" in token.scopes
     assert token.resource == "https://daynest.example.com/mcp"
-
-
-def test_integration_key_token_verifier_rejects_wrong_scope(db_session: Session) -> None:
-    user = _create_user(db_session, "wrong-scope@example.com")
-    _create_integration_client(db_session, user, raw_key="daynest_wrong_scope", scopes="ha:read")
-    verifier = IntegrationKeyTokenVerifier(_session_factory(db_session))
-
-    token = asyncio.run(verifier.verify_token("daynest_wrong_scope"))
-
-    assert token is None
 
 
 def test_mcp_backend_uses_authenticated_integration_owner(db_session: Session, monkeypatch) -> None:
@@ -356,7 +329,7 @@ def test_mcp_backend_uses_authenticated_integration_owner(db_session: Session, m
     access_token = DaynestMcpAccessToken(
         token="token",
         client_id=str(client.id),
-        scopes=["mcp:read"],
+        scopes=[],
         auth_source="integration",
         integration_client_id=client.id,
     )
@@ -376,7 +349,7 @@ def test_mcp_backend_resolves_oidc_numeric_subject(db_session: Session, monkeypa
     access_token = DaynestMcpAccessToken(
         token="token",
         client_id="123456",
-        scopes=["mcp:read"],
+        scopes=[],
         auth_source="oidc",
         oidc_subject="123456",
     )
@@ -392,7 +365,7 @@ def test_mcp_backend_rejects_authenticated_token_without_client_id(db_session: S
     _create_user(db_session, "missing-subject@example.com")
     backend = DaynestMcpBackend(_session_factory(db_session))
 
-    access_token = DaynestMcpAccessToken(token="token", client_id="", scopes=["mcp:read"], auth_source="oidc")
+    access_token = DaynestMcpAccessToken(token="token", client_id="", scopes=[], auth_source="oidc")
 
     monkeypatch.setattr("app.mcp_server.get_access_token", lambda: access_token)
 
@@ -400,12 +373,11 @@ def test_mcp_backend_rejects_authenticated_token_without_client_id(db_session: S
         backend.whoami()
 
 
-def test_oidc_mcp_token_verifier_uses_scope_claim(db_session: Session, monkeypatch) -> None:
+def test_oidc_mcp_token_verifier_accepts_valid_oidc_token(db_session: Session, monkeypatch) -> None:
     async def decode_oidc_token(_token: str) -> dict[str, str]:
         return {
             "sub": "oidc-subject",
             "email": "oidc@example.com",
-            "scope": "openid profile mcp:read",
         }
 
     monkeypatch.setattr("app.core.oidc.decode_oidc_token", decode_oidc_token)
@@ -416,7 +388,7 @@ def test_oidc_mcp_token_verifier_uses_scope_claim(db_session: Session, monkeypat
     assert token is not None
     assert token.auth_source == "oidc"
     assert token.oidc_subject == "oidc-subject"
-    assert token.scopes == ["openid", "profile", "mcp:read"]
+    assert token.scopes == []
 
 
 def test_oidc_mcp_token_verifier_accepts_resource_audience(db_session: Session, monkeypatch) -> None:
@@ -434,24 +406,7 @@ def test_oidc_mcp_token_verifier_accepts_resource_audience(db_session: Session, 
     token = asyncio.run(verifier.verify_token("oidc-token"))
 
     assert token is not None
-    assert token.scopes == ["openid", "mcp:read"]
-
-
-def test_oidc_mcp_token_verifier_rejects_unscoped_token(db_session: Session, monkeypatch) -> None:
-    async def decode_oidc_token(_token: str) -> dict[str, str]:
-        return {
-            "sub": "unscoped-subject",
-            "email": "unscoped@example.com",
-            "scope": "openid profile",
-            "aud": "daynest",
-        }
-
-    monkeypatch.setattr("app.core.oidc.decode_oidc_token", decode_oidc_token)
-    verifier = OIDCMcpTokenVerifier(_session_factory(db_session), resource_server_url="https://daynest.example.com/mcp")
-
-    token = asyncio.run(verifier.verify_token("oidc-token"))
-
-    assert token is None
+    assert token.scopes == []
 
 
 def test_mcp_backend_can_list_routines(db_session: Session) -> None:
@@ -644,50 +599,6 @@ def test_mcp_backend_delete_chore_template_raises_for_missing(db_session: Sessio
 
     with pytest.raises(ValueError, match="not found"):
         backend.delete_chore_template(9999)
-
-
-def test_mcp_write_ops_require_write_scope(db_session: Session, monkeypatch) -> None:
-    user = _create_user(db_session, "write-scope@example.com")
-    client = _create_integration_client(db_session, user, raw_key="daynest_read_only_key", scopes="mcp:read")
-    backend = DaynestMcpBackend(_session_factory(db_session))
-
-    # Token with only mcp:read — no mcp:write
-    read_only_token = DaynestMcpAccessToken(
-        token="token",
-        client_id=str(client.id),
-        scopes=["mcp:read"],
-        auth_source="integration",
-        integration_client_id=client.id,
-    )
-    monkeypatch.setattr("app.mcp_server.get_access_token", lambda: read_only_token)
-
-    write_ops = [
-        lambda: backend.complete_chore(1),
-        lambda: backend.skip_chore(1),
-        lambda: backend.reschedule_chore(1, "2026-01-01"),
-        lambda: backend.start_routine_task(1),
-        lambda: backend.complete_routine_task(1),
-        lambda: backend.skip_routine_task(1),
-        lambda: backend.create_planned_item(title="T", planned_for="2026-01-01"),
-        lambda: backend.update_planned_item(1, title="T", planned_for="2026-01-01"),
-        lambda: backend.delete_planned_item(1),
-        lambda: backend.take_medication_dose(1),
-        lambda: backend.skip_medication_dose(1),
-        lambda: backend.create_routine(name="R", start_date="2026-01-01"),
-        lambda: backend.update_routine(1, name="R", start_date="2026-01-01"),
-        lambda: backend.delete_routine(1),
-        lambda: backend.create_chore_template(name="C", start_date="2026-01-01"),
-        lambda: backend.update_chore_template(1, name="C", start_date="2026-01-01"),
-        lambda: backend.delete_chore_template(1),
-        lambda: backend.create_medication(name="M", instructions="I", start_date="2026-01-01", schedule_time="09:00"),
-        lambda: backend.update_medication(1, name="M", instructions="I", start_date="2026-01-01", schedule_time="09:00"),
-        lambda: backend.delete_medication(1),
-        lambda: backend.create_integration_client(name="C", scopes=[MCP_WRITE_SCOPE]),
-    ]
-
-    for op in write_ops:
-        with pytest.raises(PermissionError, match=MCP_WRITE_SCOPE):
-            op()
 
 
 def test_create_mcp_server_uses_backend_session_factory(db_session: Session) -> None:

--- a/custom_components/daynest/calendar.py
+++ b/custom_components/daynest/calendar.py
@@ -79,7 +79,6 @@ def _parse_event(raw: dict) -> CalendarEvent | None:
 class DaynestCalendarEntity(CalendarEntity, DaynestEntity):
     """Expose Daynest scheduled events as a Home Assistant calendar."""
 
-    _attr_icon = "mdi:calendar-check"
     _attr_supported_features = CalendarEntityFeature.CREATE_EVENT
 
     def __init__(

--- a/custom_components/daynest/calendar.py
+++ b/custom_components/daynest/calendar.py
@@ -6,8 +6,12 @@ from datetime import UTC, date, datetime
 from typing import TYPE_CHECKING
 
 from daynest import DaynestError
-
-from homeassistant.components.calendar import CalendarEntity, CalendarEntityDescription, CalendarEntityFeature, CalendarEvent
+from homeassistant.components.calendar import (
+    CalendarEntity,
+    CalendarEntityDescription,
+    CalendarEntityFeature,
+    CalendarEvent,
+)
 
 from .const import LOGGER
 from .entity import DaynestEntity

--- a/custom_components/daynest/config_flow.py
+++ b/custom_components/daynest/config_flow.py
@@ -8,7 +8,6 @@ import json
 import logging
 from typing import Any
 
-import aiohttp
 import voluptuous as vol
 
 from daynest import (
@@ -91,21 +90,19 @@ class DaynestConfigFlowHandler(config_entry_oauth2_flow.AbstractOAuth2FlowHandle
 
     @property
     def extra_authorize_data(self) -> dict[str, str]:
-        """Request Daynest scopes needed by the integration."""
-        return {"scope": "openid profile email offline_access ha:read ha:write"}
+        """Request standard OIDC scopes for the integration."""
+        return {"scope": "openid profile email offline_access"}
 
     async def _async_fetch_oidc_config(self, base_url: str) -> tuple[str, str, str] | None:
         """Fetch OIDC endpoints from the Daynest backend. Returns (authorization_url, token_url, client_id) or None on failure."""
-        url = f"{base_url}/api/v1/auth/oidc-config"
-        try:
-            session = async_get_clientsession(self.hass)
-            async with session.get(url, timeout=aiohttp.ClientTimeout(total=10)) as resp:
-                if resp.status == 200:
-                    data = await resp.json()
-                    return data["authorization_url"], data["token_url"], DEFAULT_OIDC_CLIENT_ID
-        except Exception:  # noqa: BLE001
-            pass
-        return None
+        result = await DaynestClient.async_fetch_oidc_config(
+            base_url,
+            session=async_get_clientsession(self.hass),
+        )
+        if result is None:
+            return None
+        authorization_url, token_url = result
+        return authorization_url, token_url, DEFAULT_OIDC_CLIENT_ID
 
     async def async_step_user(
         self,

--- a/custom_components/daynest/config_flow.py
+++ b/custom_components/daynest/config_flow.py
@@ -149,6 +149,44 @@ class DaynestConfigFlowHandler(config_entry_oauth2_flow.AbstractOAuth2FlowHandle
             },
         )
 
+    async def async_step_reconfigure(
+        self,
+        user_input: dict[str, Any] | None = None,
+    ) -> config_entries.ConfigFlowResult:
+        """Handle reconfiguration of the Daynest server URL."""
+        errors: dict[str, str] = {}
+        reconfigure_entry = self._get_reconfigure_entry()
+
+        if user_input is not None:
+            base_url = str(user_input[CONF_URL]).strip().rstrip("/")
+
+            oidc = await self._async_fetch_oidc_config(base_url)
+            if oidc is None:
+                errors[CONF_URL] = ERROR_CANNOT_CONNECT
+            else:
+                authorization_url, oidc_token_url, client_id = oidc
+                self.flow_impl = config_entry_oauth2_flow.LocalOAuth2ImplementationWithPkce(
+                    self.hass,
+                    DOMAIN,
+                    client_id,
+                    authorization_url,
+                    oidc_token_url,
+                )
+                self.context.update(
+                    {
+                        CONF_URL: base_url,
+                        CONF_AUTHORIZATION_URL: authorization_url,
+                        CONF_TOKEN_URL: oidc_token_url,
+                    }
+                )
+                return await self.async_step_auth()
+
+        return self.async_show_form(
+            step_id="reconfigure",
+            data_schema=_user_schema({CONF_URL: reconfigure_entry.data.get(CONF_URL, "")}),
+            errors=errors,
+        )
+
     async def async_step_reauth(
         self, entry_data: Mapping[str, Any]
     ) -> config_entries.ConfigFlowResult:
@@ -212,6 +250,21 @@ class DaynestConfigFlowHandler(config_entry_oauth2_flow.AbstractOAuth2FlowHandle
                 reauth_entry,
                 data={
                     **reauth_entry.data,
+                    **data,
+                    CONF_URL: base_url,
+                    CONF_AUTH_MODE: AUTH_MODE_OAUTH_REDIRECT,
+                    CONF_AUTHORIZATION_URL: str(self.context[CONF_AUTHORIZATION_URL]),
+                    CONF_TOKEN_URL: str(self.context[CONF_TOKEN_URL]),
+                },
+            )
+
+        if self.source == config_entries.SOURCE_RECONFIGURE:
+            reconfigure_entry = self._get_reconfigure_entry()
+            self._abort_if_unique_id_mismatch(reason="account_mismatch")
+            return self.async_update_reload_and_abort(
+                reconfigure_entry,
+                data={
+                    **reconfigure_entry.data,
                     **data,
                     CONF_URL: base_url,
                     CONF_AUTH_MODE: AUTH_MODE_OAUTH_REDIRECT,

--- a/custom_components/daynest/coordinator.py
+++ b/custom_components/daynest/coordinator.py
@@ -12,6 +12,7 @@ from daynest import (
     DaynestError,
     DaynestMalformedResponseError,
 )
+from homeassistant.components.repairs import IssueSeverity, async_create_issue, async_delete_issue
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
@@ -107,8 +108,18 @@ class DaynestDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         parsed_contract = parse_integration_contract_version(response.integration_contract)
         if parsed_contract not in SUPPORTED_INTEGRATION_CONTRACT_VERSIONS:
             unsupported_token = parsed_contract or response.integration_contract or "missing"
+            async_create_issue(
+                self.hass,
+                DOMAIN,
+                "unsupported_contract_version",
+                is_fixable=False,
+                severity=IssueSeverity.ERROR,
+                translation_key="unsupported_contract_version",
+                translation_placeholders={"contract": unsupported_token},
+            )
             raise UpdateFailed(f"Unsupported or missing integration contract version: {unsupported_token}")
 
+        async_delete_issue(self.hass, DOMAIN, "unsupported_contract_version")
         return self._normalize_dashboard(response.data.payload, parsed_contract)
 
 

--- a/custom_components/daynest/coordinator.py
+++ b/custom_components/daynest/coordinator.py
@@ -12,9 +12,9 @@ from daynest import (
     DaynestError,
     DaynestMalformedResponseError,
 )
-from homeassistant.components.repairs import IssueSeverity, async_create_issue, async_delete_issue
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed
+from homeassistant.helpers.issue_registry import IssueSeverity, async_create_issue, async_delete_issue
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
 from .const import DOMAIN, LOGGER, SUPPORTED_INTEGRATION_CONTRACT_VERSIONS, parse_integration_contract_version

--- a/custom_components/daynest/diagnostics.py
+++ b/custom_components/daynest/diagnostics.py
@@ -12,12 +12,14 @@ from homeassistant.const import CONF_API_KEY, CONF_URL
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.redact import async_redact_data
 
+from . import PLATFORMS
+from .const import CONF_AUTH_MODE
+
 if TYPE_CHECKING:
     from homeassistant.core import HomeAssistant
 
     from .data import DaynestConfigEntry
 
-# Fields to redact from diagnostics - CRITICAL for security!
 TO_REDACT = {
     CONF_API_KEY,
     CONF_URL,
@@ -26,6 +28,9 @@ TO_REDACT = {
     "api_key",
     "integration_key",
     "token",
+    "access_token",
+    "refresh_token",
+    "id_token",
 }
 
 
@@ -35,14 +40,11 @@ async def async_get_config_entry_diagnostics(
 ) -> dict[str, Any]:
     """Return diagnostics for a config entry."""
     coordinator = entry.runtime_data.coordinator
-    client = entry.runtime_data.client
     integration = entry.runtime_data.integration
 
-    # Get device and entity information
     device_reg = dr.async_get(hass)
     entity_reg = er.async_get(hass)
 
-    # Find all devices for this integration
     devices = dr.async_entries_for_config_entry(device_reg, entry.entry_id)
     device_info = []
     for device in devices:
@@ -62,34 +64,37 @@ async def async_get_config_entry_diagnostics(
                         "original_name": entity.original_name,
                         "disabled": entity.disabled,
                         "disabled_by": entity.disabled_by.value if entity.disabled_by else None,
+                        "state": (
+                            state.state
+                            if (state := hass.states.get(entity.entity_id)) is not None
+                            else None
+                        ),
                     }
                     for entity in entities
                 ],
             }
         )
 
-    # Coordinator statistics
+    last_update_success_time = getattr(coordinator, "last_update_success_time", None)
     coordinator_info = {
         "last_update_success": coordinator.last_update_success,
+        "last_update_success_time": str(last_update_success_time) if last_update_success_time else None,
+        "last_exception": str(coordinator.last_exception) if coordinator.last_exception else None,
+        "last_exception_type": type(coordinator.last_exception).__name__ if coordinator.last_exception else None,
         "update_interval": str(coordinator.update_interval),
+        "contract_version": coordinator.data.get("integration_contract") if isinstance(coordinator.data, dict) else None,
         "data_keys": list(coordinator.data.keys()) if isinstance(coordinator.data, dict) else None,
     }
 
-    # API client information (no sensitive data)
-    api_info = {
-        "has_credentials": client.has_integration_key,
-    }
-
-    # Integration information
     integration_info = {
         "name": integration.name,
         "version": integration.version,
         "domain": integration.domain,
         "documentation": integration.documentation,
         "issue_tracker": integration.issue_tracker,
+        "platforms": [str(p) for p in PLATFORMS],
     }
 
-    # Config entry details (with redacted sensitive data)
     entry_info = {
         "entry_id": entry.entry_id,
         "version": entry.version,
@@ -98,36 +103,15 @@ async def async_get_config_entry_diagnostics(
         "title": entry.title,
         "state": str(entry.state),
         "unique_id": entry.unique_id,
+        "auth_mode": entry.data.get(CONF_AUTH_MODE, "unknown"),
         "disabled_by": entry.disabled_by.value if entry.disabled_by else None,
         "data": async_redact_data(entry.data, TO_REDACT),
         "options": async_redact_data(entry.options, TO_REDACT),
     }
 
-    # Error information
-    error_info = {
-        "last_exception": str(coordinator.last_exception) if coordinator.last_exception else None,
-        "last_exception_type": (type(coordinator.last_exception).__name__ if coordinator.last_exception else None),
-    }
-
-    # Current data sample (sanitized)
-    data_sample = {}
-    if coordinator.data:
-        if isinstance(coordinator.data, dict):
-            # Include sample data but sanitize sensitive info
-            data_sample = {
-                "for_date": coordinator.data.get("for_date"),
-                "due_today_count": coordinator.data.get("due_today_count"),
-                "overdue_count": coordinator.data.get("overdue_count"),
-                "next_medication": coordinator.data.get("next_medication"),
-                "has_user_id": "userId" in coordinator.data,
-            }
-
     return {
         "entry": entry_info,
         "integration": integration_info,
         "coordinator": coordinator_info,
-        "api": api_info,
         "devices": device_info,
-        "data_sample": data_sample,
-        "error": error_info,
     }

--- a/custom_components/daynest/diagnostics.py
+++ b/custom_components/daynest/diagnostics.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
-from homeassistant.const import CONF_API_KEY, CONF_URL
+from homeassistant.const import CONF_API_KEY
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.redact import async_redact_data
 
@@ -22,7 +22,6 @@ if TYPE_CHECKING:
 
 TO_REDACT = {
     CONF_API_KEY,
-    CONF_URL,
     "username",
     "password",
     "api_key",

--- a/custom_components/daynest/entity/base.py
+++ b/custom_components/daynest/entity/base.py
@@ -66,6 +66,5 @@ class DaynestEntity(CoordinatorEntity[DaynestDataUpdateCoordinator]):
                 ),
             },
             name=coordinator.config_entry.title,
-            manufacturer=coordinator.config_entry.domain,
-            model=coordinator.data.get("model", "Unknown"),
+            manufacturer="Daynest",
         )

--- a/custom_components/daynest/icons.json
+++ b/custom_components/daynest/icons.json
@@ -1,0 +1,40 @@
+{
+  "entity": {
+    "calendar": {
+      "daynest_calendar": {
+        "default": "mdi:calendar-check"
+      }
+    },
+    "sensor": {
+      "due_today_count": {
+        "default": "mdi:format-list-checks"
+      },
+      "overdue_count": {
+        "default": "mdi:alert-circle-outline"
+      },
+      "planned_count": {
+        "default": "mdi:calendar-text-outline"
+      },
+      "medication_due_count": {
+        "default": "mdi:pill"
+      },
+      "completion_ratio": {
+        "default": "mdi:percent-circle-outline"
+      },
+      "next_medication": {
+        "default": "mdi:clock-time-eight-outline"
+      },
+      "routines_open_count": {
+        "default": "mdi:clipboard-list-outline"
+      },
+      "planned_remaining_count": {
+        "default": "mdi:calendar-check-outline"
+      }
+    },
+    "todo": {
+      "tasks_due_today": {
+        "default": "mdi:format-list-checks"
+      }
+    }
+  }
+}

--- a/custom_components/daynest/quality_scale.yaml
+++ b/custom_components/daynest/quality_scale.yaml
@@ -212,16 +212,19 @@ rules:
       removed from calendar and todo entities. All icons now defined in
       `icons.json` under `entity.<platform>.<translation_key>.default`.
   reconfiguration-flow:
-    status: todo
+    status: done
     comment: >
-      No `async_step_reconfigure` implemented yet. Users cannot change the
-      Daynest server URL without removing and re-adding the integration.
+      `async_step_reconfigure` added to `config_flow.py`. Shows the current
+      URL pre-filled, re-fetches OIDC config, re-runs OAuth, and aborts with
+      `account_mismatch` if the signed-in account differs from the configured
+      one.
   repair-issues:
-    status: todo
+    status: done
     comment: >
-      No `repairs.py` implemented yet. Known recoverable errors (e.g. expired
-      token, unsupported contract version) could surface as HA repair issues
-      instead of silent failures.
+      `repairs.py` created. The coordinator raises an
+      `unsupported_contract_version` repair issue (non-fixable, severity
+      ERROR) when the backend returns an unrecognised contract version, and
+      clears it on the next successful poll.
   stale-devices:
     status: exempt
     comment: Same reason as `dynamic-devices`.

--- a/custom_components/daynest/quality_scale.yaml
+++ b/custom_components/daynest/quality_scale.yaml
@@ -177,12 +177,14 @@ rules:
       medication metrics; none are diagnostic or config in the HA sense.
       No `EntityCategory` is warranted.
   entity-device-class:
-    status: todo
+    status: exempt
     comment: >
-      Count sensors (`SensorStateClass.MEASUREMENT`) and the `next_medication`
-      string sensor do not set a `device_class`. Consider
-      `SensorDeviceClass.TIMESTAMP` if `next_medication` is changed to an ISO
-      datetime.
+      All Daynest sensors measure application-domain concepts (task counts,
+      completion ratio, medication name) that have no matching
+      `SensorDeviceClass`. HA device classes cover physical quantities and a
+      handful of standard state types (timestamp, enum, monetary); none apply
+      here. If `next_medication` is ever changed to return an ISO datetime,
+      `SensorDeviceClass.TIMESTAMP` would apply to that sensor.
   entity-disabled-by-default:
     status: done
     comment: >

--- a/custom_components/daynest/quality_scale.yaml
+++ b/custom_components/daynest/quality_scale.yaml
@@ -114,8 +114,9 @@ rules:
   parallel-updates:
     status: done
     comment: >
-      `PARALLEL_UPDATES = 1` defined in `const.py` and re-exported from the
-      sensor platform so HA's update throttle applies.
+      `PARALLEL_UPDATES = 1` defined in `const.py` and re-exported from
+      `sensor` and `todo`; `calendar` sets `PARALLEL_UPDATES = 0` (read-only,
+      coordinator-driven).
   reauthentication-flow:
     status: done
     comment: >
@@ -219,12 +220,13 @@ rules:
       `account_mismatch` if the signed-in account differs from the configured
       one.
   repair-issues:
-    status: done
+    status: todo
     comment: >
-      `repairs.py` created. The coordinator raises an
-      `unsupported_contract_version` repair issue (non-fixable, severity
-      ERROR) when the backend returns an unrecognised contract version, and
-      clears it on the next successful poll.
+      Infrastructure in place: `repairs.py` exists and the coordinator raises
+      an `unsupported_contract_version` issue (non-fixable, severity ERROR)
+      when the backend returns an unrecognised contract version. Missing: no
+      UI-fixable repair flows are implemented; `async_create_fix_flow` is a
+      stub that raises `NotImplementedError`.
   stale-devices:
     status: exempt
     comment: Same reason as `dynamic-devices`.

--- a/custom_components/daynest/quality_scale.yaml
+++ b/custom_components/daynest/quality_scale.yaml
@@ -43,11 +43,9 @@ rules:
       documentation for actions is not yet written.
   docs-high-level-description:
     status: todo
-  docs-installation:
+  docs-installation-instructions:
     status: todo
-  docs-removal:
-    status: todo
-  docs-troubleshooting:
+  docs-removal-instructions:
     status: todo
   entity-event-setup:
     status: done
@@ -137,7 +135,11 @@ rules:
       manufacturer so all entities group under one device per config entry.
   diagnostics:
     status: done
-    comment: "`diagnostics.py` implements `async_get_config_entry_diagnostics`."
+    comment: >
+      `diagnostics.py` implements `async_get_config_entry_diagnostics`.
+      Sensitive fields (`token`, `access_token`, `refresh_token`, `id_token`,
+      `api_key`, `integration_key`, `password`, `username`) are redacted via
+      `async_redact_data`; the server URL is kept visible to aid debugging.
   discovery:
     status: exempt
     comment: >
@@ -157,7 +159,9 @@ rules:
       hardware devices.
   docs-supported-functions:
     status: todo
-  docs-troubleshooting-known-error:
+  docs-examples:
+    status: todo
+  docs-troubleshooting:
     status: todo
   docs-use-cases:
     status: todo
@@ -205,20 +209,17 @@ rules:
       Static `icon=` removed from all sensor descriptions and `_attr_icon`
       removed from calendar and todo entities. All icons now defined in
       `icons.json` under `entity.<platform>.<translation_key>.default`.
-  no-secrets-in-logs:
-    status: done
-    comment: >
-      No credential values are interpolated into log statements — logs only
-      contain service names, entity IDs, and exception messages.
-      `diagnostics.py` uses `async_redact_data` with `TO_REDACT` covering
-      `token`, `access_token`, `refresh_token`, `id_token`, `api_key`,
-      `integration_key`, `password`, and `username`. The server URL is
-      intentionally not redacted so connection issues remain debuggable.
   reconfiguration-flow:
     status: todo
     comment: >
       No `async_step_reconfigure` implemented yet. Users cannot change the
       Daynest server URL without removing and re-adding the integration.
+  repair-issues:
+    status: todo
+    comment: >
+      No `repairs.py` implemented yet. Known recoverable errors (e.g. expired
+      token, unsupported contract version) could surface as HA repair issues
+      instead of silent failures.
   stale-devices:
     status: exempt
     comment: Same reason as `dynamic-devices`.

--- a/custom_components/daynest/quality_scale.yaml
+++ b/custom_components/daynest/quality_scale.yaml
@@ -205,6 +205,15 @@ rules:
       Static `icon=` removed from all sensor descriptions and `_attr_icon`
       removed from calendar and todo entities. All icons now defined in
       `icons.json` under `entity.<platform>.<translation_key>.default`.
+  no-secrets-in-logs:
+    status: done
+    comment: >
+      No credential values are interpolated into log statements — logs only
+      contain service names, entity IDs, and exception messages.
+      `diagnostics.py` uses `async_redact_data` with `TO_REDACT` covering
+      `token`, `access_token`, `refresh_token`, `id_token`, `api_key`,
+      `integration_key`, `password`, and `username`. The server URL is
+      intentionally not redacted so connection issues remain debuggable.
   reconfiguration-flow:
     status: todo
     comment: >

--- a/custom_components/daynest/quality_scale.yaml
+++ b/custom_components/daynest/quality_scale.yaml
@@ -1,0 +1,230 @@
+rules:
+  # Bronze
+  action-setup:
+    status: done
+    comment: >
+      Services are registered inside `async_setup_entry` via
+      `async_setup_services` and unregistered in `async_unload_entry`.
+  appropriate-polling:
+    status: done
+    comment: >
+      `DASHBOARD_UPDATE_INTERVAL = timedelta(minutes=15)` with
+      `always_update=False` so unchanged payloads don't trigger writes.
+  brands:
+    status: todo
+    comment: >
+      No brand assets (logo/icon) committed yet. Add them before submitting
+      to the HA integration catalogue.
+  common-modules:
+    status: done
+    comment: >
+      `coordinator.py` holds `DaynestDataUpdateCoordinator`;
+      `entity/base.py` holds `DaynestEntity` (common unique-ID, DeviceInfo,
+      attribution). Platform modules import from these.
+  config-flow:
+    status: done
+    comment: >
+      Full OAuth 2.0 PKCE config flow (`async_step_user` → `async_step_auth`
+      → `async_oauth_create_entry`) with reauth support.
+  config-flow-test-coverage:
+    status: todo
+    comment: >
+      Config flow steps (user, reauth, OAuth callback) are not yet covered by
+      dedicated HA-style tests.
+  dependency-transparency:
+    status: done
+    comment: >
+      `manifest.json` pins the `python-daynest` requirement with an exact
+      version (`==0.1.0`).
+  docs-actions:
+    status: todo
+    comment: >
+      Service descriptions exist in `services.yaml` but integration-level
+      documentation for actions is not yet written.
+  docs-high-level-description:
+    status: todo
+  docs-installation:
+    status: todo
+  docs-removal:
+    status: todo
+  docs-troubleshooting:
+    status: todo
+  entity-event-setup:
+    status: done
+    comment: >
+      All entity platforms inherit `DaynestEntity(CoordinatorEntity)`.
+      No manual subscription or event listener setup is needed.
+  entity-unique-id:
+    status: done
+    comment: >
+      `_attr_unique_id = f"{entry_id}_{entity_description.key}"` set in
+      `DaynestEntity.__init__`.
+  has-entity-name:
+    status: done
+    comment: "`_attr_has_entity_name = True` set on `DaynestEntity`."
+  runtime-data:
+    status: done
+    comment: >
+      `entry.runtime_data` is typed via `DaynestConfigEntry` (TypeAlias of
+      `ConfigEntry[DaynestData]`) and populated in `async_setup_entry`.
+  test-before-configure:
+    status: done
+    comment: >
+      `_async_validate_oauth_token` calls `async_get_summary` during
+      `async_oauth_create_entry` and aborts on auth/connection errors before
+      storing the config entry.
+  test-before-setup:
+    status: done
+    comment: >
+      `coordinator.async_config_entry_first_refresh()` is awaited in
+      `async_setup_entry`; a failed refresh raises and blocks setup.
+  unique-config-entry:
+    status: done
+    comment: >
+      `async_set_unique_id(sub or base_url)` + `_abort_if_unique_id_configured`
+      called in both the initial flow and `async_oauth_create_entry`.
+
+  # Silver
+  action-exceptions:
+    status: done
+    comment: >
+      All service handlers catch `DaynestError` variants and re-raise as
+      `HomeAssistantError` in `_call_client`.
+  config-entry-unloading:
+    status: done
+    comment: >
+      `async_unload_entry` forwards to `async_unload_platforms`, removes the
+      Lovelace resource, and calls `async_unload_services` when no entries
+      remain loaded.
+  docs-configuration-parameters:
+    status: todo
+  docs-installation-parameters:
+    status: todo
+  entity-unavailable:
+    status: done
+    comment: >
+      `CoordinatorEntity` marks entities unavailable automatically when the
+      coordinator raises `UpdateFailed`; no manual override needed.
+  integration-owner:
+    status: done
+    comment: "`codeowners: [\"@tjorim\"]` set in `manifest.json`."
+  log-when-unavailable:
+    status: done
+    comment: >
+      `DataUpdateCoordinator` is initialised with the module `LOGGER`; it
+      logs a warning automatically when polling fails repeatedly.
+  parallel-updates:
+    status: done
+    comment: >
+      `PARALLEL_UPDATES = 1` defined in `const.py` and re-exported from the
+      sensor platform so HA's update throttle applies.
+  reauthentication-flow:
+    status: done
+    comment: >
+      `async_step_reauth` / `async_step_reauth_confirm` implemented; on
+      success calls `async_update_reload_and_abort`.
+  test-coverage:
+    status: todo
+    comment: >
+      HA-specific code (coordinator, entity setup, config flow) lacks
+      dedicated unit/integration tests. Backend API tests exist separately.
+
+  # Gold
+  devices:
+    status: done
+    comment: >
+      `DaynestEntity` sets `_attr_device_info` with identifiers, name, and
+      manufacturer so all entities group under one device per config entry.
+  diagnostics:
+    status: done
+    comment: "`diagnostics.py` implements `async_get_config_entry_diagnostics`."
+  discovery:
+    status: exempt
+    comment: >
+      Daynest is a cloud-polling service; there is no local network discovery
+      protocol.
+  discovery-update-info:
+    status: exempt
+    comment: Same reason as `discovery`.
+  docs-data-update:
+    status: todo
+  docs-known-limitations:
+    status: todo
+  docs-supported-devices:
+    status: exempt
+    comment: >
+      The integration represents a single cloud account, not a range of
+      hardware devices.
+  docs-supported-functions:
+    status: todo
+  docs-troubleshooting-known-error:
+    status: todo
+  docs-use-cases:
+    status: todo
+  dynamic-devices:
+    status: exempt
+    comment: >
+      One config entry = one user account = one logical device. Devices are
+      not added or removed dynamically after setup.
+  entity-category:
+    status: todo
+    comment: >
+      None of the sensor or calendar entities set `entity_category`. Metric
+      sensors are primary UI sensors; diagnostic/config categorisation has not
+      been applied yet.
+  entity-device-class:
+    status: todo
+    comment: >
+      Count sensors (`SensorStateClass.MEASUREMENT`) and the `next_medication`
+      string sensor do not set a `device_class`. Consider
+      `SensorDeviceClass.TIMESTAMP` if `next_medication` is changed to an ISO
+      datetime.
+  entity-disabled-by-default:
+    status: todo
+    comment: >
+      All entities are enabled by default. Lower-priority sensors
+      (e.g. `planned_remaining_count`, `routines_open_count`) should be
+      disabled by default via `entity_registry_enabled_default = False`.
+  entity-translations:
+    status: done
+    comment: >
+      All entity descriptions use `translation_key`; strings live in
+      `translations/en.json`.
+  exception-translations:
+    status: todo
+    comment: >
+      `HomeAssistantError` messages in `services.py` use f-strings.
+      They should reference translation keys from `strings.json` /
+      `translations/en.json` instead.
+  icon-translations:
+    status: todo
+    comment: >
+      Icons are set as static strings on `DaynestSensorEntityDescription`.
+      They should be moved to `icons.json` to support icon overrides.
+  reconfiguration-flow:
+    status: todo
+    comment: >
+      No `async_step_reconfigure` implemented yet. Users cannot change the
+      Daynest server URL without removing and re-adding the integration.
+  stale-devices:
+    status: exempt
+    comment: Same reason as `dynamic-devices`.
+
+  # Platinum
+  async-dependency:
+    status: done
+    comment: >
+      `python-daynest` is fully async (all I/O via `aiohttp`); no blocking
+      calls are made.
+  inject-websession:
+    status: done
+    comment: >
+      `DaynestClient` accepts an optional `session: aiohttp.ClientSession`
+      parameter; `async_get_clientsession(hass)` is injected in both
+      `async_setup_entry` and the config flow.
+  strict-typing:
+    status: todo
+    comment: >
+      `custom_components/daynest` is not listed in `.strict-typing` and has
+      not been validated under `mypy --strict` / `ty --strict` for the
+      integration-specific code.

--- a/custom_components/daynest/quality_scale.yaml
+++ b/custom_components/daynest/quality_scale.yaml
@@ -167,11 +167,11 @@ rules:
       One config entry = one user account = one logical device. Devices are
       not added or removed dynamically after setup.
   entity-category:
-    status: todo
+    status: done
     comment: >
-      None of the sensor or calendar entities set `entity_category`. Metric
-      sensors are primary UI sensors; diagnostic/config categorisation has not
-      been applied yet.
+      All Daynest sensor entities expose primary user-facing task and
+      medication metrics; none are diagnostic or config in the HA sense.
+      No `EntityCategory` is warranted.
   entity-device-class:
     status: todo
     comment: >
@@ -180,27 +180,31 @@ rules:
       `SensorDeviceClass.TIMESTAMP` if `next_medication` is changed to an ISO
       datetime.
   entity-disabled-by-default:
-    status: todo
+    status: done
     comment: >
-      All entities are enabled by default. Lower-priority sensors
-      (e.g. `planned_remaining_count`, `routines_open_count`) should be
-      disabled by default via `entity_registry_enabled_default = False`.
+      Secondary sensors (`planned_count`, `planned_remaining_count`,
+      `routines_open_count`, `next_medication`) set
+      `entity_registry_enabled_default=False`. Primary metrics
+      (`due_today_count`, `overdue_count`, `medication_due_count`,
+      `completion_ratio`) remain enabled.
   entity-translations:
     status: done
     comment: >
       All entity descriptions use `translation_key`; strings live in
       `translations/en.json`.
   exception-translations:
-    status: todo
+    status: done
     comment: >
-      `HomeAssistantError` messages in `services.py` use f-strings.
-      They should reference translation keys from `strings.json` /
-      `translations/en.json` instead.
+      All `HomeAssistantError` raises in `services.py` and `todo.py` use
+      `translation_domain=DOMAIN` + `translation_key` with optional
+      `translation_placeholders`. Strings live in
+      `translations/en.json` under `exceptions`.
   icon-translations:
-    status: todo
+    status: done
     comment: >
-      Icons are set as static strings on `DaynestSensorEntityDescription`.
-      They should be moved to `icons.json` to support icon overrides.
+      Static `icon=` removed from all sensor descriptions and `_attr_icon`
+      removed from calendar and todo entities. All icons now defined in
+      `icons.json` under `entity.<platform>.<translation_key>.default`.
   reconfiguration-flow:
     status: todo
     comment: >

--- a/custom_components/daynest/repairs.py
+++ b/custom_components/daynest/repairs.py
@@ -1,0 +1,22 @@
+"""Repairs support for the Daynest integration."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from homeassistant.components.repairs import RepairsFlow
+    from homeassistant.core import HomeAssistant
+
+
+async def async_create_fix_flow(
+    hass: HomeAssistant,
+    issue_id: str,
+    data: dict[str, str] | None,
+) -> RepairsFlow:
+    """Create a fix flow for a repair issue.
+
+    Currently all Daynest repair issues require manual action (e.g. updating
+    the integration), so no automated fix flow is provided.
+    """
+    raise NotImplementedError(f"No fix flow for Daynest issue {issue_id!r}")

--- a/custom_components/daynest/sensor/__init__.py
+++ b/custom_components/daynest/sensor/__init__.py
@@ -31,35 +31,31 @@ ENTITY_DESCRIPTIONS: tuple[DaynestSensorEntityDescription, ...] = (
     DaynestSensorEntityDescription(
         key="due_today_count",
         translation_key="due_today_count",
-        icon="mdi:format-list-checks",
         state_class=SensorStateClass.MEASUREMENT,
         value_key="due_today_count",
     ),
     DaynestSensorEntityDescription(
         key="overdue_count",
         translation_key="overdue_count",
-        icon="mdi:alert-circle-outline",
         state_class=SensorStateClass.MEASUREMENT,
         value_key="overdue_count",
     ),
     DaynestSensorEntityDescription(
         key="planned_count",
         translation_key="planned_count",
-        icon="mdi:calendar-text-outline",
         state_class=SensorStateClass.MEASUREMENT,
         value_key="planned_count",
+        entity_registry_enabled_default=False,
     ),
     DaynestSensorEntityDescription(
         key="medication_due_count",
         translation_key="medication_due_count",
-        icon="mdi:pill",
         state_class=SensorStateClass.MEASUREMENT,
         value_key="medication_due_count",
     ),
     DaynestSensorEntityDescription(
         key="completion_ratio",
         translation_key="completion_ratio",
-        icon="mdi:percent-circle-outline",
         native_unit_of_measurement=PERCENTAGE,
         suggested_display_precision=0,
         state_class=SensorStateClass.MEASUREMENT,
@@ -69,22 +65,22 @@ ENTITY_DESCRIPTIONS: tuple[DaynestSensorEntityDescription, ...] = (
     DaynestSensorEntityDescription(
         key="next_medication",
         translation_key="next_medication",
-        icon="mdi:clock-time-eight-outline",
         value_key="next_medication",
+        entity_registry_enabled_default=False,
     ),
     DaynestSensorEntityDescription(
         key="routines_open_count",
         translation_key="routines_open_count",
-        icon="mdi:clipboard-list-outline",
         state_class=SensorStateClass.MEASUREMENT,
         value_key="routines_open_count",
+        entity_registry_enabled_default=False,
     ),
     DaynestSensorEntityDescription(
         key="planned_remaining_count",
         translation_key="planned_remaining_count",
-        icon="mdi:calendar-check-outline",
         state_class=SensorStateClass.MEASUREMENT,
         value_key="planned_remaining_count",
+        entity_registry_enabled_default=False,
     ),
 )
 

--- a/custom_components/daynest/services.py
+++ b/custom_components/daynest/services.py
@@ -87,13 +87,25 @@ async def _call_client(
         await coro
     except DaynestAuthError as err:
         LOGGER.error("daynest.%s: authentication error for %s", service, entity_id)
-        raise HomeAssistantError(f"Authentication error in daynest.{service}") from err
+        raise HomeAssistantError(
+            translation_domain=DOMAIN,
+            translation_key="service_auth_error",
+            translation_placeholders={"service": service},
+        ) from err
     except DaynestCommunicationError as err:
         LOGGER.error("daynest.%s: communication error for %s: %s", service, entity_id, err)
-        raise HomeAssistantError(f"Communication error in daynest.{service}") from err
+        raise HomeAssistantError(
+            translation_domain=DOMAIN,
+            translation_key="service_communication_error",
+            translation_placeholders={"service": service},
+        ) from err
     except DaynestError as err:
         LOGGER.error("daynest.%s: error for %s: %s", service, entity_id, err)
-        raise HomeAssistantError(f"Error in daynest.{service}") from err
+        raise HomeAssistantError(
+            translation_domain=DOMAIN,
+            translation_key="service_error",
+            translation_placeholders={"service": service},
+        ) from err
     LOGGER.debug("daynest.%s: %s succeeded", service, entity_id)
     await entry.runtime_data.coordinator.async_refresh()
 

--- a/custom_components/daynest/todo.py
+++ b/custom_components/daynest/todo.py
@@ -9,8 +9,10 @@ from homeassistant.components.todo import TodoItem, TodoItemStatus, TodoListEnti
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity import EntityDescription
 
-from .const import DOMAIN, PARALLEL_UPDATES as PARALLEL_UPDATES
+from .const import DOMAIN
 from .entity import DaynestEntity
+
+PARALLEL_UPDATES = 1
 
 if TYPE_CHECKING:
     from homeassistant.core import HomeAssistant

--- a/custom_components/daynest/todo.py
+++ b/custom_components/daynest/todo.py
@@ -9,6 +9,7 @@ from homeassistant.components.todo import TodoItem, TodoItemStatus, TodoListEnti
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity import EntityDescription
 
+from .const import DOMAIN
 from .entity import DaynestEntity
 
 if TYPE_CHECKING:
@@ -47,7 +48,6 @@ async def async_setup_entry(
 class DaynestTodoListEntity(TodoListEntity, DaynestEntity):
     """Expose due-today and planned Daynest tasks as a Home Assistant to-do list."""
 
-    _attr_icon = "mdi:format-list-checks"
     _attr_supported_features = (
         TodoListEntityFeature.CREATE_TODO_ITEM
         |
@@ -85,8 +85,10 @@ class DaynestTodoListEntity(TodoListEntity, DaynestEntity):
         if kind == "due":
             status = changes.get("status")
             if status != COMPLETE_STATUS:
-                msg = "Only marking due-today chore items as complete is supported."
-                raise HomeAssistantError(msg)
+                raise HomeAssistantError(
+                    translation_domain=DOMAIN,
+                    translation_key="todo_complete_only",
+                )
 
             await client.async_complete_task(raw_id)
             await self.coordinator.async_request_refresh()
@@ -94,16 +96,21 @@ class DaynestTodoListEntity(TodoListEntity, DaynestEntity):
 
         planned_item = self._find_planned_item(raw_id)
         if planned_item is None:
-            msg = f"Unable to locate planned item for id {raw_id}."
-            raise HomeAssistantError(msg)
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="todo_planned_item_not_found",
+                translation_placeholders={"item_id": str(raw_id)},
+            )
 
         status = changes.get("status")
         if status is None:
             status = COMPLETE_STATUS if planned_item.get("is_done") else TodoItemStatus.NEEDS_ACTION
         summary = str(changes.get("summary", planned_item.get("title") or "Task")).strip()
         if not summary:
-            msg = "Planned item title cannot be empty."
-            raise HomeAssistantError(msg)
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="todo_title_empty",
+            )
         planned_for = self._format_due_for_payload(changes.get("due", planned_item.get("planned_for")))
         notes = changes.get("description", planned_item.get("notes"))
 
@@ -124,8 +131,10 @@ class DaynestTodoListEntity(TodoListEntity, DaynestEntity):
         """Create a planned Daynest item from Home Assistant."""
         summary = str(item.summary or "").strip()
         if not summary:
-            msg = "Todo item summary is required."
-            raise HomeAssistantError(msg)
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="todo_summary_required",
+            )
 
         await self.coordinator.config_entry.runtime_data.client.async_create_planned_item(
             title=summary,
@@ -199,16 +208,25 @@ class DaynestTodoListEntity(TodoListEntity, DaynestEntity):
         """Parse item IDs encoded as '<kind>:<id>'."""
         kind, separator, raw_id = item_id.partition(":")
         if not separator or kind not in {"due", "planned"}:
-            msg = f"Unsupported Daynest to-do item id: {item_id}"
-            raise HomeAssistantError(msg)
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="todo_invalid_item_id",
+                translation_placeholders={"item_id": item_id},
+            )
         try:
             parsed_id = int(raw_id)
         except ValueError as err:
-            msg = f"Unsupported Daynest to-do item id: {item_id}"
-            raise HomeAssistantError(msg) from err
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="todo_invalid_item_id",
+                translation_placeholders={"item_id": item_id},
+            ) from err
         if parsed_id <= 0:
-            msg = f"Unsupported Daynest to-do item id: {item_id}"
-            raise HomeAssistantError(msg)
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="todo_invalid_item_id",
+                translation_placeholders={"item_id": item_id},
+            )
         return kind, parsed_id
 
     def _is_complete_status(self, status: Any) -> bool:

--- a/custom_components/daynest/todo.py
+++ b/custom_components/daynest/todo.py
@@ -9,7 +9,7 @@ from homeassistant.components.todo import TodoItem, TodoItemStatus, TodoListEnti
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity import EntityDescription
 
-from .const import DOMAIN
+from .const import DOMAIN, PARALLEL_UPDATES as PARALLEL_UPDATES
 from .entity import DaynestEntity
 
 if TYPE_CHECKING:

--- a/custom_components/daynest/translations/en.json
+++ b/custom_components/daynest/translations/en.json
@@ -35,6 +35,30 @@
     },
     "update_failed": {
       "message": "Failed to update data from the server."
+    },
+    "service_auth_error": {
+      "message": "Authentication error calling daynest.{service}."
+    },
+    "service_communication_error": {
+      "message": "Communication error calling daynest.{service}."
+    },
+    "service_error": {
+      "message": "Error calling daynest.{service}."
+    },
+    "todo_complete_only": {
+      "message": "Only marking due-today chore items as complete is supported."
+    },
+    "todo_planned_item_not_found": {
+      "message": "Unable to locate planned item {item_id}."
+    },
+    "todo_title_empty": {
+      "message": "Planned item title cannot be empty."
+    },
+    "todo_summary_required": {
+      "message": "Todo item summary is required."
+    },
+    "todo_invalid_item_id": {
+      "message": "Unsupported Daynest to-do item id: {item_id}."
     }
   },
   "entity": {

--- a/custom_components/daynest/translations/en.json
+++ b/custom_components/daynest/translations/en.json
@@ -82,7 +82,7 @@
     },
     "complete_task": {
       "name": "Complete Task",
-      "description": "Marks a Daynest chore instance as complete. Requires the Daynest Home Assistant client to have the ha:write scope.",
+      "description": "Marks a Daynest chore instance as complete. Requires an authenticated Daynest connection.",
       "fields": {
         "chore_instance_id": {
           "name": "Chore Instance ID",
@@ -92,7 +92,7 @@
     },
     "snooze_task": {
       "name": "Snooze Task",
-      "description": "Reschedules a Daynest chore instance to a later date. Requires the Daynest Home Assistant client to have the ha:write scope.",
+      "description": "Reschedules a Daynest chore instance to a later date. Requires an authenticated Daynest connection.",
       "fields": {
         "chore_instance_id": {
           "name": "Chore Instance ID",
@@ -106,7 +106,7 @@
     },
     "mark_medication_taken": {
       "name": "Mark Medication Taken",
-      "description": "Marks a scheduled medication dose as taken. Requires the Daynest Home Assistant client to have the ha:write scope.",
+      "description": "Marks a scheduled medication dose as taken. Requires an authenticated Daynest connection.",
       "fields": {
         "medication_dose_id": {
           "name": "Medication Dose ID",
@@ -116,7 +116,7 @@
     },
     "skip_task": {
       "name": "Skip Task",
-      "description": "Skips a Daynest chore instance. Requires the Daynest Home Assistant client to have the ha:write scope.",
+      "description": "Skips a Daynest chore instance. Requires an authenticated Daynest connection.",
       "fields": {
         "chore_instance_id": {
           "name": "Chore Instance ID",
@@ -126,7 +126,7 @@
     },
     "skip_medication": {
       "name": "Skip Medication Dose",
-      "description": "Skips a scheduled medication dose. Requires the Daynest Home Assistant client to have the ha:write scope.",
+      "description": "Skips a scheduled medication dose. Requires an authenticated Daynest connection.",
       "fields": {
         "medication_dose_id": {
           "name": "Medication Dose ID",

--- a/custom_components/daynest/translations/en.json
+++ b/custom_components/daynest/translations/en.json
@@ -10,6 +10,12 @@
       "reauth_confirm": {
         "title": "Re-authenticate with Daynest",
         "description": "Your Daynest session has expired or been revoked. Click Submit to sign in again."
+      },
+      "reconfigure": {
+        "description": "Update the Daynest server URL. You will be asked to sign in again after changing the URL.",
+        "data": {
+          "url": "Daynest base URL"
+        }
       }
     },
     "error": {
@@ -26,7 +32,14 @@
       "cannot_connect": "Unable to reach the Daynest host.",
       "timeout": "Connection to Daynest timed out.",
       "unsupported_contract": "The Daynest server contract version is not supported by this integration.",
-      "unknown": "Unknown error occurred."
+      "unknown": "Unknown error occurred.",
+      "account_mismatch": "The signed-in Daynest account does not match the configured account. Remove and re-add the integration to switch accounts."
+    }
+  },
+  "issues": {
+    "unsupported_contract_version": {
+      "title": "Unsupported Daynest backend version",
+      "description": "The Daynest backend returned an unsupported integration contract version (`{contract}`). Update the Daynest custom component to the latest version to restore sensor updates."
     }
   },
   "exceptions": {

--- a/custom_components/tests/test_sensor.py
+++ b/custom_components/tests/test_sensor.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import json
+import pathlib
 from unittest.mock import MagicMock
 
 import pytest
@@ -82,9 +84,11 @@ class TestEntityDescriptions:
             if desc.key != "completion_ratio":
                 assert desc.scale == 1.0, f"{desc.key} should have scale 1.0"
 
-    def test_each_description_has_icon(self) -> None:
+    def test_each_description_has_icon_in_icons_json(self) -> None:
+        icons = json.loads((pathlib.Path(__file__).parent.parent / "daynest" / "icons.json").read_text())
+        sensor_icons = icons.get("entity", {}).get("sensor", {})
         for desc in ENTITY_DESCRIPTIONS:
-            assert desc.icon, f"{desc.key} is missing an icon"
+            assert desc.key in sensor_icons, f"{desc.key} is missing an icon in icons.json"
 
     def test_each_description_has_value_key(self) -> None:
         for desc in ENTITY_DESCRIPTIONS:

--- a/custom_components/tests/test_services.py
+++ b/custom_components/tests/test_services.py
@@ -162,8 +162,9 @@ class TestHandleCompleteTask:
         hass = _make_hass(entries=[entry])
         await async_setup_services(hass)
         handler = await _get_handler(hass, SERVICE_COMPLETE_TASK)
-        with pytest.raises(HomeAssistantError, match="Authentication error in daynest.complete_task"):
+        with pytest.raises(HomeAssistantError) as exc_info:
             await handler(_make_service_call(**{ATTR_CHORE_INSTANCE_ID: 7}))
+        assert exc_info.value.translation_key == "service_auth_error"
 
     async def test_communication_error_raises_homeassistant_error(self) -> None:
         client = AsyncMock()
@@ -172,8 +173,9 @@ class TestHandleCompleteTask:
         hass = _make_hass(entries=[entry])
         await async_setup_services(hass)
         handler = await _get_handler(hass, SERVICE_COMPLETE_TASK)
-        with pytest.raises(HomeAssistantError, match="Communication error in daynest.complete_task"):
+        with pytest.raises(HomeAssistantError) as exc_info:
             await handler(_make_service_call(**{ATTR_CHORE_INSTANCE_ID: 7}))
+        assert exc_info.value.translation_key == "service_communication_error"
 
     async def test_generic_api_error_raises_homeassistant_error(self) -> None:
         client = AsyncMock()
@@ -182,8 +184,9 @@ class TestHandleCompleteTask:
         hass = _make_hass(entries=[entry])
         await async_setup_services(hass)
         handler = await _get_handler(hass, SERVICE_COMPLETE_TASK)
-        with pytest.raises(HomeAssistantError, match="Error in daynest.complete_task"):
+        with pytest.raises(HomeAssistantError) as exc_info:
             await handler(_make_service_call(**{ATTR_CHORE_INSTANCE_ID: 7}))
+        assert exc_info.value.translation_key == "service_error"
 
     async def test_error_does_not_trigger_coordinator_refresh(self) -> None:
         client = AsyncMock()
@@ -236,8 +239,9 @@ class TestHandleSnoozeTask:
         hass = _make_hass(entries=[entry])
         await async_setup_services(hass)
         handler = await _get_handler(hass, SERVICE_SNOOZE_TASK)
-        with pytest.raises(HomeAssistantError, match="Authentication error in daynest.snooze_task"):
+        with pytest.raises(HomeAssistantError) as exc_info:
             await handler(_make_service_call(**{ATTR_CHORE_INSTANCE_ID: 3, ATTR_DAYS: 2}))
+        assert exc_info.value.translation_key == "service_auth_error"
 
     async def test_communication_error_raises_homeassistant_error(self) -> None:
         client = AsyncMock()
@@ -246,8 +250,9 @@ class TestHandleSnoozeTask:
         hass = _make_hass(entries=[entry])
         await async_setup_services(hass)
         handler = await _get_handler(hass, SERVICE_SNOOZE_TASK)
-        with pytest.raises(HomeAssistantError, match="Communication error in daynest.snooze_task"):
+        with pytest.raises(HomeAssistantError) as exc_info:
             await handler(_make_service_call(**{ATTR_CHORE_INSTANCE_ID: 3, ATTR_DAYS: 2}))
+        assert exc_info.value.translation_key == "service_communication_error"
 
     async def test_generic_api_error_raises_homeassistant_error(self) -> None:
         client = AsyncMock()
@@ -256,8 +261,9 @@ class TestHandleSnoozeTask:
         hass = _make_hass(entries=[entry])
         await async_setup_services(hass)
         handler = await _get_handler(hass, SERVICE_SNOOZE_TASK)
-        with pytest.raises(HomeAssistantError, match="Error in daynest.snooze_task"):
+        with pytest.raises(HomeAssistantError) as exc_info:
             await handler(_make_service_call(**{ATTR_CHORE_INSTANCE_ID: 3, ATTR_DAYS: 2}))
+        assert exc_info.value.translation_key == "service_error"
 
 
 @pytest.mark.unit
@@ -299,8 +305,9 @@ class TestHandleMarkMedicationTaken:
         hass = _make_hass(entries=[entry])
         await async_setup_services(hass)
         handler = await _get_handler(hass, SERVICE_MARK_MEDICATION_TAKEN)
-        with pytest.raises(HomeAssistantError, match="Authentication error in daynest.mark_medication_taken"):
+        with pytest.raises(HomeAssistantError) as exc_info:
             await handler(_make_service_call(**{ATTR_MEDICATION_DOSE_ID: 15}))
+        assert exc_info.value.translation_key == "service_auth_error"
 
     async def test_communication_error_raises_homeassistant_error(self) -> None:
         client = AsyncMock()
@@ -309,8 +316,9 @@ class TestHandleMarkMedicationTaken:
         hass = _make_hass(entries=[entry])
         await async_setup_services(hass)
         handler = await _get_handler(hass, SERVICE_MARK_MEDICATION_TAKEN)
-        with pytest.raises(HomeAssistantError, match="Communication error in daynest.mark_medication_taken"):
+        with pytest.raises(HomeAssistantError) as exc_info:
             await handler(_make_service_call(**{ATTR_MEDICATION_DOSE_ID: 15}))
+        assert exc_info.value.translation_key == "service_communication_error"
 
     async def test_generic_api_error_raises_homeassistant_error(self) -> None:
         client = AsyncMock()
@@ -319,8 +327,9 @@ class TestHandleMarkMedicationTaken:
         hass = _make_hass(entries=[entry])
         await async_setup_services(hass)
         handler = await _get_handler(hass, SERVICE_MARK_MEDICATION_TAKEN)
-        with pytest.raises(HomeAssistantError, match="Error in daynest.mark_medication_taken"):
+        with pytest.raises(HomeAssistantError) as exc_info:
             await handler(_make_service_call(**{ATTR_MEDICATION_DOSE_ID: 15}))
+        assert exc_info.value.translation_key == "service_error"
 
     async def test_error_does_not_trigger_coordinator_refresh(self) -> None:
         client = AsyncMock()
@@ -356,8 +365,9 @@ class TestHandleSkipTask:
         hass = _make_hass(entries=[entry])
         await async_setup_services(hass)
         handler = await _get_handler(hass, SERVICE_SKIP_TASK)
-        with pytest.raises(HomeAssistantError, match="Authentication error in daynest.skip_task"):
+        with pytest.raises(HomeAssistantError) as exc_info:
             await handler(_make_service_call(**{ATTR_CHORE_INSTANCE_ID: 9}))
+        assert exc_info.value.translation_key == "service_auth_error"
 
 
 @pytest.mark.unit
@@ -401,8 +411,9 @@ class TestHandleMarkPlannedDone:
         hass = _make_hass(entries=[entry])
         await async_setup_services(hass)
         handler = await _get_handler(hass, SERVICE_MARK_PLANNED_DONE)
-        with pytest.raises(HomeAssistantError, match="Authentication error in daynest.mark_planned_done"):
+        with pytest.raises(HomeAssistantError) as exc_info:
             await handler(_make_service_call(**{ATTR_PLANNED_ITEM_ID: 42}))
+        assert exc_info.value.translation_key == "service_auth_error"
 
     async def test_communication_error_raises_homeassistant_error(self) -> None:
         client = AsyncMock()
@@ -411,8 +422,9 @@ class TestHandleMarkPlannedDone:
         hass = _make_hass(entries=[entry])
         await async_setup_services(hass)
         handler = await _get_handler(hass, SERVICE_MARK_PLANNED_DONE)
-        with pytest.raises(HomeAssistantError, match="Communication error in daynest.mark_planned_done"):
+        with pytest.raises(HomeAssistantError) as exc_info:
             await handler(_make_service_call(**{ATTR_PLANNED_ITEM_ID: 42}))
+        assert exc_info.value.translation_key == "service_communication_error"
 
     async def test_generic_api_error_raises_homeassistant_error(self) -> None:
         client = AsyncMock()
@@ -421,8 +433,9 @@ class TestHandleMarkPlannedDone:
         hass = _make_hass(entries=[entry])
         await async_setup_services(hass)
         handler = await _get_handler(hass, SERVICE_MARK_PLANNED_DONE)
-        with pytest.raises(HomeAssistantError, match="Error in daynest.mark_planned_done"):
+        with pytest.raises(HomeAssistantError) as exc_info:
             await handler(_make_service_call(**{ATTR_PLANNED_ITEM_ID: 42}))
+        assert exc_info.value.translation_key == "service_error"
 
     async def test_error_does_not_trigger_coordinator_refresh(self) -> None:
         client = AsyncMock()

--- a/custom_components/tests/test_todo.py
+++ b/custom_components/tests/test_todo.py
@@ -177,8 +177,9 @@ class TestDaynestTodoListEntity:
             entity_description=ENTITY_DESCRIPTION,
         )
 
-        with pytest.raises(HomeAssistantError, match="Unable to locate planned item for id 201"):
+        with pytest.raises(HomeAssistantError) as exc_info:
             await entity.async_update_todo_item("planned:201", {"status": COMPLETE_STATUS})
+        assert exc_info.value.translation_key == "todo_planned_item_not_found"
 
     async def test_update_with_unsupported_status_raises(self) -> None:
         coordinator = _make_coordinator()
@@ -187,8 +188,9 @@ class TestDaynestTodoListEntity:
             entity_description=ENTITY_DESCRIPTION,
         )
 
-        with pytest.raises(HomeAssistantError, match="Only marking due-today chore items as complete is supported"):
+        with pytest.raises(HomeAssistantError) as exc_info:
             await entity.async_update_todo_item("due:101", {"status": TodoItemStatus.NEEDS_ACTION})
+        assert exc_info.value.translation_key == "todo_complete_only"
 
     async def test_delete_due_items_maps_to_skip(self) -> None:
         coordinator = _make_coordinator()
@@ -245,5 +247,6 @@ class TestDaynestTodoListEntity:
             entity_description=ENTITY_DESCRIPTION,
         )
 
-        with pytest.raises(HomeAssistantError, match="Todo item summary is required"):
+        with pytest.raises(HomeAssistantError) as exc_info:
             await entity.async_create_todo_item(TodoItem(summary="", status=TodoItemStatus.NEEDS_ACTION))
+        assert exc_info.value.translation_key == "todo_summary_required"

--- a/frontend/src/features/settings/SettingsPage.tsx
+++ b/frontend/src/features/settings/SettingsPage.tsx
@@ -20,65 +20,6 @@ import {
 } from "@/lib/api/auth";
 import { getCustomServerUrl, setCustomServerUrl } from "@/lib/api/serverConfig";
 
-const AVAILABLE_SCOPES = [
-  {
-    key: "ha:read",
-    label: "Home Assistant dashboard",
-    description: "Allows Home Assistant summary, entity, and dashboard reads.",
-  },
-  {
-    key: "ha:write",
-    label: "Home Assistant actions",
-    description:
-      "Allows Home Assistant services to complete tasks, snooze tasks, and mark medication taken.",
-  },
-  {
-    key: "mcp:read",
-    label: "MCP Adapter (read)",
-    description: "Allows MCP read tools: today view, calendar, planned items, routines, chores, medications.",
-  },
-  {
-    key: "mcp:write",
-    label: "MCP Adapter (write)",
-    description: "Allows MCP write tools: complete/skip/reschedule tasks, create/update/delete planned items, routines, chores, and medications.",
-  },
-];
-
-const INTEGRATION_PRESETS = [
-  {
-    key: "ha-dashboard",
-    label: "Home Assistant dashboard",
-    name: "Home Assistant",
-    scopes: ["ha:read"],
-    rateLimit: "120",
-    description: "Sensors, dashboard metrics, setup validation, and entity reads.",
-  },
-  {
-    key: "ha-automation",
-    label: "Home Assistant automations",
-    name: "Home Assistant Automations",
-    scopes: ["ha:read", "ha:write"],
-    rateLimit: "120",
-    description: "Everything in dashboard mode plus write services for household automations.",
-  },
-  {
-    key: "mcp-reader",
-    label: "MCP read-only",
-    name: "MCP Adapter",
-    scopes: ["mcp:read"],
-    rateLimit: "60",
-    description: "Least-privilege read access for MCP consumers.",
-  },
-  {
-    key: "mcp-full",
-    label: "MCP read + write",
-    name: "MCP Adapter",
-    scopes: ["mcp:read", "mcp:write"],
-    rateLimit: "60",
-    description: "Full MCP access including write tools (complete tasks, manage items, etc.).",
-  },
-];
-
 const HA_ENDPOINTS = [
   "GET /api/v1/integrations/home-assistant/summary",
   "GET /api/v1/integrations/home-assistant/dashboard",
@@ -106,7 +47,6 @@ export function SettingsPage() {
 
   const [name, setName] = useState("Home Assistant");
   const [rateLimit, setRateLimit] = useState("120");
-  const [selectedScopes, setSelectedScopes] = useState<string[]>(["ha:read"]);
 
   const [revokingClient, setRevokingClient] = useState<number | null>(null);
   const [revokeClientError, setRevokeClientError] = useState<string | null>(null);
@@ -254,29 +194,9 @@ export function SettingsPage() {
     return unsubscribe;
   }, []);
 
-  const toggleScope = (scope: string) => {
-    setSelectedScopes((current) =>
-      current.includes(scope) ? current.filter((item) => item !== scope) : [...current, scope],
-    );
-    setSubmitError(null);
-  };
-
-  const applyPreset = (preset: (typeof INTEGRATION_PRESETS)[number]) => {
-    setName(preset.name);
-    setRateLimit(preset.rateLimit);
-    setSelectedScopes(preset.scopes);
-    setSubmitError(null);
-    setSuccessMessage(null);
-  };
-
   const onCreateClient = async () => {
     if (!name.trim()) {
       setSubmitError("Client name is required.");
-      return;
-    }
-
-    if (selectedScopes.length === 0) {
-      setSubmitError("Select at least one scope.");
       return;
     }
 
@@ -293,7 +213,6 @@ export function SettingsPage() {
     try {
       const created = await createIntegrationClient({
         name: name.trim(),
-        scopes: selectedScopes,
         rate_limit_per_minute: parsedRateLimit,
       });
       setCreatedClient(created);
@@ -435,23 +354,6 @@ export function SettingsPage() {
           </div>
 
           <div className="card mb-3">
-            <div className="card-header fw-semibold py-2">Integration presets</div>
-            <div className="card-body d-grid gap-2">
-              {INTEGRATION_PRESETS.map((preset) => (
-                <button
-                  key={preset.key}
-                  type="button"
-                  className="btn btn-outline-primary text-start"
-                  onClick={() => applyPreset(preset)}
-                >
-                  <span className="fw-semibold d-block">{preset.label}</span>
-                  <span className="small text-muted">{preset.description}</span>
-                </button>
-              ))}
-            </div>
-          </div>
-
-          <div className="card mb-3">
             <div className="card-header fw-semibold py-2">Create integration client</div>
             <div className="card-body d-grid gap-3">
               <input
@@ -463,26 +365,6 @@ export function SettingsPage() {
                 }}
                 placeholder="Client name"
               />
-              <div>
-                <label className="form-label small fw-semibold mb-2">Scopes</label>
-                <div className="d-grid gap-2">
-                  {AVAILABLE_SCOPES.map((scope) => (
-                    <label key={scope.key} className="border rounded p-2">
-                      <div className="form-check">
-                        <input
-                          className="form-check-input"
-                          type="checkbox"
-                          checked={selectedScopes.includes(scope.key)}
-                          onChange={() => toggleScope(scope.key)}
-                          id={`scope-${scope.key}`}
-                        />
-                        <span className="form-check-label fw-semibold">{scope.label}</span>
-                      </div>
-                      <small className="text-muted d-block mt-1">{scope.description}</small>
-                    </label>
-                  ))}
-                </div>
-              </div>
               <div>
                 <label className="form-label small fw-semibold mb-1">Rate limit per minute</label>
                 <input
@@ -607,16 +489,7 @@ export function SettingsPage() {
                       <div>
                         <div className="fw-semibold">{client.name}</div>
                         <small className="text-muted d-block">
-                          {client.scopes.join(", ")} • {client.rate_limit_per_minute}/min
-                        </small>
-                        <small className="text-muted d-block mt-1">
-                          {[
-                            client.scopes.includes("ha:read") && "Home Assistant dashboard ready.",
-                            client.scopes.includes("ha:write") && "HA actions enabled.",
-                            client.scopes.includes("mcp:read") && "MCP adapter ready.",
-                          ]
-                            .filter(Boolean)
-                            .join(" ")}
+                          {client.rate_limit_per_minute}/min
                         </small>
                       </div>
                       <div className="d-flex align-items-center gap-2 flex-wrap justify-content-end">

--- a/frontend/src/lib/api/today.ts
+++ b/frontend/src/lib/api/today.ts
@@ -294,14 +294,12 @@ export interface MedicationHistoryResponse {
 export interface IntegrationClient {
   id: number;
   name: string;
-  scopes: string[];
   rate_limit_per_minute: number;
   is_active: boolean;
 }
 
 export interface IntegrationClientInput {
   name: string;
-  scopes: string[];
   rate_limit_per_minute: number;
 }
 

--- a/frontend/tests/features/settings/SettingsPage.test.tsx
+++ b/frontend/tests/features/settings/SettingsPage.test.tsx
@@ -38,7 +38,6 @@ describe("SettingsPage", () => {
     apiMock.createIntegrationClient.mockResolvedValue({
       id: 1,
       name: "Home Assistant Automations",
-      scopes: ["ha:read", "ha:write"],
       rate_limit_per_minute: 120,
       is_active: true,
       api_key: "daynest_test_key",
@@ -51,28 +50,25 @@ describe("SettingsPage", () => {
     pwaMock.subscribeInstallPrompt.mockImplementation(() => () => undefined);
   });
 
-  it("shows Home Assistant setup details and the action scope", async () => {
+  it("shows Home Assistant setup details", async () => {
     render(<SettingsPage />);
 
     expect(await screen.findByText("Home Assistant connection details")).toBeInTheDocument();
     expect(screen.getByText("home-assistant; version=ha.v1")).toBeInTheDocument();
     expect(screen.getByText(/setup now uses browser-based oauth redirect/i)).toBeInTheDocument();
     expect(screen.getByText("https://my.home-assistant.io/redirect/oauth")).toBeInTheDocument();
-    expect(screen.getByLabelText(/home assistant actions/i)).toBeInTheDocument();
   });
 
-  it("applies the Home Assistant automation preset when creating a client", async () => {
+  it("creates a client with the given name and rate limit", async () => {
     const user = userEvent.setup();
     render(<SettingsPage />);
 
-    await screen.findByText("Integration presets");
-    await user.click(screen.getByRole("button", { name: /home assistant automations/i }));
+    await screen.findByText("Create integration client");
     await user.click(screen.getByRole("button", { name: /^create client$/i }));
 
     await waitFor(() => {
       expect(apiMock.createIntegrationClient).toHaveBeenCalledWith({
-        name: "Home Assistant Automations",
-        scopes: ["ha:read", "ha:write"],
+        name: "Home Assistant",
         rate_limit_per_minute: 120,
       });
     });

--- a/python-daynest/src/daynest/client.py
+++ b/python-daynest/src/daynest/client.py
@@ -160,6 +160,38 @@ class DaynestClient:
             return {"X-Integration-Key": self._integration_key}
         return {}
 
+    @classmethod
+    async def async_fetch_oidc_config(
+        cls,
+        base_url: str,
+        *,
+        session: aiohttp.ClientSession | None = None,
+    ) -> tuple[str, str] | None:
+        """Fetch OIDC discovery endpoints from the Daynest backend.
+
+        Returns (authorization_url, token_url) or None if the backend is
+        unreachable or the response is malformed. Does not require authentication.
+        """
+        url = urljoin(f"{base_url.strip().rstrip('/')}/", "api/v1/auth/oidc-config")
+        owned = session is None
+        if owned:
+            session = aiohttp.ClientSession()
+        try:
+            async with session.get(url, timeout=REQUEST_TIMEOUT) as resp:
+                if resp.status == 200:
+                    data = await resp.json(content_type=None)
+                    if isinstance(data, dict):
+                        auth_url = data.get("authorization_url")
+                        token_url = data.get("token_url")
+                        if isinstance(auth_url, str) and isinstance(token_url, str):
+                            return auth_url, token_url
+        except Exception:  # noqa: BLE001
+            pass
+        finally:
+            if owned:
+                await session.close()
+        return None
+
     async def async_get_data(self) -> dict[str, Any]:
         """Fetch summary data as the coordinator's primary payload."""
         response = await self.async_get_summary()


### PR DESCRIPTION
## Summary

- **Remove integration client scopes system-wide** — any valid token (OIDC or PAT) now grants full access to the authenticated user's own data; per-client identity and revocation are handled at the Keycloak/OIDC layer. Drops the `scopes_csv` column via Alembic migration, removes scope UI from frontend (React) and Android, cleans up all references in docs and translations.
- **Move OIDC config discovery into `python-daynest`** — adds `DaynestClient.async_fetch_oidc_config` classmethod so the HA integration no longer makes raw HTTP calls.
- **HA integration polish** (quality scale improvements):
  - Fix `DeviceInfo` (remove phantom `model` field that always returned `"Unknown"`)
  - Expand diagnostics payload: entity states, auth mode, contract version, error info, platform list; extend `TO_REDACT` to cover all token fields
  - Add `icons.json` — move all entity icons out of static Python attributes
  - `entity-disabled-by-default` — secondary sensors start disabled (`planned_count`, `planned_remaining_count`, `routines_open_count`, `next_medication`)
  - `exception-translations` — all `HomeAssistantError` raises in `services.py` and `todo.py` use translation keys
  - `PARALLEL_UPDATES` — add to `todo` platform (was missing)
  - `reconfiguration-flow` — `async_step_reconfigure` lets users update the server URL without removing the integration
  - `repair-issues` — coordinator raises `unsupported_contract_version` repair issue when the backend returns an unrecognised contract version
  - Add `quality_scale.yaml` tracking all 56 rules (Bronze/Silver/Gold/Platinum)
  - Closes #264 (expand diagnostics), closes #263 (HACS checklist)

## Test plan

- [ ] Remove and re-add the integration — initial OAuth flow works end to end
- [ ] Trigger reauth (revoke token in Keycloak) — reauth flow surfaces and completes
- [ ] Use Reconfigure on an existing entry — URL updates, OAuth re-runs, entry reloads
- [ ] Verify sensors: primary sensors enabled by default, secondary sensors disabled
- [ ] Verify icons appear correctly in entity list (no static icon fallback)
- [ ] Check HA Repairs panel after pointing at a server with an unsupported contract version
- [ ] Run backend test suite — all 103 tests pass
- [ ] Run frontend type-check and build