### PR TITLE
feat: backend batch 1 — user settings, bulk mutations, priority/tags, rrule, template REST paths, export/import, search, streaks

### DIFF
--- a/backend/alembic/versions/20260521_0002_priority_and_tags.py
+++ b/backend/alembic/versions/20260521_0002_priority_and_tags.py
@@ -1,0 +1,30 @@
+"""add priority and tags to planned_items and chore_templates
+
+Revision ID: 20260521_0002
+Revises: 20260521_0001
+Create Date: 2026-05-21 00:00:00.000000
+"""
+
+from typing import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "20260521_0002"
+down_revision: str | None = "20260521_0001"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column("planned_items", sa.Column("priority", sa.String(20), nullable=False, server_default="normal"))
+    op.add_column("planned_items", sa.Column("tags", sa.JSON(), nullable=False, server_default="[]"))
+    op.add_column("chore_templates", sa.Column("priority", sa.String(20), nullable=False, server_default="normal"))
+    op.add_column("chore_templates", sa.Column("tags", sa.JSON(), nullable=False, server_default="[]"))
+
+
+def downgrade() -> None:
+    op.drop_column("planned_items", "priority")
+    op.drop_column("planned_items", "tags")
+    op.drop_column("chore_templates", "priority")
+    op.drop_column("chore_templates", "tags")

--- a/backend/alembic/versions/20260521_0002_priority_and_tags.py
+++ b/backend/alembic/versions/20260521_0002_priority_and_tags.py
@@ -16,15 +16,23 @@ branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None
 
 
+_PRIORITY_VALUES = ("low", "normal", "high", "urgent")
+_PRIORITY_CHECK = f"priority IN {_PRIORITY_VALUES}"
+
+
 def upgrade() -> None:
     op.add_column("planned_items", sa.Column("priority", sa.String(20), nullable=False, server_default="normal"))
+    op.create_check_constraint("ck_planned_items_priority", "planned_items", _PRIORITY_CHECK)
     op.add_column("planned_items", sa.Column("tags", sa.JSON(), nullable=False, server_default="[]"))
     op.add_column("chore_templates", sa.Column("priority", sa.String(20), nullable=False, server_default="normal"))
+    op.create_check_constraint("ck_chore_templates_priority", "chore_templates", _PRIORITY_CHECK)
     op.add_column("chore_templates", sa.Column("tags", sa.JSON(), nullable=False, server_default="[]"))
 
 
 def downgrade() -> None:
-    op.drop_column("planned_items", "priority")
-    op.drop_column("planned_items", "tags")
-    op.drop_column("chore_templates", "priority")
+    op.drop_constraint("ck_chore_templates_priority", "chore_templates")
     op.drop_column("chore_templates", "tags")
+    op.drop_column("chore_templates", "priority")
+    op.drop_constraint("ck_planned_items_priority", "planned_items")
+    op.drop_column("planned_items", "tags")
+    op.drop_column("planned_items", "priority")

--- a/backend/alembic/versions/20260521_0003_rrule.py
+++ b/backend/alembic/versions/20260521_0003_rrule.py
@@ -1,0 +1,26 @@
+"""add rrule field to routine_templates and chore_templates
+
+Revision ID: 20260521_0003
+Revises: 20260521_0002
+Create Date: 2026-05-21 00:00:00.000000
+"""
+
+from typing import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "20260521_0003"
+down_revision: str | None = "20260521_0002"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column("routine_templates", sa.Column("rrule", sa.String(500), nullable=True))
+    op.add_column("chore_templates", sa.Column("rrule", sa.String(500), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("routine_templates", "rrule")
+    op.drop_column("chore_templates", "rrule")

--- a/backend/alembic/versions/20260521_0004_user_settings.py
+++ b/backend/alembic/versions/20260521_0004_user_settings.py
@@ -1,0 +1,30 @@
+"""add user preference fields (snooze, medication reminder, quiet hours)
+
+Revision ID: 20260521_0004
+Revises: 20260521_0003
+Create Date: 2026-05-21 00:00:00.000000
+"""
+
+from typing import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "20260521_0004"
+down_revision: str | None = "20260521_0003"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column("users", sa.Column("default_snooze_days", sa.Integer(), nullable=False, server_default="1"))
+    op.add_column("users", sa.Column("medication_reminder_minutes", sa.Integer(), nullable=False, server_default="30"))
+    op.add_column("users", sa.Column("quiet_hours_start", sa.Time(), nullable=True))
+    op.add_column("users", sa.Column("quiet_hours_end", sa.Time(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("users", "default_snooze_days")
+    op.drop_column("users", "medication_reminder_minutes")
+    op.drop_column("users", "quiet_hours_start")
+    op.drop_column("users", "quiet_hours_end")

--- a/backend/alembic/versions/20260521_0005_calendar_token.py
+++ b/backend/alembic/versions/20260521_0005_calendar_token.py
@@ -1,0 +1,26 @@
+"""add calendar_token to users
+
+Revision ID: 20260521_0005
+Revises: 20260521_0004
+Create Date: 2026-05-21 00:00:00.000000
+"""
+
+from typing import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "20260521_0005"
+down_revision: str | None = "20260521_0004"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column("users", sa.Column("calendar_token", sa.String(64), nullable=True))
+    op.create_index("ix_users_calendar_token", "users", ["calendar_token"], unique=True)
+
+
+def downgrade() -> None:
+    op.drop_index("ix_users_calendar_token", table_name="users")
+    op.drop_column("users", "calendar_token")

--- a/backend/app/api/dependencies/auth.py
+++ b/backend/app/api/dependencies/auth.py
@@ -9,6 +9,28 @@ from app.models.user import User
 bearer_scheme = HTTPBearer(auto_error=False)
 
 
+async def get_current_user_optional(
+    request: Request,
+    credentials: HTTPAuthorizationCredentials | None = Depends(bearer_scheme),
+    db: Session = Depends(get_db),
+) -> User | None:
+    if credentials is None:
+        return None
+    try:
+        claims = await decode_oidc_token(credentials.credentials)
+    except OIDCTokenError:
+        return None
+    subject: str | None = claims.get("sub")
+    if not subject:
+        return None
+    user = get_or_create_local_user(subject, claims, db)
+    if not user.is_active:
+        return None
+    request.state.user_id = user.id
+    request.state.roles = _extract_roles(claims)
+    return user
+
+
 async def get_current_user(
     request: Request,
     credentials: HTTPAuthorizationCredentials | None = Depends(bearer_scheme),

--- a/backend/app/api/routes/analytics.py
+++ b/backend/app/api/routes/analytics.py
@@ -7,7 +7,7 @@ from sqlalchemy.orm import Session
 from app.api.dependencies.auth import get_current_user
 from app.db.session import get_db
 from app.models.user import User
-from app.repositories.analytics_repository import get_chore_stats, get_medication_stats, get_planned_item_stats
+from app.repositories.analytics_repository import get_chore_stats, get_medication_stats, get_planned_item_stats, get_routine_stats
 from app.schemas.analytics import AnalyticsSummaryResponse
 
 router = APIRouter(prefix="/analytics", tags=["analytics"])
@@ -38,4 +38,5 @@ def get_analytics_summary(
         chores=get_chore_stats(db, current_user.id, start_date, end_date),
         medications=get_medication_stats(db, current_user.id, start_date, end_date),
         planned_items=get_planned_item_stats(db, current_user.id, start_date, end_date),
+        routines=get_routine_stats(db, current_user.id, start_date, end_date),
     )

--- a/backend/app/api/routes/analytics.py
+++ b/backend/app/api/routes/analytics.py
@@ -1,0 +1,41 @@
+from datetime import date, timedelta
+from typing import Literal
+
+from fastapi import APIRouter, Depends, Query
+from sqlalchemy.orm import Session
+
+from app.api.dependencies.auth import get_current_user
+from app.db.session import get_db
+from app.models.user import User
+from app.repositories.analytics_repository import get_chore_stats, get_medication_stats, get_planned_item_stats
+from app.schemas.analytics import AnalyticsSummaryResponse
+
+router = APIRouter(prefix="/analytics", tags=["analytics"])
+
+AnalyticsPeriod = Literal["week", "month", "year"]
+
+
+def _period_start(today: date, period: AnalyticsPeriod) -> date:
+    if period == "week":
+        return today - timedelta(days=6)
+    if period == "month":
+        return today - timedelta(days=29)
+    return today - timedelta(days=364)
+
+
+@router.get("/summary", response_model=AnalyticsSummaryResponse)
+def get_analytics_summary(
+    period: AnalyticsPeriod = Query(default="week"),
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+) -> AnalyticsSummaryResponse:
+    end_date = date.today()
+    start_date = _period_start(end_date, period)
+    return AnalyticsSummaryResponse(
+        period=period,
+        start_date=start_date,
+        end_date=end_date,
+        chores=get_chore_stats(db, current_user.id, start_date, end_date),
+        medications=get_medication_stats(db, current_user.id, start_date, end_date),
+        planned_items=get_planned_item_stats(db, current_user.id, start_date, end_date),
+    )

--- a/backend/app/api/routes/bulk.py
+++ b/backend/app/api/routes/bulk.py
@@ -1,0 +1,36 @@
+from fastapi import APIRouter, Depends, HTTPException
+
+from app.api.dependencies.auth import get_current_user
+from app.api.dependencies.today import get_today_service
+from app.models.user import User
+from app.schemas.bulk import BulkMutationItem, BulkMutationRequest, BulkMutationResponse, BulkMutationResult, MutationType
+from app.services.today_service import TodayService
+
+router = APIRouter(tags=["bulk"])
+
+
+def _apply_mutation(service: TodayService, user_id: int, mutation: BulkMutationItem) -> None:
+    if mutation.type == MutationType.complete_chore:
+        service.complete_chore(user_id=user_id, chore_instance_id=mutation.id)
+    elif mutation.type == MutationType.skip_chore:
+        service.skip_chore(user_id=user_id, chore_instance_id=mutation.id)
+    elif mutation.type == MutationType.mark_planned_done:
+        service.mark_planned_done(user_id=user_id, planned_item_id=mutation.id)
+
+
+@router.post("/bulk", response_model=BulkMutationResponse)
+def bulk_mutate(
+    request: BulkMutationRequest,
+    service: TodayService = Depends(get_today_service),
+    current_user: User = Depends(get_current_user),
+) -> BulkMutationResponse:
+    results: list[BulkMutationResult] = []
+    for mutation in request.mutations:
+        try:
+            _apply_mutation(service, current_user.id, mutation)
+            results.append(BulkMutationResult(type=mutation.type, id=mutation.id, success=True))
+        except HTTPException as exc:
+            results.append(BulkMutationResult(type=mutation.type, id=mutation.id, success=False, error=exc.detail))
+        except Exception as exc:
+            results.append(BulkMutationResult(type=mutation.type, id=mutation.id, success=False, error=str(exc)))
+    return BulkMutationResponse(results=results)

--- a/backend/app/api/routes/bulk.py
+++ b/backend/app/api/routes/bulk.py
@@ -11,11 +11,11 @@ router = APIRouter(tags=["bulk"])
 
 def _apply_mutation(service: TodayService, user_id: int, mutation: BulkMutationItem) -> None:
     if mutation.type == MutationType.complete_chore:
-        service.complete_chore(user_id=user_id, chore_instance_id=mutation.id)
+        service.complete_chore(user_id=user_id, chore_instance_id=mutation.id, persist=False)
     elif mutation.type == MutationType.skip_chore:
-        service.skip_chore(user_id=user_id, chore_instance_id=mutation.id)
+        service.skip_chore(user_id=user_id, chore_instance_id=mutation.id, persist=False)
     elif mutation.type == MutationType.mark_planned_done:
-        service.mark_planned_done(user_id=user_id, planned_item_id=mutation.id)
+        service.mark_planned_done(user_id=user_id, planned_item_id=mutation.id, persist=False)
 
 
 @router.post("/bulk", response_model=BulkMutationResponse)
@@ -25,12 +25,16 @@ def bulk_mutate(
     current_user: User = Depends(get_current_user),
 ) -> BulkMutationResponse:
     results: list[BulkMutationResult] = []
+    has_success = False
     for mutation in request.mutations:
         try:
             _apply_mutation(service, current_user.id, mutation)
             results.append(BulkMutationResult(type=mutation.type, id=mutation.id, success=True))
+            has_success = True
         except HTTPException as exc:
             results.append(BulkMutationResult(type=mutation.type, id=mutation.id, success=False, error=exc.detail))
         except Exception as exc:
             results.append(BulkMutationResult(type=mutation.type, id=mutation.id, success=False, error=str(exc)))
+    if has_success:
+        service.save()
     return BulkMutationResponse(results=results)

--- a/backend/app/api/routes/bulk.py
+++ b/backend/app/api/routes/bulk.py
@@ -1,3 +1,5 @@
+import logging
+
 from fastapi import APIRouter, Depends, HTTPException
 
 from app.api.dependencies.auth import get_current_user
@@ -7,6 +9,7 @@ from app.schemas.bulk import BulkMutationItem, BulkMutationRequest, BulkMutation
 from app.services.today_service import TodayService
 
 router = APIRouter(tags=["bulk"])
+logger = logging.getLogger(__name__)
 
 
 def _apply_mutation(service: TodayService, user_id: int, mutation: BulkMutationItem) -> None:
@@ -33,8 +36,16 @@ def bulk_mutate(
             has_success = True
         except HTTPException as exc:
             results.append(BulkMutationResult(type=mutation.type, id=mutation.id, success=False, error=exc.detail))
-        except Exception as exc:
-            results.append(BulkMutationResult(type=mutation.type, id=mutation.id, success=False, error=str(exc)))
+        except Exception:
+            logger.exception("Unexpected error applying mutation type=%s id=%s", mutation.type, mutation.id)
+            results.append(BulkMutationResult(type=mutation.type, id=mutation.id, success=False, error="failed to apply mutation"))
     if has_success:
-        service.save()
+        try:
+            service.save()
+        except Exception:
+            logger.exception("Failed to persist bulk mutations")
+            for r in results:
+                if r.success:
+                    r.success = False
+                    r.error = "persist error"
     return BulkMutationResponse(results=results)

--- a/backend/app/api/routes/calendar.py
+++ b/backend/app/api/routes/calendar.py
@@ -149,7 +149,7 @@ def _resolve_user(
 
 
 @router.get("/calendar/export.ics")
-async def export_ical(
+def export_ical(
     token: str | None = Query(default=None, description="Per-user calendar subscription token"),
     db: Session = Depends(get_db),
     service: TodayService = Depends(get_today_service),
@@ -181,5 +181,10 @@ async def export_ical(
     return Response(
         content=_build_ical(event_lines),
         media_type="text/calendar; charset=utf-8",
-        headers={"Content-Disposition": 'attachment; filename="daynest.ics"'},
+        headers={
+            "Content-Disposition": 'attachment; filename="daynest.ics"',
+            "Cache-Control": "private, no-store",
+            "Pragma": "no-cache",
+            "Expires": "0",
+        },
     )

--- a/backend/app/api/routes/calendar.py
+++ b/backend/app/api/routes/calendar.py
@@ -1,0 +1,185 @@
+from datetime import date, datetime, timedelta, timezone
+from secrets import token_urlsafe
+from zoneinfo import ZoneInfo
+
+from fastapi import APIRouter, Depends, HTTPException, Query, Response, status
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from app.api.dependencies.auth import get_current_user, get_current_user_optional
+from app.api.dependencies.today import get_today_service
+from app.db.session import get_db
+from app.models.user import User
+from app.schemas.calendar import CalendarTokenResponse
+from app.services.today_service import TodayService
+
+router = APIRouter(tags=["calendar"])
+
+_EXPORT_PAST_DAYS = 60
+_EXPORT_FUTURE_DAYS = 365
+
+
+# --- iCal formatting helpers ---
+
+def _ical_escape(text: str) -> str:
+    return text.replace("\\", "\\\\").replace(";", "\\;").replace(",", "\\,").replace("\n", "\\n")
+
+
+def _fold_line(line: str) -> str:
+    """Fold long content-lines per RFC 5545 (max 75 octets per line)."""
+    result = []
+    while len(line.encode("utf-8")) > 75:
+        n = 75
+        while len(line[:n].encode("utf-8")) > 75:
+            n -= 1
+        result.append(line[:n])
+        line = " " + line[n:]
+    result.append(line)
+    return "\r\n".join(result)
+
+
+def _build_ical(event_lines: list[str]) -> str:
+    header = [
+        "BEGIN:VCALENDAR",
+        "VERSION:2.0",
+        "PRODID:-//Daynest//Daynest Calendar//EN",
+        "CALSCALE:GREGORIAN",
+        "METHOD:PUBLISH",
+        "X-WR-CALNAME:Daynest",
+    ]
+    footer = ["END:VCALENDAR"]
+    all_lines = header + event_lines + footer
+    return "\r\n".join(_fold_line(line) for line in all_lines) + "\r\n"
+
+
+def _format_utc_ical_datetime(value: str) -> str:
+    dt = datetime.fromisoformat(value)
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt.astimezone(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+
+
+def _format_event(
+    *,
+    uid: str,
+    dtstamp: str,
+    summary: str,
+    start: dict[str, str],
+    end: dict[str, str],
+    description: str | None,
+    reminder_minutes: int | None,
+) -> list[str]:
+    lines = [
+        "BEGIN:VEVENT",
+        f"UID:{_ical_escape(uid)}",
+        f"DTSTAMP:{dtstamp}",
+    ]
+    if "dateTime" in start:
+        lines.append(f"DTSTART:{_format_utc_ical_datetime(start['dateTime'])}")
+        lines.append(f"DTEND:{_format_utc_ical_datetime(end['dateTime'])}")
+    else:
+        d = date.fromisoformat(start["date"])
+        d_end = date.fromisoformat(end["date"])
+        lines.append(f"DTSTART;VALUE=DATE:{d.strftime('%Y%m%d')}")
+        lines.append(f"DTEND;VALUE=DATE:{d_end.strftime('%Y%m%d')}")
+    lines.append(f"SUMMARY:{_ical_escape(summary)}")
+    if description:
+        lines.append(f"DESCRIPTION:{_ical_escape(description)}")
+    if reminder_minutes and reminder_minutes > 0:
+        lines += [
+            "BEGIN:VALARM",
+            "ACTION:DISPLAY",
+            f"TRIGGER:-PT{reminder_minutes}M",
+            f"DESCRIPTION:{_ical_escape(summary)}",
+            "END:VALARM",
+        ]
+    lines.append("END:VEVENT")
+    return lines
+
+
+# --- Calendar token endpoints ---
+
+@router.post("/users/me/calendar-token", response_model=CalendarTokenResponse, status_code=status.HTTP_201_CREATED)
+def generate_calendar_token(
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+) -> CalendarTokenResponse:
+    token = token_urlsafe(32)
+    current_user.calendar_token = token
+    db.commit()
+    db.refresh(current_user)
+    return CalendarTokenResponse(token=token)
+
+
+@router.get("/users/me/calendar-token", response_model=CalendarTokenResponse)
+def get_calendar_token(current_user: User = Depends(get_current_user)) -> CalendarTokenResponse:
+    if not current_user.calendar_token:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="No calendar token exists; POST to generate one")
+    return CalendarTokenResponse(token=current_user.calendar_token)
+
+
+@router.delete("/users/me/calendar-token", status_code=status.HTTP_204_NO_CONTENT)
+def revoke_calendar_token(
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+) -> Response:
+    current_user.calendar_token = None
+    db.commit()
+    return Response(status_code=status.HTTP_204_NO_CONTENT)
+
+
+# --- iCal export ---
+
+def _resolve_user(
+    token: str | None,
+    bearer_user: User | None,
+    db: Session,
+) -> User:
+    if bearer_user is not None:
+        return bearer_user
+    if token:
+        user = db.scalar(select(User).where(User.calendar_token == token).where(User.is_active.is_(True)))
+        if user:
+            return user
+    raise HTTPException(
+        status_code=status.HTTP_401_UNAUTHORIZED,
+        detail="Provide a Bearer token or a valid ?token= calendar token",
+        headers={"WWW-Authenticate": "Bearer"},
+    )
+
+
+@router.get("/calendar/export.ics")
+async def export_ical(
+    token: str | None = Query(default=None, description="Per-user calendar subscription token"),
+    db: Session = Depends(get_db),
+    service: TodayService = Depends(get_today_service),
+    bearer_user: User | None = Depends(get_current_user_optional),
+) -> Response:
+    user = _resolve_user(token, bearer_user, db)
+
+    today = datetime.now(ZoneInfo(user.timezone)).date()
+    start_date = today - timedelta(days=_EXPORT_PAST_DAYS)
+    end_date = today + timedelta(days=_EXPORT_FUTURE_DAYS)
+
+    events = service.get_calendar_events(user_id=user.id, start_date=start_date, end_date=end_date)
+    reminder_minutes = user.medication_reminder_minutes
+    dtstamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+
+    event_lines: list[str] = []
+    for event in events:
+        is_medication = event.uid.startswith("daynest_medication_")
+        event_lines.extend(_format_event(
+            uid=event.uid,
+            dtstamp=dtstamp,
+            summary=event.summary,
+            start=event.start,
+            end=event.end,
+            description=event.description,
+            reminder_minutes=reminder_minutes if is_medication else None,
+        ))
+
+    return Response(
+        content=_build_ical(event_lines),
+        media_type="text/calendar; charset=utf-8",
+        headers={"Content-Disposition": 'attachment; filename="daynest.ics"'},
+    )

--- a/backend/app/api/routes/search.py
+++ b/backend/app/api/routes/search.py
@@ -1,0 +1,175 @@
+from __future__ import annotations
+
+from datetime import date, datetime
+
+from fastapi import APIRouter, Depends, Query
+from pydantic import BaseModel
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from app.api.dependencies.auth import get_current_user
+from app.db.session import get_db
+from app.models.chore_template import ChoreTemplate
+from app.models.medication_plan import MedicationPlan
+from app.models.planned_item import PlannedItem
+from app.models.routine_template import RoutineTemplate
+from app.models.user import User
+
+router = APIRouter(prefix="/search", tags=["search"])
+
+_DEFAULT_LIMIT = 20
+_ESCAPE_CHAR = "\\"
+
+
+def _like_pattern(q: str) -> str:
+    escaped = q.replace(_ESCAPE_CHAR, _ESCAPE_CHAR * 2).replace("%", f"{_ESCAPE_CHAR}%").replace("_", f"{_ESCAPE_CHAR}_")
+    return f"%{escaped}%"
+
+
+class RoutineSearchResult(BaseModel):
+    id: int
+    name: str
+    description: str | None
+    is_active: bool
+    created_at: datetime
+
+
+class ChoreSearchResult(BaseModel):
+    id: int
+    name: str
+    description: str | None
+    priority: str
+    tags: list[str]
+    is_active: bool
+    created_at: datetime
+
+
+class MedicationSearchResult(BaseModel):
+    id: int
+    name: str
+    instructions: str
+    is_active: bool
+    created_at: datetime
+
+
+class PlannedItemSearchResult(BaseModel):
+    id: int
+    title: str
+    notes: str | None
+    planned_for: date
+    priority: str
+    tags: list[str]
+    is_done: bool
+    created_at: datetime
+
+
+class SearchResponse(BaseModel):
+    query: str
+    routine_templates: list[RoutineSearchResult]
+    chore_templates: list[ChoreSearchResult]
+    medication_plans: list[MedicationSearchResult]
+    planned_items: list[PlannedItemSearchResult]
+
+
+@router.get("", response_model=SearchResponse)
+def search(
+    q: str = Query(min_length=2, max_length=100),
+    limit: int = Query(default=_DEFAULT_LIMIT, ge=1, le=100),
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+) -> SearchResponse:
+    pattern = _like_pattern(q)
+    uid = current_user.id
+
+    routines = db.scalars(
+        select(RoutineTemplate)
+        .where(
+            RoutineTemplate.user_id == uid,
+            (RoutineTemplate.name.ilike(pattern, escape=_ESCAPE_CHAR))
+            | (RoutineTemplate.description.ilike(pattern, escape=_ESCAPE_CHAR)),
+        )
+        .order_by(RoutineTemplate.name)
+        .limit(limit)
+    ).all()
+
+    chores = db.scalars(
+        select(ChoreTemplate)
+        .where(
+            ChoreTemplate.user_id == uid,
+            (ChoreTemplate.name.ilike(pattern, escape=_ESCAPE_CHAR))
+            | (ChoreTemplate.description.ilike(pattern, escape=_ESCAPE_CHAR)),
+        )
+        .order_by(ChoreTemplate.name)
+        .limit(limit)
+    ).all()
+
+    medications = db.scalars(
+        select(MedicationPlan)
+        .where(
+            MedicationPlan.user_id == uid,
+            (MedicationPlan.name.ilike(pattern, escape=_ESCAPE_CHAR))
+            | (MedicationPlan.instructions.ilike(pattern, escape=_ESCAPE_CHAR)),
+        )
+        .order_by(MedicationPlan.name)
+        .limit(limit)
+    ).all()
+
+    planned = db.scalars(
+        select(PlannedItem)
+        .where(
+            PlannedItem.user_id == uid,
+            (PlannedItem.title.ilike(pattern, escape=_ESCAPE_CHAR))
+            | (PlannedItem.notes.ilike(pattern, escape=_ESCAPE_CHAR)),
+        )
+        .order_by(PlannedItem.planned_for.desc(), PlannedItem.title)
+        .limit(limit)
+    ).all()
+
+    return SearchResponse(
+        query=q,
+        routine_templates=[
+            RoutineSearchResult(
+                id=r.id,
+                name=r.name,
+                description=r.description,
+                is_active=r.is_active,
+                created_at=r.created_at,
+            )
+            for r in routines
+        ],
+        chore_templates=[
+            ChoreSearchResult(
+                id=c.id,
+                name=c.name,
+                description=c.description,
+                priority=c.priority,
+                tags=c.tags or [],
+                is_active=c.is_active,
+                created_at=c.created_at,
+            )
+            for c in chores
+        ],
+        medication_plans=[
+            MedicationSearchResult(
+                id=m.id,
+                name=m.name,
+                instructions=m.instructions,
+                is_active=m.is_active,
+                created_at=m.created_at,
+            )
+            for m in medications
+        ],
+        planned_items=[
+            PlannedItemSearchResult(
+                id=p.id,
+                title=p.title,
+                notes=p.notes,
+                planned_for=p.planned_for,
+                priority=p.priority,
+                tags=p.tags or [],
+                is_done=p.is_done,
+                created_at=p.created_at,
+            )
+            for p in planned
+        ],
+    )

--- a/backend/app/api/routes/templates.py
+++ b/backend/app/api/routes/templates.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter, Depends, HTTPException, Response, status
+from fastapi import APIRouter, Depends, HTTPException, Query, Response, status
 from sqlalchemy.orm import Session
 
 from app.api.dependencies.auth import get_current_user
@@ -26,6 +26,7 @@ def _routine_to_response(template: RoutineTemplate) -> RoutineTemplateResponse:
         description=template.description,
         start_date=template.start_date,
         every_n_days=template.every_n_days,
+        rrule=template.rrule,
         due_time=template.due_time,
         is_active=template.is_active,
         created_at=template.created_at,
@@ -39,6 +40,9 @@ def _chore_to_response(template: ChoreTemplate) -> ChoreTemplateResponse:
         description=template.description,
         start_date=template.start_date,
         every_n_days=template.every_n_days,
+        rrule=template.rrule,
+        priority=template.priority,
+        tags=template.tags or [],
         is_active=template.is_active,
         created_at=template.created_at,
     )
@@ -81,6 +85,7 @@ def create_routine(
             description=request.description,
             start_date=request.start_date,
             every_n_days=request.every_n_days,
+            rrule=request.rrule,
             due_time=request.due_time,
             is_active=request.is_active,
         )
@@ -103,6 +108,7 @@ def update_routine(
         description=request.description,
         start_date=request.start_date,
         every_n_days=request.every_n_days,
+        rrule=request.rrule,
         due_time=request.due_time,
         is_active=request.is_active,
     )
@@ -121,16 +127,18 @@ def delete_routine(
     return Response(status_code=status.HTTP_204_NO_CONTENT)
 
 
-@router.get("/chore-templates", response_model=list[ChoreTemplateResponse])
+@router.get("/chores", response_model=list[ChoreTemplateResponse])
 def list_chore_templates(
+    tags: str | None = Query(default=None, description="Comma-separated tags to filter by (OR match)"),
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ) -> list[ChoreTemplateResponse]:
     repository = TodayRepository(db)
-    return [_chore_to_response(item) for item in repository.list_chore_templates(current_user.id)]
+    tag_list = [t.strip() for t in tags.split(",")] if tags else None
+    return [_chore_to_response(item) for item in repository.list_chore_templates(current_user.id, tags=tag_list)]
 
 
-@router.post("/chore-templates", response_model=ChoreTemplateResponse, status_code=201)
+@router.post("/chores", response_model=ChoreTemplateResponse, status_code=201)
 def create_chore_template(
     request: ChoreTemplateCreateRequest,
     db: Session = Depends(get_db),
@@ -144,13 +152,16 @@ def create_chore_template(
             description=request.description,
             start_date=request.start_date,
             every_n_days=request.every_n_days,
+            rrule=request.rrule,
+            priority=request.priority,
+            tags=request.tags,
             is_active=request.is_active,
         )
     )
     return _chore_to_response(template)
 
 
-@router.put("/chore-templates/{chore_template_id}", response_model=ChoreTemplateResponse)
+@router.put("/chores/{chore_template_id}", response_model=ChoreTemplateResponse)
 def update_chore_template(
     chore_template_id: int,
     request: ChoreTemplateUpdateRequest,
@@ -165,12 +176,15 @@ def update_chore_template(
         description=request.description,
         start_date=request.start_date,
         every_n_days=request.every_n_days,
+        rrule=request.rrule,
+        priority=request.priority,
+        tags=request.tags,
         is_active=request.is_active,
     )
     return _chore_to_response(updated)
 
 
-@router.delete("/chore-templates/{chore_template_id}", status_code=status.HTTP_204_NO_CONTENT)
+@router.delete("/chores/{chore_template_id}", status_code=status.HTTP_204_NO_CONTENT)
 def delete_chore_template(
     chore_template_id: int,
     db: Session = Depends(get_db),

--- a/backend/app/api/routes/templates.py
+++ b/backend/app/api/routes/templates.py
@@ -134,7 +134,7 @@ def list_chore_templates(
     current_user: User = Depends(get_current_user),
 ) -> list[ChoreTemplateResponse]:
     repository = TodayRepository(db)
-    tag_list = [t.strip() for t in tags.split(",")] if tags else None
+    tag_list = [t.strip() for t in tags.split(",") if t.strip()] if tags else None
     return [_chore_to_response(item) for item in repository.list_chore_templates(current_user.id, tags=tag_list)]
 
 

--- a/backend/app/api/routes/today.py
+++ b/backend/app/api/routes/today.py
@@ -56,7 +56,8 @@ def list_planned_items(
     service: TodayService = Depends(get_today_service),
     current_user: User = Depends(get_current_user),
 ) -> list[PlannedTodayItem]:
-    tag_list = [t.strip() for t in tags.split(",")] if tags else None
+    tag_list = [t.strip() for t in tags.split(",") if t.strip()] if tags else None
+    tag_list = tag_list or None
     return service.list_planned_items(user_id=current_user.id, start_date=start_date, end_date=end_date, tags=tag_list)
 
 

--- a/backend/app/api/routes/today.py
+++ b/backend/app/api/routes/today.py
@@ -52,10 +52,12 @@ def get_calendar_day(
 def list_planned_items(
     start_date: date | None = Query(default=None),
     end_date: date | None = Query(default=None),
+    tags: str | None = Query(default=None, description="Comma-separated tags to filter by (OR match)"),
     service: TodayService = Depends(get_today_service),
     current_user: User = Depends(get_current_user),
 ) -> list[PlannedTodayItem]:
-    return service.list_planned_items(user_id=current_user.id, start_date=start_date, end_date=end_date)
+    tag_list = [t.strip() for t in tags.split(",")] if tags else None
+    return service.list_planned_items(user_id=current_user.id, start_date=start_date, end_date=end_date, tags=tag_list)
 
 
 @router.post("/planned-items", response_model=PlannedTodayItem)

--- a/backend/app/api/routes/users.py
+++ b/backend/app/api/routes/users.py
@@ -1,0 +1,51 @@
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.orm import Session
+
+from app.api.dependencies.auth import get_current_user
+from app.db.session import get_db
+from app.models.user import User
+from app.schemas.users import UserSettingsPatchRequest, UserSettingsResponse
+
+router = APIRouter(prefix="/users", tags=["users"])
+
+
+def _to_response(user: User) -> UserSettingsResponse:
+    return UserSettingsResponse(
+        timezone=user.timezone,
+        default_snooze_days=user.default_snooze_days,
+        medication_reminder_minutes=user.medication_reminder_minutes,
+        quiet_hours_start=user.quiet_hours_start,
+        quiet_hours_end=user.quiet_hours_end,
+    )
+
+
+@router.get("/me/settings", response_model=UserSettingsResponse)
+def get_settings(current_user: User = Depends(get_current_user)) -> UserSettingsResponse:
+    return _to_response(current_user)
+
+
+@router.patch("/me/settings", response_model=UserSettingsResponse)
+def update_settings(
+    request: UserSettingsPatchRequest,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+) -> UserSettingsResponse:
+    if request.timezone is not None:
+        try:
+            ZoneInfo(request.timezone)
+        except ZoneInfoNotFoundError:
+            raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail="Invalid IANA timezone")
+        current_user.timezone = request.timezone
+    if request.default_snooze_days is not None:
+        current_user.default_snooze_days = request.default_snooze_days
+    if request.medication_reminder_minutes is not None:
+        current_user.medication_reminder_minutes = request.medication_reminder_minutes
+    if request.quiet_hours_start is not None:
+        current_user.quiet_hours_start = request.quiet_hours_start
+    if request.quiet_hours_end is not None:
+        current_user.quiet_hours_end = request.quiet_hours_end
+    db.commit()
+    db.refresh(current_user)
+    return _to_response(current_user)

--- a/backend/app/api/routes/users.py
+++ b/backend/app/api/routes/users.py
@@ -42,9 +42,9 @@ def update_settings(
         current_user.default_snooze_days = request.default_snooze_days
     if request.medication_reminder_minutes is not None:
         current_user.medication_reminder_minutes = request.medication_reminder_minutes
-    if request.quiet_hours_start is not None:
+    if "quiet_hours_start" in request.model_fields_set:
         current_user.quiet_hours_start = request.quiet_hours_start
-    if request.quiet_hours_end is not None:
+    if "quiet_hours_end" in request.model_fields_set:
         current_user.quiet_hours_end = request.quiet_hours_end
     db.commit()
     db.refresh(current_user)

--- a/backend/app/api/routes/users.py
+++ b/backend/app/api/routes/users.py
@@ -1,12 +1,14 @@
+from typing import Any
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Body, Depends, HTTPException, Query, Response, status
 from sqlalchemy.orm import Session
 
 from app.api.dependencies.auth import get_current_user
 from app.db.session import get_db
 from app.models.user import User
 from app.schemas.users import UserSettingsPatchRequest, UserSettingsResponse
+from app.services.export_import_service import build_user_export, import_user_export, user_export_to_csv
 
 router = APIRouter(prefix="/users", tags=["users"])
 
@@ -49,3 +51,30 @@ def update_settings(
     db.commit()
     db.refresh(current_user)
     return _to_response(current_user)
+
+
+@router.get("/me/export", response_model=None)
+def export_user_data(
+    format: str = Query(default="json", pattern="^(json|csv)$"),
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+) -> dict[str, Any] | Response:
+    payload = build_user_export(db, current_user)
+    if format == "csv":
+        return Response(
+            content=user_export_to_csv(payload),
+            media_type="text/csv",
+            headers={"Content-Disposition": 'attachment; filename="daynest-export.csv"'},
+        )
+    return payload
+
+
+@router.post("/me/import")
+def import_user_data(
+    payload: dict[str, Any] = Body(...),
+    replace: bool = Query(default=False),
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+) -> dict[str, Any]:
+    counts = import_user_export(db, current_user, payload, replace=replace)
+    return {"imported": counts}

--- a/backend/app/core/enums.py
+++ b/backend/app/core/enums.py
@@ -1,6 +1,13 @@
 import enum
 
 
+class Priority(str, enum.Enum):
+    low = "low"
+    normal = "normal"
+    high = "high"
+    urgent = "urgent"
+
+
 class TaskStatus(str, enum.Enum):
     pending = "pending"
     in_progress = "in_progress"

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -9,6 +9,7 @@ from app.api.routes.auth import router as auth_router
 from app.api.routes.analytics import router as analytics_router
 from app.api.routes.bulk import router as bulk_router
 from app.api.routes.calendar import router as calendar_router
+from app.api.routes.search import router as search_router
 from app.api.routes.health import router as system_router
 from app.api.routes.integrations.clients import router as integration_clients_router
 from app.api.routes.integrations.home_assistant import router as home_assistant_router
@@ -65,6 +66,7 @@ app.include_router(medications_router, prefix=settings.api_prefix)
 app.include_router(templates_router, prefix=f"{settings.api_prefix}/templates")
 app.include_router(bulk_router, prefix=settings.api_prefix)
 app.include_router(calendar_router, prefix=settings.api_prefix)
+app.include_router(search_router, prefix=settings.api_prefix)
 if _mcp is not None:
     app.mount("/mcp", _mcp.streamable_http_app())
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -6,12 +6,14 @@ from fastapi.middleware.trustedhost import TrustedHostMiddleware
 
 from app.api.routes.auth import close_http_client as close_auth_http_client
 from app.api.routes.auth import router as auth_router
+from app.api.routes.bulk import router as bulk_router
 from app.api.routes.health import router as system_router
 from app.api.routes.integrations.clients import router as integration_clients_router
 from app.api.routes.integrations.home_assistant import router as home_assistant_router
 from app.api.routes.medications import router as medications_router
 from app.api.routes.templates import router as templates_router
 from app.api.routes.today import router as today_router
+from app.api.routes.users import router as users_router
 from app.core.config import settings
 from app.core.observability import configure_error_tracking, configure_logging, observability_middleware
 from app.mcp_server import create_mcp_server
@@ -52,11 +54,13 @@ if settings.cors_allow_origins:
 
 app.include_router(system_router, prefix=settings.api_prefix)
 app.include_router(auth_router, prefix=settings.api_prefix)
+app.include_router(users_router, prefix=settings.api_prefix)
 app.include_router(integration_clients_router, prefix=settings.api_prefix)
 app.include_router(home_assistant_router, prefix=settings.api_prefix)
 app.include_router(today_router, prefix=settings.api_prefix)
 app.include_router(medications_router, prefix=settings.api_prefix)
-app.include_router(templates_router, prefix=settings.api_prefix)
+app.include_router(templates_router, prefix=f"{settings.api_prefix}/templates")
+app.include_router(bulk_router, prefix=settings.api_prefix)
 if _mcp is not None:
     app.mount("/mcp", _mcp.streamable_http_app())
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -6,7 +6,9 @@ from fastapi.middleware.trustedhost import TrustedHostMiddleware
 
 from app.api.routes.auth import close_http_client as close_auth_http_client
 from app.api.routes.auth import router as auth_router
+from app.api.routes.analytics import router as analytics_router
 from app.api.routes.bulk import router as bulk_router
+from app.api.routes.calendar import router as calendar_router
 from app.api.routes.health import router as system_router
 from app.api.routes.integrations.clients import router as integration_clients_router
 from app.api.routes.integrations.home_assistant import router as home_assistant_router
@@ -55,12 +57,14 @@ if settings.cors_allow_origins:
 app.include_router(system_router, prefix=settings.api_prefix)
 app.include_router(auth_router, prefix=settings.api_prefix)
 app.include_router(users_router, prefix=settings.api_prefix)
+app.include_router(analytics_router, prefix=settings.api_prefix)
 app.include_router(integration_clients_router, prefix=settings.api_prefix)
 app.include_router(home_assistant_router, prefix=settings.api_prefix)
 app.include_router(today_router, prefix=settings.api_prefix)
 app.include_router(medications_router, prefix=settings.api_prefix)
 app.include_router(templates_router, prefix=f"{settings.api_prefix}/templates")
 app.include_router(bulk_router, prefix=settings.api_prefix)
+app.include_router(calendar_router, prefix=settings.api_prefix)
 if _mcp is not None:
     app.mount("/mcp", _mcp.streamable_http_app())
 

--- a/backend/app/mcp_server.py
+++ b/backend/app/mcp_server.py
@@ -75,6 +75,7 @@ def _routine_template_to_dict(t: Any) -> dict[str, Any]:
         "description": t.description,
         "start_date": t.start_date.isoformat(),
         "every_n_days": t.every_n_days,
+        "rrule": t.rrule,
         "due_time": t.due_time.isoformat() if t.due_time else None,
         "is_active": t.is_active,
     }
@@ -87,6 +88,9 @@ def _chore_template_to_dict(t: Any) -> dict[str, Any]:
         "description": t.description,
         "start_date": t.start_date.isoformat(),
         "every_n_days": t.every_n_days,
+        "rrule": t.rrule,
+        "priority": t.priority,
+        "tags": t.tags or [],
         "is_active": t.is_active,
     }
 
@@ -393,6 +397,7 @@ class DaynestMcpBackend:
                     name=name,
                     start_date=parsed_start,
                     every_n_days=every_n_days,
+                    rrule=None,
                     description=description,
                     due_time=parsed_due_time,
                     is_active=is_active,
@@ -449,6 +454,9 @@ class DaynestMcpBackend:
                     name=name,
                     start_date=parsed_start,
                     every_n_days=every_n_days,
+                    rrule=None,
+                    priority="normal",
+                    tags=[],
                     description=description,
                     is_active=is_active,
                 )

--- a/backend/app/mcp_server.py
+++ b/backend/app/mcp_server.py
@@ -390,21 +390,24 @@ class DaynestMcpBackend:
     ) -> dict[str, Any]:
         parsed_start = _parse_date(start_date)
         parsed_due_time = time.fromisoformat(due_time) if due_time and due_time.strip() else None
-        return self._with_service(
-            lambda _db, user, service: _routine_template_to_dict(
+
+        def _do(_db: Any, user: Any, service: Any) -> dict[str, Any]:
+            existing = service.repository.get_routine_template_for_user(user.id, routine_template_id)
+            return _routine_template_to_dict(
                 service.update_routine_template(
                     user.id,
                     routine_template_id,
                     name=name,
                     start_date=parsed_start,
                     every_n_days=every_n_days,
-                    rrule=None,
+                    rrule=existing.rrule if existing else None,
                     description=description,
                     due_time=parsed_due_time,
                     is_active=is_active,
                 )
             )
-        )
+
+        return self._with_service(_do)
 
     def delete_routine(self, routine_template_id: int) -> dict[str, Any]:
         self._with_service(lambda _db, user, service: service.delete_routine_template(user.id, routine_template_id))
@@ -447,22 +450,25 @@ class DaynestMcpBackend:
         is_active: bool | None = None,
     ) -> dict[str, Any]:
         parsed_start = _parse_date(start_date)
-        return self._with_service(
-            lambda _db, user, service: _chore_template_to_dict(
+
+        def _do(_db: Any, user: Any, service: Any) -> dict[str, Any]:
+            existing = service.repository.get_chore_template_for_user(user.id, chore_template_id)
+            return _chore_template_to_dict(
                 service.update_chore_template(
                     user.id,
                     chore_template_id,
                     name=name,
                     start_date=parsed_start,
                     every_n_days=every_n_days,
-                    rrule=None,
-                    priority=Priority.normal,
-                    tags=[],
+                    rrule=existing.rrule if existing else None,
+                    priority=existing.priority if existing else Priority.normal,
+                    tags=existing.tags if existing else [],
                     description=description,
                     is_active=is_active,
                 )
             )
-        )
+
+        return self._with_service(_do)
 
     def delete_chore_template(self, chore_template_id: int) -> dict[str, Any]:
         self._with_service(lambda _db, user, service: service.delete_chore_template(user.id, chore_template_id))

--- a/backend/app/mcp_server.py
+++ b/backend/app/mcp_server.py
@@ -27,6 +27,7 @@ from app.api.dependencies.integration_auth import (
     hash_integration_key,
 )
 from app.core.config import settings
+from app.core.enums import Priority
 from app.db.session import SessionLocal
 from app.models.integration_client import IntegrationClient
 from app.models.user import User
@@ -455,7 +456,7 @@ class DaynestMcpBackend:
                     start_date=parsed_start,
                     every_n_days=every_n_days,
                     rrule=None,
-                    priority="normal",
+                    priority=Priority.normal,
                     tags=[],
                     description=description,
                     is_active=is_active,

--- a/backend/app/models/chore_template.py
+++ b/backend/app/models/chore_template.py
@@ -4,7 +4,7 @@ from datetime import date, datetime
 from typing import TYPE_CHECKING
 
 import sqlalchemy as sa
-from sqlalchemy import Boolean, Date, DateTime, ForeignKey, Integer, String, Text, func
+from sqlalchemy import Boolean, Date, DateTime, ForeignKey, Integer, JSON, String, Text, func
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from app.db.base import Base
@@ -23,6 +23,9 @@ class ChoreTemplate(Base):
     description: Mapped[str | None] = mapped_column(Text, nullable=True)
     start_date: Mapped[date] = mapped_column(Date, nullable=False)
     every_n_days: Mapped[int] = mapped_column(Integer, nullable=False, default=1, server_default="1")
+    rrule: Mapped[str | None] = mapped_column(String(500), nullable=True)
+    priority: Mapped[str] = mapped_column(String(20), nullable=False, default="normal", server_default="normal")
+    tags: Mapped[list] = mapped_column(JSON, nullable=False, default=list, server_default="[]")
     is_active: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True, server_default=sa.text("true"))
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False, server_default=func.now())
 

--- a/backend/app/models/chore_template.py
+++ b/backend/app/models/chore_template.py
@@ -7,6 +7,7 @@ import sqlalchemy as sa
 from sqlalchemy import Boolean, Date, DateTime, ForeignKey, Integer, JSON, String, Text, func
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
+from app.core.enums import Priority
 from app.db.base import Base
 
 if TYPE_CHECKING:
@@ -24,7 +25,12 @@ class ChoreTemplate(Base):
     start_date: Mapped[date] = mapped_column(Date, nullable=False)
     every_n_days: Mapped[int] = mapped_column(Integer, nullable=False, default=1, server_default="1")
     rrule: Mapped[str | None] = mapped_column(String(500), nullable=True)
-    priority: Mapped[str] = mapped_column(String(20), nullable=False, default="normal", server_default="normal")
+    priority: Mapped[Priority] = mapped_column(
+        String(20),
+        nullable=False,
+        default=Priority.normal,
+        server_default="normal",
+    )
     tags: Mapped[list] = mapped_column(JSON, nullable=False, default=list, server_default="[]")
     is_active: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True, server_default=sa.text("true"))
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False, server_default=func.now())

--- a/backend/app/models/planned_item.py
+++ b/backend/app/models/planned_item.py
@@ -7,6 +7,7 @@ import sqlalchemy as sa
 from sqlalchemy import Boolean, Date, DateTime, ForeignKey, JSON, String, Text, func
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
+from app.core.enums import Priority
 from app.db.base import Base
 
 if TYPE_CHECKING:
@@ -25,7 +26,12 @@ class PlannedItem(Base):
     linked_source: Mapped[str | None] = mapped_column(String(120), nullable=True)
     linked_ref: Mapped[str | None] = mapped_column(String(255), nullable=True)
     planned_for: Mapped[date] = mapped_column(Date, nullable=False, index=True)
-    priority: Mapped[str] = mapped_column(String(20), nullable=False, default="normal", server_default="normal")
+    priority: Mapped[Priority] = mapped_column(
+        String(20),
+        nullable=False,
+        default=Priority.normal,
+        server_default="normal",
+    )
     tags: Mapped[list] = mapped_column(JSON, nullable=False, default=list, server_default="[]")
     is_done: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False, server_default=sa.text("false"))
     completed_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)

--- a/backend/app/models/planned_item.py
+++ b/backend/app/models/planned_item.py
@@ -4,7 +4,7 @@ from datetime import date, datetime
 from typing import TYPE_CHECKING
 
 import sqlalchemy as sa
-from sqlalchemy import Boolean, Date, DateTime, ForeignKey, String, Text, func
+from sqlalchemy import Boolean, Date, DateTime, ForeignKey, JSON, String, Text, func
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from app.db.base import Base
@@ -25,6 +25,8 @@ class PlannedItem(Base):
     linked_source: Mapped[str | None] = mapped_column(String(120), nullable=True)
     linked_ref: Mapped[str | None] = mapped_column(String(255), nullable=True)
     planned_for: Mapped[date] = mapped_column(Date, nullable=False, index=True)
+    priority: Mapped[str] = mapped_column(String(20), nullable=False, default="normal", server_default="normal")
+    tags: Mapped[list] = mapped_column(JSON, nullable=False, default=list, server_default="[]")
     is_done: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False, server_default=sa.text("false"))
     completed_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False, server_default=func.now())

--- a/backend/app/models/routine_template.py
+++ b/backend/app/models/routine_template.py
@@ -26,6 +26,7 @@ class RoutineTemplate(Base):
     description: Mapped[str | None] = mapped_column(Text, nullable=True)
     start_date: Mapped[date] = mapped_column(Date, nullable=False)
     every_n_days: Mapped[int] = mapped_column(Integer, nullable=False, default=1, server_default="1")
+    rrule: Mapped[str | None] = mapped_column(String(500), nullable=True)
     # due_time is stored as a naive time value and treated as UTC by calling code (see today_repository.ensure_task_instances_generated)
     due_time: Mapped[time | None] = mapped_column(Time, nullable=True)
     is_active: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True, server_default=sa.text("true"))

--- a/backend/app/models/user.py
+++ b/backend/app/models/user.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import datetime, time
 from typing import TYPE_CHECKING
 
 import sqlalchemy as sa
-from sqlalchemy import Boolean, DateTime, String, func
+from sqlalchemy import Boolean, DateTime, Integer, String, Time, func
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from app.db.base import Base
@@ -31,6 +31,10 @@ class User(Base):
     oidc_subject: Mapped[str | None] = mapped_column(String(255), unique=True, nullable=True, index=True)
     is_active: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True, server_default=sa.text("true"))
     timezone: Mapped[str] = mapped_column(String(100), nullable=False, default="UTC", server_default="UTC")
+    default_snooze_days: Mapped[int] = mapped_column(Integer, nullable=False, default=1, server_default="1")
+    medication_reminder_minutes: Mapped[int] = mapped_column(Integer, nullable=False, default=30, server_default="30")
+    quiet_hours_start: Mapped[time | None] = mapped_column(Time, nullable=True)
+    quiet_hours_end: Mapped[time | None] = mapped_column(Time, nullable=True)
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False, server_default=func.now())
 
     routine_templates: Mapped[list["RoutineTemplate"]] = relationship(back_populates="user", cascade="all, delete-orphan")

--- a/backend/app/models/user.py
+++ b/backend/app/models/user.py
@@ -35,6 +35,7 @@ class User(Base):
     medication_reminder_minutes: Mapped[int] = mapped_column(Integer, nullable=False, default=30, server_default="30")
     quiet_hours_start: Mapped[time | None] = mapped_column(Time, nullable=True)
     quiet_hours_end: Mapped[time | None] = mapped_column(Time, nullable=True)
+    calendar_token: Mapped[str | None] = mapped_column(String(64), nullable=True, unique=True, index=True)
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False, server_default=func.now())
 
     routine_templates: Mapped[list["RoutineTemplate"]] = relationship(back_populates="user", cascade="all, delete-orphan")

--- a/backend/app/repositories/analytics_repository.py
+++ b/backend/app/repositories/analytics_repository.py
@@ -1,0 +1,207 @@
+from collections import defaultdict
+from datetime import date, timedelta
+
+from sqlalchemy import case, func, select
+from sqlalchemy.orm import Session
+
+from app.core.enums import ChoreStatus, MedicationDoseStatus
+from app.models.chore_instance import ChoreInstance
+from app.models.chore_template import ChoreTemplate
+from app.models.medication_dose_instance import MedicationDoseInstance
+from app.models.planned_item import PlannedItem
+from app.schemas.analytics import (
+    ChoreStats,
+    ChoreStreak,
+    DailyAdherence,
+    DailyCount,
+    MedicationStats,
+    PlannedItemStats,
+    SkippedChore,
+)
+
+_MIN_STREAK_LOOKBACK_DAYS = 90
+
+
+def _date_range(start: date, end: date) -> list[date]:
+    return [start + timedelta(days=i) for i in range((end - start).days + 1)]
+
+
+def _rate(numerator: int, denominator: int) -> float:
+    return round(numerator / denominator, 4) if denominator else 0.0
+
+
+def _streak_lookback_start(start_date: date, end_date: date) -> date:
+    period_days = (end_date - start_date).days + 1
+    lookback_days = max(period_days, _MIN_STREAK_LOOKBACK_DAYS)
+    return end_date - timedelta(days=lookback_days - 1)
+
+
+def get_chore_stats(db: Session, user_id: int, start_date: date, end_date: date) -> ChoreStats:
+    daily_rows = db.execute(
+        select(
+            ChoreInstance.scheduled_date,
+            func.count(ChoreInstance.id),
+            func.sum(case((ChoreInstance.status == ChoreStatus.completed, 1), else_=0)),
+        )
+        .where(ChoreInstance.user_id == user_id)
+        .where(ChoreInstance.scheduled_date >= start_date)
+        .where(ChoreInstance.scheduled_date <= end_date)
+        .group_by(ChoreInstance.scheduled_date)
+    ).all()
+
+    by_date = {row[0]: {"total": int(row[1]), "completed": int(row[2] or 0)} for row in daily_rows}
+
+    dates = _date_range(start_date, end_date)
+    daily_completions = []
+    for d in dates:
+        total = by_date.get(d, {}).get("total", 0)
+        completed = by_date.get(d, {}).get("completed", 0)
+        daily_completions.append(DailyCount(date=d, completed=completed, total=total, completion_rate=_rate(completed, total)))
+
+    total_completed = sum(day["completed"] for day in by_date.values())
+    total_scheduled = sum(day["total"] for day in by_date.values())
+    completion_rate = _rate(total_completed, total_scheduled)
+
+    streak_start_date = _streak_lookback_start(start_date, end_date)
+    templates = {
+        t.id: t.name
+        for t in db.scalars(select(ChoreTemplate).where(ChoreTemplate.user_id == user_id)).all()
+    }
+
+    all_resolved = db.scalars(
+        select(ChoreInstance)
+        .where(ChoreInstance.user_id == user_id)
+        .where(ChoreInstance.scheduled_date >= streak_start_date)
+        .where(ChoreInstance.scheduled_date <= end_date)
+        .where(ChoreInstance.status != ChoreStatus.pending)
+        .order_by(ChoreInstance.chore_template_id, ChoreInstance.scheduled_date)
+    ).all()
+
+    by_template: dict[int, list[ChoreInstance]] = defaultdict(list)
+    for inst in all_resolved:
+        by_template[inst.chore_template_id].append(inst)
+
+    streaks: list[ChoreStreak] = []
+
+    for template_id, insts in by_template.items():
+        name = templates.get(template_id, f"Chore #{template_id}")
+        sorted_insts = insts
+
+        current = 0
+        for inst in reversed(sorted_insts):
+            if inst.status == ChoreStatus.completed:
+                current += 1
+            else:
+                break
+
+        longest, run = 0, 0
+        for inst in sorted_insts:
+            if inst.status == ChoreStatus.completed:
+                run += 1
+                longest = max(longest, run)
+            else:
+                run = 0
+
+        streaks.append(ChoreStreak(
+            chore_id=template_id,
+            name=name,
+            current_streak=current,
+            longest_streak=longest,
+        ))
+
+    skipped_rows = db.execute(
+        select(ChoreInstance.chore_template_id, func.count(ChoreInstance.id))
+        .where(ChoreInstance.user_id == user_id)
+        .where(ChoreInstance.scheduled_date >= start_date)
+        .where(ChoreInstance.scheduled_date <= end_date)
+        .where(ChoreInstance.status == ChoreStatus.skipped)
+        .group_by(ChoreInstance.chore_template_id)
+    ).all()
+    most_skipped = [
+        SkippedChore(
+            chore_id=row[0],
+            name=templates.get(row[0], f"Chore #{row[0]}"),
+            skip_count=int(row[1]),
+        )
+        for row in skipped_rows
+    ]
+
+    streaks.sort(key=lambda x: x.current_streak, reverse=True)
+    most_skipped.sort(key=lambda x: x.skip_count, reverse=True)
+
+    return ChoreStats(
+        completion_rate=round(completion_rate, 4),
+        total_completed=total_completed,
+        total_scheduled=total_scheduled,
+        daily_completions=daily_completions,
+        streaks=streaks,
+        most_skipped=most_skipped,
+    )
+
+
+def get_medication_stats(db: Session, user_id: int, start_date: date, end_date: date) -> MedicationStats:
+    daily_rows = db.execute(
+        select(
+            MedicationDoseInstance.scheduled_date,
+            func.count(MedicationDoseInstance.id),
+            func.sum(case((MedicationDoseInstance.status == MedicationDoseStatus.taken, 1), else_=0)),
+        )
+        .where(MedicationDoseInstance.user_id == user_id)
+        .where(MedicationDoseInstance.scheduled_date >= start_date)
+        .where(MedicationDoseInstance.scheduled_date <= end_date)
+        .group_by(MedicationDoseInstance.scheduled_date)
+    ).all()
+
+    by_date = {row[0]: {"total": int(row[1]), "taken": int(row[2] or 0)} for row in daily_rows}
+
+    dates = _date_range(start_date, end_date)
+    daily_adherence = []
+    for d in dates:
+        total = by_date.get(d, {}).get("total", 0)
+        taken = by_date.get(d, {}).get("taken", 0)
+        daily_adherence.append(DailyAdherence(date=d, taken=taken, total=total, adherence_rate=_rate(taken, total)))
+
+    total_taken = sum(day["taken"] for day in by_date.values())
+    total_scheduled = sum(day["total"] for day in by_date.values())
+    adherence_rate = _rate(total_taken, total_scheduled)
+
+    return MedicationStats(
+        adherence_rate=round(adherence_rate, 4),
+        total_taken=total_taken,
+        total_scheduled=total_scheduled,
+        daily_adherence=daily_adherence,
+    )
+
+
+def get_planned_item_stats(db: Session, user_id: int, start_date: date, end_date: date) -> PlannedItemStats:
+    daily_rows = db.execute(
+        select(
+            PlannedItem.planned_for,
+            func.count(PlannedItem.id),
+            func.sum(case((PlannedItem.is_done.is_(True), 1), else_=0)),
+        )
+        .where(PlannedItem.user_id == user_id)
+        .where(PlannedItem.planned_for >= start_date)
+        .where(PlannedItem.planned_for <= end_date)
+        .group_by(PlannedItem.planned_for)
+    ).all()
+
+    by_date = {row[0]: {"total": int(row[1]), "completed": int(row[2] or 0)} for row in daily_rows}
+
+    dates = _date_range(start_date, end_date)
+    daily_completions = []
+    for d in dates:
+        total = by_date.get(d, {}).get("total", 0)
+        completed = by_date.get(d, {}).get("completed", 0)
+        daily_completions.append(DailyCount(date=d, completed=completed, total=total, completion_rate=_rate(completed, total)))
+
+    total_completed = sum(day["completed"] for day in by_date.values())
+    total_scheduled = sum(day["total"] for day in by_date.values())
+    completion_rate = _rate(total_completed, total_scheduled)
+
+    return PlannedItemStats(
+        completion_rate=round(completion_rate, 4),
+        total_completed=total_completed,
+        total_scheduled=total_scheduled,
+        daily_completions=daily_completions,
+    )

--- a/backend/app/repositories/analytics_repository.py
+++ b/backend/app/repositories/analytics_repository.py
@@ -4,11 +4,13 @@ from datetime import date, timedelta
 from sqlalchemy import case, func, select
 from sqlalchemy.orm import Session
 
-from app.core.enums import ChoreStatus, MedicationDoseStatus
+from app.core.enums import ChoreStatus, MedicationDoseStatus, TaskStatus
 from app.models.chore_instance import ChoreInstance
 from app.models.chore_template import ChoreTemplate
 from app.models.medication_dose_instance import MedicationDoseInstance
 from app.models.planned_item import PlannedItem
+from app.models.routine_template import RoutineTemplate
+from app.models.task_instance import TaskInstance
 from app.schemas.analytics import (
     ChoreStats,
     ChoreStreak,
@@ -16,6 +18,8 @@ from app.schemas.analytics import (
     DailyCount,
     MedicationStats,
     PlannedItemStats,
+    RoutineStats,
+    RoutineStreak,
     SkippedChore,
 )
 
@@ -204,4 +208,86 @@ def get_planned_item_stats(db: Session, user_id: int, start_date: date, end_date
         total_completed=total_completed,
         total_scheduled=total_scheduled,
         daily_completions=daily_completions,
+    )
+
+
+def get_routine_stats(db: Session, user_id: int, start_date: date, end_date: date) -> RoutineStats:
+    daily_rows = db.execute(
+        select(
+            TaskInstance.scheduled_date,
+            func.count(TaskInstance.id),
+            func.sum(case((TaskInstance.status == TaskStatus.completed, 1), else_=0)),
+        )
+        .where(TaskInstance.user_id == user_id)
+        .where(TaskInstance.scheduled_date >= start_date)
+        .where(TaskInstance.scheduled_date <= end_date)
+        .group_by(TaskInstance.scheduled_date)
+    ).all()
+
+    by_date = {row[0]: {"total": int(row[1]), "completed": int(row[2] or 0)} for row in daily_rows}
+
+    dates = _date_range(start_date, end_date)
+    daily_completions = []
+    for d in dates:
+        total = by_date.get(d, {}).get("total", 0)
+        completed = by_date.get(d, {}).get("completed", 0)
+        daily_completions.append(DailyCount(date=d, completed=completed, total=total, completion_rate=_rate(completed, total)))
+
+    total_completed = sum(day["completed"] for day in by_date.values())
+    total_scheduled = sum(day["total"] for day in by_date.values())
+    completion_rate = _rate(total_completed, total_scheduled)
+
+    streak_start_date = _streak_lookback_start(start_date, end_date)
+    templates = {
+        t.id: t.name
+        for t in db.scalars(select(RoutineTemplate).where(RoutineTemplate.user_id == user_id)).all()
+    }
+
+    all_resolved = db.scalars(
+        select(TaskInstance)
+        .where(TaskInstance.user_id == user_id)
+        .where(TaskInstance.scheduled_date >= streak_start_date)
+        .where(TaskInstance.scheduled_date <= end_date)
+        .where(TaskInstance.status.notin_([TaskStatus.pending, TaskStatus.in_progress]))
+        .order_by(TaskInstance.routine_template_id, TaskInstance.scheduled_date)
+    ).all()
+
+    by_template: dict[int, list[TaskInstance]] = defaultdict(list)
+    for inst in all_resolved:
+        by_template[inst.routine_template_id].append(inst)
+
+    streaks: list[RoutineStreak] = []
+    for template_id, insts in by_template.items():
+        name = templates.get(template_id, f"Routine #{template_id}")
+
+        current = 0
+        for inst in reversed(insts):
+            if inst.status == TaskStatus.completed:
+                current += 1
+            else:
+                break
+
+        longest, run = 0, 0
+        for inst in insts:
+            if inst.status == TaskStatus.completed:
+                run += 1
+                longest = max(longest, run)
+            else:
+                run = 0
+
+        streaks.append(RoutineStreak(
+            routine_id=template_id,
+            name=name,
+            current_streak=current,
+            longest_streak=longest,
+        ))
+
+    streaks.sort(key=lambda x: x.current_streak, reverse=True)
+
+    return RoutineStats(
+        completion_rate=round(completion_rate, 4),
+        total_completed=total_completed,
+        total_scheduled=total_scheduled,
+        daily_completions=daily_completions,
+        streaks=streaks,
     )

--- a/backend/app/repositories/today_repository.py
+++ b/backend/app/repositories/today_repository.py
@@ -11,7 +11,7 @@ from sqlalchemy import and_, func, insert, select, update
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.orm import Session
 
-from app.core.enums import ChoreStatus, MedicationDoseStatus, TaskStatus
+from app.core.enums import ChoreStatus, MedicationDoseStatus, Priority, TaskStatus
 from app.models.user import User
 from app.models.chore_instance import ChoreInstance
 from app.models.chore_template import ChoreTemplate
@@ -52,23 +52,28 @@ class TodayRepository:
 
             last = last_generated_map.get(template.id)
 
+            rrule_generated = False
+            rrule_failed = False
             if template.rrule and _DATEUTIL_AVAILABLE:
-                dtstart = datetime.combine(template.start_date, time.min)
-                rule = _rrulestr(template.rrule, dtstart=dtstart, ignoretz=True)
-                for dt in rule:
-                    d = dt.date()
-                    if d > through_date:
-                        break
-                    if last is not None and d <= last:
-                        continue
-                    rows.append({
-                        "user_id": user_id,
-                        "chore_template_id": template.id,
-                        "title": template.name,
-                        "scheduled_date": d,
-                        "status": ChoreStatus.pending,
-                    })
-            else:
+                try:
+                    dtstart = datetime.combine(template.start_date, time.min)
+                    rule = _rrulestr(template.rrule, dtstart=dtstart, ignoretz=True)
+                    start_search = datetime.combine(last, time.max) if last else dtstart - timedelta(seconds=1)
+                    occurrences = rule.between(start_search, datetime.combine(through_date, time.max), inc=False)
+                except Exception:
+                    rrule_failed = True
+                else:
+                    rrule_generated = True
+                    for dt in occurrences:
+                        rows.append({
+                            "user_id": user_id,
+                            "chore_template_id": template.id,
+                            "title": template.name,
+                            "scheduled_date": dt.date(),
+                            "status": ChoreStatus.pending,
+                        })
+
+            if not template.rrule or not _DATEUTIL_AVAILABLE or rrule_failed:
                 step = max(template.every_n_days, 1)
                 cursor = template.start_date if last is None else date.fromordinal(last.toordinal() + step)
                 while cursor <= through_date:
@@ -80,6 +85,8 @@ class TodayRepository:
                         "status": ChoreStatus.pending,
                     })
                     cursor = date.fromordinal(cursor.toordinal() + step)
+            elif rrule_generated:
+                continue
 
         if rows:
             dialect_name = self.db.connection().dialect.name
@@ -218,25 +225,31 @@ class TodayRepository:
 
             last = last_generated_map.get(template.id)
 
+            rrule_generated = False
+            rrule_failed = False
             if template.rrule and _DATEUTIL_AVAILABLE:
-                dtstart = datetime.combine(template.start_date, time.min)
-                rule = _rrulestr(template.rrule, dtstart=dtstart, ignoretz=True)
-                for dt in rule:
-                    cursor = dt.date()
-                    if cursor > through_date:
-                        break
-                    if last is not None and cursor <= last:
-                        continue
-                    due_at = datetime.combine(cursor, template.due_time, tzinfo=timezone.utc) if template.due_time else None
-                    rows.append({
-                        "user_id": user_id,
-                        "routine_template_id": template.id,
-                        "title": template.name,
-                        "scheduled_date": cursor,
-                        "due_at": due_at,
-                        "status": TaskStatus.pending,
-                    })
-            else:
+                try:
+                    dtstart = datetime.combine(template.start_date, time.min)
+                    rule = _rrulestr(template.rrule, dtstart=dtstart, ignoretz=True)
+                    start_search = datetime.combine(last, time.max) if last else dtstart - timedelta(seconds=1)
+                    occurrences = rule.between(start_search, datetime.combine(through_date, time.max), inc=False)
+                except Exception:
+                    rrule_failed = True
+                else:
+                    rrule_generated = True
+                    for dt in occurrences:
+                        cursor = dt.date()
+                        due_at = datetime.combine(cursor, template.due_time, tzinfo=timezone.utc) if template.due_time else None
+                        rows.append({
+                            "user_id": user_id,
+                            "routine_template_id": template.id,
+                            "title": template.name,
+                            "scheduled_date": cursor,
+                            "due_at": due_at,
+                            "status": TaskStatus.pending,
+                        })
+
+            if not template.rrule or not _DATEUTIL_AVAILABLE or rrule_failed:
                 step = max(template.every_n_days, 1)
                 cursor = template.start_date if last is None else date.fromordinal(last.toordinal() + step)
                 while cursor <= through_date:
@@ -250,6 +263,8 @@ class TodayRepository:
                         "status": TaskStatus.pending,
                     })
                     cursor = date.fromordinal(cursor.toordinal() + step)
+            elif rrule_generated:
+                continue
 
         if rows:
             dialect_name = self.db.connection().dialect.name
@@ -323,7 +338,7 @@ class TodayRepository:
         start_date: date,
         every_n_days: int,
         rrule: str | None,
-        priority: str,
+        priority: Priority,
         tags: list,
         is_active: bool,
     ) -> ChoreTemplate:

--- a/backend/app/repositories/today_repository.py
+++ b/backend/app/repositories/today_repository.py
@@ -1,6 +1,12 @@
 from datetime import date, datetime, time, timedelta, timezone
 from zoneinfo import ZoneInfo
 
+try:
+    from dateutil.rrule import rrulestr as _rrulestr
+    _DATEUTIL_AVAILABLE = True
+except ImportError:
+    _DATEUTIL_AVAILABLE = False
+
 from sqlalchemy import and_, func, insert, select, update
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.orm import Session
@@ -44,19 +50,36 @@ class TodayRepository:
             if template.start_date > through_date:
                 continue
 
-            step = max(template.every_n_days, 1)
             last = last_generated_map.get(template.id)
-            cursor = template.start_date if last is None else date.fromordinal(last.toordinal() + step)
 
-            while cursor <= through_date:
-                rows.append({
-                    "user_id": user_id,
-                    "chore_template_id": template.id,
-                    "title": template.name,
-                    "scheduled_date": cursor,
-                    "status": ChoreStatus.pending,
-                })
-                cursor = date.fromordinal(cursor.toordinal() + step)
+            if template.rrule and _DATEUTIL_AVAILABLE:
+                dtstart = datetime.combine(template.start_date, time.min)
+                rule = _rrulestr(template.rrule, dtstart=dtstart, ignoretz=True)
+                for dt in rule:
+                    d = dt.date()
+                    if d > through_date:
+                        break
+                    if last is not None and d <= last:
+                        continue
+                    rows.append({
+                        "user_id": user_id,
+                        "chore_template_id": template.id,
+                        "title": template.name,
+                        "scheduled_date": d,
+                        "status": ChoreStatus.pending,
+                    })
+            else:
+                step = max(template.every_n_days, 1)
+                cursor = template.start_date if last is None else date.fromordinal(last.toordinal() + step)
+                while cursor <= through_date:
+                    rows.append({
+                        "user_id": user_id,
+                        "chore_template_id": template.id,
+                        "title": template.name,
+                        "scheduled_date": cursor,
+                        "status": ChoreStatus.pending,
+                    })
+                    cursor = date.fromordinal(cursor.toordinal() + step)
 
         if rows:
             dialect_name = self.db.connection().dialect.name
@@ -193,21 +216,40 @@ class TodayRepository:
             if template.start_date > through_date:
                 continue
 
-            step = max(template.every_n_days, 1)
             last = last_generated_map.get(template.id)
-            cursor = template.start_date if last is None else date.fromordinal(last.toordinal() + step)
 
-            while cursor <= through_date:
-                due_at = datetime.combine(cursor, template.due_time, tzinfo=timezone.utc) if template.due_time else None
-                rows.append({
-                    "user_id": user_id,
-                    "routine_template_id": template.id,
-                    "title": template.name,
-                    "scheduled_date": cursor,
-                    "due_at": due_at,
-                    "status": TaskStatus.pending,
-                })
-                cursor = date.fromordinal(cursor.toordinal() + step)
+            if template.rrule and _DATEUTIL_AVAILABLE:
+                dtstart = datetime.combine(template.start_date, time.min)
+                rule = _rrulestr(template.rrule, dtstart=dtstart, ignoretz=True)
+                for dt in rule:
+                    cursor = dt.date()
+                    if cursor > through_date:
+                        break
+                    if last is not None and cursor <= last:
+                        continue
+                    due_at = datetime.combine(cursor, template.due_time, tzinfo=timezone.utc) if template.due_time else None
+                    rows.append({
+                        "user_id": user_id,
+                        "routine_template_id": template.id,
+                        "title": template.name,
+                        "scheduled_date": cursor,
+                        "due_at": due_at,
+                        "status": TaskStatus.pending,
+                    })
+            else:
+                step = max(template.every_n_days, 1)
+                cursor = template.start_date if last is None else date.fromordinal(last.toordinal() + step)
+                while cursor <= through_date:
+                    due_at = datetime.combine(cursor, template.due_time, tzinfo=timezone.utc) if template.due_time else None
+                    rows.append({
+                        "user_id": user_id,
+                        "routine_template_id": template.id,
+                        "title": template.name,
+                        "scheduled_date": cursor,
+                        "due_at": due_at,
+                        "status": TaskStatus.pending,
+                    })
+                    cursor = date.fromordinal(cursor.toordinal() + step)
 
         if rows:
             dialect_name = self.db.connection().dialect.name
@@ -237,6 +279,7 @@ class TodayRepository:
         description: str | None,
         start_date: date,
         every_n_days: int,
+        rrule: str | None,
         due_time: time | None,
         is_active: bool,
     ) -> RoutineTemplate:
@@ -244,15 +287,19 @@ class TodayRepository:
         template.description = description
         template.start_date = start_date
         template.every_n_days = every_n_days
+        template.rrule = rrule
         template.due_time = due_time
         template.is_active = is_active
         self.db.commit()
         self.db.refresh(template)
         return template
 
-    def list_chore_templates(self, user_id: int) -> list[ChoreTemplate]:
+    def list_chore_templates(self, user_id: int, tags: list[str] | None = None) -> list[ChoreTemplate]:
         stmt = select(ChoreTemplate).where(ChoreTemplate.user_id == user_id).order_by(ChoreTemplate.id.asc())
-        return list(self.db.scalars(stmt).all())
+        templates = list(self.db.scalars(stmt).all())
+        if tags:
+            templates = [t for t in templates if any(tag in (t.tags or []) for tag in tags)]
+        return templates
 
     def add_chore_template(self, template: ChoreTemplate) -> ChoreTemplate:
         self.db.add(template)
@@ -275,12 +322,18 @@ class TodayRepository:
         description: str | None,
         start_date: date,
         every_n_days: int,
+        rrule: str | None,
+        priority: str,
+        tags: list,
         is_active: bool,
     ) -> ChoreTemplate:
         template.name = name
         template.description = description
         template.start_date = start_date
         template.every_n_days = every_n_days
+        template.rrule = rrule
+        template.priority = priority
+        template.tags = tags
         template.is_active = is_active
         self.db.commit()
         self.db.refresh(template)

--- a/backend/app/repositories/today_repository.py
+++ b/backend/app/repositories/today_repository.py
@@ -431,7 +431,7 @@ class TodayRepository:
         stmt = select(ChoreInstance).where(ChoreInstance.user_id == user_id).where(ChoreInstance.id == chore_instance_id)
         return self.db.scalar(stmt)
 
-    def list_planned_items(self, user_id: int, start_date: date | None = None, end_date: date | None = None, is_done: bool | None = None) -> list[PlannedItem]:
+    def list_planned_items(self, user_id: int, start_date: date | None = None, end_date: date | None = None, is_done: bool | None = None, tags: list[str] | None = None) -> list[PlannedItem]:
         stmt = select(PlannedItem).where(PlannedItem.user_id == user_id)
         if start_date is not None:
             stmt = stmt.where(PlannedItem.planned_for >= start_date)
@@ -440,7 +440,10 @@ class TodayRepository:
         if is_done is not None:
             stmt = stmt.where(PlannedItem.is_done.is_(is_done))
         stmt = stmt.order_by(PlannedItem.planned_for.asc(), PlannedItem.id.asc())
-        return list(self.db.scalars(stmt).all())
+        items = list(self.db.scalars(stmt).all())
+        if tags:
+            items = [item for item in items if any(tag in (item.tags or []) for tag in tags)]
+        return items
 
     def add_planned_item(self, item: PlannedItem) -> PlannedItem:
         self.db.add(item)

--- a/backend/app/repositories/today_repository.py
+++ b/backend/app/repositories/today_repository.py
@@ -1,5 +1,8 @@
+import logging
 from datetime import date, datetime, time, timedelta, timezone
 from zoneinfo import ZoneInfo
+
+logger = logging.getLogger(__name__)
 
 try:
     from dateutil.rrule import rrulestr as _rrulestr
@@ -61,6 +64,7 @@ class TodayRepository:
                     start_search = datetime.combine(last, time.max) if last else dtstart - timedelta(seconds=1)
                     occurrences = rule.between(start_search, datetime.combine(through_date, time.max), inc=False)
                 except Exception:
+                    logger.warning("Failed to parse rrule for chore template %s: %r", template.id, template.rrule, exc_info=True)
                     rrule_failed = True
                 else:
                     rrule_generated = True
@@ -234,6 +238,7 @@ class TodayRepository:
                     start_search = datetime.combine(last, time.max) if last else dtstart - timedelta(seconds=1)
                     occurrences = rule.between(start_search, datetime.combine(through_date, time.max), inc=False)
                 except Exception:
+                    logger.warning("Failed to parse rrule for routine template %s: %r", template.id, template.rrule, exc_info=True)
                     rrule_failed = True
                 else:
                     rrule_generated = True

--- a/backend/app/schemas/analytics.py
+++ b/backend/app/schemas/analytics.py
@@ -1,0 +1,63 @@
+from datetime import date
+from typing import Literal
+
+from pydantic import BaseModel
+
+
+class DailyCount(BaseModel):
+    date: date
+    completed: int
+    total: int
+    completion_rate: float
+
+
+class ChoreStreak(BaseModel):
+    chore_id: int
+    name: str
+    current_streak: int
+    longest_streak: int
+
+
+class SkippedChore(BaseModel):
+    chore_id: int
+    name: str
+    skip_count: int
+
+
+class ChoreStats(BaseModel):
+    completion_rate: float
+    total_completed: int
+    total_scheduled: int
+    daily_completions: list[DailyCount]
+    streaks: list[ChoreStreak]
+    most_skipped: list[SkippedChore]
+
+
+class DailyAdherence(BaseModel):
+    date: date
+    taken: int
+    total: int
+    adherence_rate: float
+
+
+class MedicationStats(BaseModel):
+    adherence_rate: float
+    total_taken: int
+    total_scheduled: int
+    daily_adherence: list[DailyAdherence]
+
+
+class PlannedItemStats(BaseModel):
+    completion_rate: float
+    total_completed: int
+    total_scheduled: int
+    daily_completions: list[DailyCount]
+
+
+class AnalyticsSummaryResponse(BaseModel):
+    period: Literal["week", "month", "year"]
+    start_date: date
+    end_date: date
+    chores: ChoreStats
+    medications: MedicationStats
+    planned_items: PlannedItemStats

--- a/backend/app/schemas/analytics.py
+++ b/backend/app/schemas/analytics.py
@@ -54,6 +54,21 @@ class PlannedItemStats(BaseModel):
     daily_completions: list[DailyCount]
 
 
+class RoutineStreak(BaseModel):
+    routine_id: int
+    name: str
+    current_streak: int
+    longest_streak: int
+
+
+class RoutineStats(BaseModel):
+    completion_rate: float
+    total_completed: int
+    total_scheduled: int
+    daily_completions: list[DailyCount]
+    streaks: list[RoutineStreak]
+
+
 class AnalyticsSummaryResponse(BaseModel):
     period: Literal["week", "month", "year"]
     start_date: date
@@ -61,3 +76,4 @@ class AnalyticsSummaryResponse(BaseModel):
     chores: ChoreStats
     medications: MedicationStats
     planned_items: PlannedItemStats
+    routines: RoutineStats

--- a/backend/app/schemas/bulk.py
+++ b/backend/app/schemas/bulk.py
@@ -1,0 +1,29 @@
+import enum
+
+from pydantic import BaseModel, Field
+
+
+class MutationType(str, enum.Enum):
+    complete_chore = "complete_chore"
+    skip_chore = "skip_chore"
+    mark_planned_done = "mark_planned_done"
+
+
+class BulkMutationItem(BaseModel):
+    type: MutationType
+    id: int
+
+
+class BulkMutationRequest(BaseModel):
+    mutations: list[BulkMutationItem] = Field(..., min_length=1, max_length=100)
+
+
+class BulkMutationResult(BaseModel):
+    type: MutationType
+    id: int
+    success: bool
+    error: str | None = None
+
+
+class BulkMutationResponse(BaseModel):
+    results: list[BulkMutationResult]

--- a/backend/app/schemas/calendar.py
+++ b/backend/app/schemas/calendar.py
@@ -1,0 +1,5 @@
+from pydantic import BaseModel
+
+
+class CalendarTokenResponse(BaseModel):
+    token: str

--- a/backend/app/schemas/templates.py
+++ b/backend/app/schemas/templates.py
@@ -2,12 +2,15 @@ from datetime import date, datetime, time
 
 from pydantic import BaseModel, Field
 
+from app.core.enums import Priority
+
 
 class RoutineTemplateBase(BaseModel):
     name: str = Field(..., min_length=1, max_length=255)
     description: str | None = Field(default=None, max_length=4000)
     start_date: date
     every_n_days: int = Field(default=1, ge=1)
+    rrule: str | None = Field(default=None, max_length=500)
     due_time: time | None = None
     is_active: bool = True
 
@@ -30,6 +33,9 @@ class ChoreTemplateBase(BaseModel):
     description: str | None = Field(default=None, max_length=4000)
     start_date: date
     every_n_days: int = Field(default=1, ge=1)
+    rrule: str | None = Field(default=None, max_length=500)
+    priority: Priority = Priority.normal
+    tags: list[str] = Field(default_factory=list)
     is_active: bool = True
 
 

--- a/backend/app/schemas/today.py
+++ b/backend/app/schemas/today.py
@@ -111,6 +111,7 @@ class UnifiedDayItem(BaseModel):
     recurrence_hint: str | None = None
     linked_source: str | None = None
     linked_ref: str | None = None
+    priority: Priority = Priority.normal
 
 
 class CalendarDayResponse(BaseModel):

--- a/backend/app/schemas/today.py
+++ b/backend/app/schemas/today.py
@@ -3,7 +3,7 @@ from typing import Literal
 
 from pydantic import BaseModel, Field, model_validator
 
-from app.core.enums import ChoreStatus, MedicationDoseStatus, TaskStatus
+from app.core.enums import ChoreStatus, MedicationDoseStatus, Priority, TaskStatus
 
 
 class MedicationTodayItem(BaseModel):
@@ -68,6 +68,8 @@ class PlannedTodayItem(BaseModel):
     recurrence_hint: str | None = None
     linked_source: str | None = None
     linked_ref: str | None = None
+    priority: Priority = Priority.normal
+    tags: list[str] = Field(default_factory=list)
     is_done: bool
 
 
@@ -79,6 +81,8 @@ class PlannedItemBase(BaseModel):
     recurrence_hint: str | None = Field(default=None, max_length=255)
     linked_source: str | None = Field(default=None, max_length=120)
     linked_ref: str | None = Field(default=None, max_length=255)
+    priority: Priority = Priority.normal
+    tags: list[str] = Field(default_factory=list)
 
     @model_validator(mode="after")
     def _apply_module_defaults(self) -> "PlannedItemBase":

--- a/backend/app/schemas/users.py
+++ b/backend/app/schemas/users.py
@@ -1,0 +1,19 @@
+from datetime import time
+
+from pydantic import BaseModel, Field
+
+
+class UserSettingsResponse(BaseModel):
+    timezone: str
+    default_snooze_days: int
+    medication_reminder_minutes: int
+    quiet_hours_start: time | None
+    quiet_hours_end: time | None
+
+
+class UserSettingsPatchRequest(BaseModel):
+    timezone: str | None = Field(default=None, max_length=100)
+    default_snooze_days: int | None = Field(default=None, ge=1)
+    medication_reminder_minutes: int | None = Field(default=None, ge=0)
+    quiet_hours_start: time | None = None
+    quiet_hours_end: time | None = None

--- a/backend/app/services/export_import_service.py
+++ b/backend/app/services/export_import_service.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import csv
+import enum
 import json
 from collections.abc import Iterable, Mapping
 from datetime import date, datetime, time, timezone
@@ -22,7 +23,7 @@ from app.models.routine_template import RoutineTemplate
 from app.models.task_instance import TaskInstance
 from app.models.user import User
 
-_E = TypeVar("_E")
+_E = TypeVar("_E", bound=enum.Enum)
 
 EXPORT_VERSION = 1
 
@@ -437,8 +438,7 @@ def _enum(cls: type[_E], value: Any, field: str) -> _E:
     try:
         return cls(s)  # type: ignore[call-arg]
     except ValueError:
-        valid = ", ".join(m.value for m in cls)  # type: ignore[attr-defined]
-        _invalid(f"{field} has invalid value '{s}'; expected one of: {valid}")
+        _invalid(f"{field} has invalid value: {s!r}")
 
 
 def _list(value: Any, field: str) -> list[Any]:

--- a/backend/app/services/export_import_service.py
+++ b/backend/app/services/export_import_service.py
@@ -1,0 +1,492 @@
+from __future__ import annotations
+
+import csv
+import json
+from collections.abc import Iterable, Mapping
+from datetime import date, datetime, time, timezone
+from io import StringIO
+from typing import Any, NoReturn, TypeVar
+
+from fastapi import HTTPException, status
+from sqlalchemy import delete
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Session
+
+_E = TypeVar("_E")
+
+from app.core.enums import ChoreStatus, MedicationDoseStatus, Priority, TaskStatus
+from app.models.chore_instance import ChoreInstance
+from app.models.chore_template import ChoreTemplate
+from app.models.medication_dose_instance import MedicationDoseInstance
+from app.models.medication_plan import MedicationPlan
+from app.models.planned_item import PlannedItem
+from app.models.routine_template import RoutineTemplate
+from app.models.task_instance import TaskInstance
+from app.models.user import User
+
+EXPORT_VERSION = 1
+
+_USER_SETTING_FIELDS = (
+    "timezone",
+    "default_snooze_days",
+    "medication_reminder_minutes",
+    "quiet_hours_start",
+    "quiet_hours_end",
+)
+_ROUTINE_TEMPLATE_FIELDS = (
+    "id",
+    "name",
+    "description",
+    "start_date",
+    "every_n_days",
+    "rrule",
+    "due_time",
+    "is_active",
+    "created_at",
+)
+_CHORE_TEMPLATE_FIELDS = (
+    "id",
+    "name",
+    "description",
+    "start_date",
+    "every_n_days",
+    "rrule",
+    "priority",
+    "tags",
+    "is_active",
+    "created_at",
+)
+_MEDICATION_PLAN_FIELDS = (
+    "id",
+    "name",
+    "instructions",
+    "start_date",
+    "schedule_time",
+    "every_n_days",
+    "is_active",
+    "created_at",
+)
+_TASK_INSTANCE_FIELDS = (
+    "id",
+    "routine_template_id",
+    "title",
+    "scheduled_date",
+    "due_at",
+    "status",
+    "completed_at",
+    "created_at",
+)
+_CHORE_INSTANCE_FIELDS = (
+    "id",
+    "chore_template_id",
+    "title",
+    "scheduled_date",
+    "status",
+    "completed_at",
+    "skipped_at",
+    "created_at",
+)
+_MEDICATION_DOSE_FIELDS = (
+    "id",
+    "medication_plan_id",
+    "name",
+    "instructions",
+    "scheduled_date",
+    "scheduled_at",
+    "status",
+    "taken_at",
+    "skipped_at",
+    "missed_at",
+    "created_at",
+)
+_PLANNED_ITEM_FIELDS = (
+    "id",
+    "title",
+    "notes",
+    "module_key",
+    "recurrence_hint",
+    "linked_source",
+    "linked_ref",
+    "planned_for",
+    "priority",
+    "tags",
+    "is_done",
+    "completed_at",
+    "created_at",
+)
+
+
+def build_user_export(db: Session, user: User) -> dict[str, Any]:
+    return {
+        "version": EXPORT_VERSION,
+        "exported_at": datetime.now(timezone.utc).isoformat(),
+        "user_settings": _fields_to_dict(user, _USER_SETTING_FIELDS),
+        "routine_templates": _export_rows(
+            db.query(RoutineTemplate).filter(RoutineTemplate.user_id == user.id).order_by(RoutineTemplate.id).all(),
+            _ROUTINE_TEMPLATE_FIELDS,
+        ),
+        "chore_templates": _export_rows(
+            db.query(ChoreTemplate).filter(ChoreTemplate.user_id == user.id).order_by(ChoreTemplate.id).all(),
+            _CHORE_TEMPLATE_FIELDS,
+        ),
+        "medication_plans": _export_rows(
+            db.query(MedicationPlan).filter(MedicationPlan.user_id == user.id).order_by(MedicationPlan.id).all(),
+            _MEDICATION_PLAN_FIELDS,
+        ),
+        "task_instances": _export_rows(
+            db.query(TaskInstance).filter(TaskInstance.user_id == user.id).order_by(TaskInstance.id).all(),
+            _TASK_INSTANCE_FIELDS,
+        ),
+        "chore_instances": _export_rows(
+            db.query(ChoreInstance).filter(ChoreInstance.user_id == user.id).order_by(ChoreInstance.id).all(),
+            _CHORE_INSTANCE_FIELDS,
+        ),
+        "medication_dose_instances": _export_rows(
+            db.query(MedicationDoseInstance)
+            .filter(MedicationDoseInstance.user_id == user.id)
+            .order_by(MedicationDoseInstance.id)
+            .all(),
+            _MEDICATION_DOSE_FIELDS,
+        ),
+        "planned_items": _export_rows(
+            db.query(PlannedItem).filter(PlannedItem.user_id == user.id).order_by(PlannedItem.id).all(),
+            _PLANNED_ITEM_FIELDS,
+        ),
+    }
+
+
+def user_export_to_csv(payload: Mapping[str, Any]) -> str:
+    rows: list[dict[str, Any]] = []
+    settings = payload.get("user_settings")
+    if isinstance(settings, Mapping):
+        rows.append({"table": "user_settings", **settings})
+
+    for table in (
+        "routine_templates",
+        "chore_templates",
+        "medication_plans",
+        "task_instances",
+        "chore_instances",
+        "medication_dose_instances",
+        "planned_items",
+    ):
+        values = payload.get(table)
+        if isinstance(values, list):
+            rows.extend({"table": table, **row} for row in values if isinstance(row, Mapping))
+
+    fieldnames = ["table", *sorted({key for row in rows for key in row if key != "table"})]
+    out = StringIO()
+    writer = csv.DictWriter(out, fieldnames=fieldnames, extrasaction="ignore")
+    writer.writeheader()
+    for row in rows:
+        writer.writerow({key: _csv_value(row.get(key)) for key in fieldnames})
+    return out.getvalue()
+
+
+def import_user_export(db: Session, user: User, payload: Mapping[str, Any], *, replace: bool = False) -> dict[str, int]:
+    if payload.get("version") != EXPORT_VERSION:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=f"Unsupported export version: {payload.get('version')}",
+        )
+
+    if replace:
+        _delete_user_data(db, user.id)
+
+    settings = _mapping(payload.get("user_settings"), "user_settings")
+    for field in _USER_SETTING_FIELDS:
+        if field in settings:
+            setattr(user, field, _coerce_setting(field, settings[field]))
+
+    routine_id_map: dict[int, int] = {}
+    chore_id_map: dict[int, int] = {}
+    medication_id_map: dict[int, int] = {}
+
+    counts = {
+        "routine_templates": 0,
+        "chore_templates": 0,
+        "medication_plans": 0,
+        "task_instances": 0,
+        "chore_instances": 0,
+        "medication_dose_instances": 0,
+        "planned_items": 0,
+    }
+
+    for row in _rows(payload, "routine_templates"):
+        old_id = _int(row.get("id"), "routine_templates.id")
+        item = RoutineTemplate(
+            user_id=user.id,
+            name=_str(row.get("name"), "routine_templates.name"),
+            description=_nullable_str(row.get("description"), "routine_templates.description"),
+            start_date=_date(row.get("start_date"), "routine_templates.start_date"),
+            every_n_days=_int(row.get("every_n_days"), "routine_templates.every_n_days"),
+            rrule=_nullable_str(row.get("rrule"), "routine_templates.rrule"),
+            due_time=_nullable_time(row.get("due_time"), "routine_templates.due_time"),
+            is_active=_bool(row.get("is_active"), "routine_templates.is_active"),
+            created_at=_datetime(row.get("created_at"), "routine_templates.created_at"),
+        )
+        db.add(item)
+        db.flush()
+        routine_id_map[old_id] = item.id
+        counts["routine_templates"] += 1
+
+    for row in _rows(payload, "chore_templates"):
+        old_id = _int(row.get("id"), "chore_templates.id")
+        item = ChoreTemplate(
+            user_id=user.id,
+            name=_str(row.get("name"), "chore_templates.name"),
+            description=_nullable_str(row.get("description"), "chore_templates.description"),
+            start_date=_date(row.get("start_date"), "chore_templates.start_date"),
+            every_n_days=_int(row.get("every_n_days"), "chore_templates.every_n_days"),
+            rrule=_nullable_str(row.get("rrule"), "chore_templates.rrule"),
+            priority=_enum(Priority, row.get("priority", Priority.normal.value), "chore_templates.priority"),
+            tags=_list(row.get("tags"), "chore_templates.tags"),
+            is_active=_bool(row.get("is_active"), "chore_templates.is_active"),
+            created_at=_datetime(row.get("created_at"), "chore_templates.created_at"),
+        )
+        db.add(item)
+        db.flush()
+        chore_id_map[old_id] = item.id
+        counts["chore_templates"] += 1
+
+    for row in _rows(payload, "medication_plans"):
+        old_id = _int(row.get("id"), "medication_plans.id")
+        item = MedicationPlan(
+            user_id=user.id,
+            name=_str(row.get("name"), "medication_plans.name"),
+            instructions=_str(row.get("instructions"), "medication_plans.instructions"),
+            start_date=_date(row.get("start_date"), "medication_plans.start_date"),
+            schedule_time=_time(row.get("schedule_time"), "medication_plans.schedule_time"),
+            every_n_days=_int(row.get("every_n_days"), "medication_plans.every_n_days"),
+            is_active=_bool(row.get("is_active"), "medication_plans.is_active"),
+            created_at=_datetime(row.get("created_at"), "medication_plans.created_at"),
+        )
+        db.add(item)
+        db.flush()
+        medication_id_map[old_id] = item.id
+        counts["medication_plans"] += 1
+
+    for row in _rows(payload, "task_instances"):
+        item = TaskInstance(
+            user_id=user.id,
+            routine_template_id=_mapped_id(routine_id_map, row.get("routine_template_id"), "task_instances.routine_template_id"),
+            title=_str(row.get("title"), "task_instances.title"),
+            scheduled_date=_date(row.get("scheduled_date"), "task_instances.scheduled_date"),
+            due_at=_nullable_datetime(row.get("due_at"), "task_instances.due_at"),
+            status=_enum(TaskStatus, row.get("status"), "task_instances.status"),
+            completed_at=_nullable_datetime(row.get("completed_at"), "task_instances.completed_at"),
+            created_at=_datetime(row.get("created_at"), "task_instances.created_at"),
+        )
+        db.add(item)
+        counts["task_instances"] += 1
+
+    for row in _rows(payload, "chore_instances"):
+        item = ChoreInstance(
+            user_id=user.id,
+            chore_template_id=_mapped_id(chore_id_map, row.get("chore_template_id"), "chore_instances.chore_template_id"),
+            title=_str(row.get("title"), "chore_instances.title"),
+            scheduled_date=_date(row.get("scheduled_date"), "chore_instances.scheduled_date"),
+            status=_enum(ChoreStatus, row.get("status"), "chore_instances.status"),
+            completed_at=_nullable_datetime(row.get("completed_at"), "chore_instances.completed_at"),
+            skipped_at=_nullable_datetime(row.get("skipped_at"), "chore_instances.skipped_at"),
+            created_at=_datetime(row.get("created_at"), "chore_instances.created_at"),
+        )
+        db.add(item)
+        counts["chore_instances"] += 1
+
+    for row in _rows(payload, "medication_dose_instances"):
+        item = MedicationDoseInstance(
+            user_id=user.id,
+            medication_plan_id=_mapped_id(
+                medication_id_map,
+                row.get("medication_plan_id"),
+                "medication_dose_instances.medication_plan_id",
+            ),
+            name=_str(row.get("name"), "medication_dose_instances.name"),
+            instructions=_str(row.get("instructions"), "medication_dose_instances.instructions"),
+            scheduled_date=_date(row.get("scheduled_date"), "medication_dose_instances.scheduled_date"),
+            scheduled_at=_datetime(row.get("scheduled_at"), "medication_dose_instances.scheduled_at"),
+            status=_enum(MedicationDoseStatus, row.get("status"), "medication_dose_instances.status"),
+            taken_at=_nullable_datetime(row.get("taken_at"), "medication_dose_instances.taken_at"),
+            skipped_at=_nullable_datetime(row.get("skipped_at"), "medication_dose_instances.skipped_at"),
+            missed_at=_nullable_datetime(row.get("missed_at"), "medication_dose_instances.missed_at"),
+            created_at=_datetime(row.get("created_at"), "medication_dose_instances.created_at"),
+        )
+        db.add(item)
+        counts["medication_dose_instances"] += 1
+
+    for row in _rows(payload, "planned_items"):
+        item = PlannedItem(
+            user_id=user.id,
+            title=_str(row.get("title"), "planned_items.title"),
+            notes=_nullable_str(row.get("notes"), "planned_items.notes"),
+            module_key=_nullable_str(row.get("module_key"), "planned_items.module_key"),
+            recurrence_hint=_nullable_str(row.get("recurrence_hint"), "planned_items.recurrence_hint"),
+            linked_source=_nullable_str(row.get("linked_source"), "planned_items.linked_source"),
+            linked_ref=_nullable_str(row.get("linked_ref"), "planned_items.linked_ref"),
+            planned_for=_date(row.get("planned_for"), "planned_items.planned_for"),
+            priority=_enum(Priority, row.get("priority", Priority.normal.value), "planned_items.priority"),
+            tags=_list(row.get("tags"), "planned_items.tags"),
+            is_done=_bool(row.get("is_done"), "planned_items.is_done"),
+            completed_at=_nullable_datetime(row.get("completed_at"), "planned_items.completed_at"),
+            created_at=_datetime(row.get("created_at"), "planned_items.created_at"),
+        )
+        db.add(item)
+        counts["planned_items"] += 1
+
+    try:
+        db.commit()
+    except IntegrityError as exc:
+        db.rollback()
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=f"Import conflicts with existing data: {exc.orig}",
+        ) from exc
+    return counts
+
+
+def _delete_user_data(db: Session, user_id: int) -> None:
+    for model in (
+        MedicationDoseInstance,
+        ChoreInstance,
+        TaskInstance,
+        PlannedItem,
+        MedicationPlan,
+        ChoreTemplate,
+        RoutineTemplate,
+    ):
+        db.execute(delete(model).where(model.user_id == user_id))
+
+
+def _export_rows(rows: Iterable[Any], fields: tuple[str, ...]) -> list[dict[str, Any]]:
+    return [_fields_to_dict(row, fields) for row in rows]
+
+
+def _fields_to_dict(row: Any, fields: tuple[str, ...]) -> dict[str, Any]:
+    return {field: _json_value(getattr(row, field)) for field in fields}
+
+
+def _json_value(value: Any) -> Any:
+    if isinstance(value, datetime | date | time):
+        return value.isoformat()
+    if hasattr(value, "value"):
+        return value.value
+    return value
+
+
+def _csv_value(value: Any) -> Any:
+    if isinstance(value, list | dict):
+        return json.dumps(value, separators=(",", ":"))
+    return value
+
+
+def _rows(payload: Mapping[str, Any], key: str) -> list[Mapping[str, Any]]:
+    values = payload.get(key, [])
+    if not isinstance(values, list):
+        _invalid(f"{key} must be a list")
+    return [_mapping(value, key) for value in values]
+
+
+def _mapping(value: Any, field: str) -> Mapping[str, Any]:
+    if not isinstance(value, Mapping):
+        _invalid(f"{field} must be an object")
+    return value
+
+
+def _mapped_id(mapping: Mapping[int, int], value: Any, field: str) -> int:
+    old_id = _int(value, field)
+    if old_id not in mapping:
+        _invalid(f"{field} references an item missing from this import")
+    return mapping[old_id]
+
+
+def _coerce_setting(field: str, value: Any) -> Any:
+    if field in {"timezone"}:
+        return _str(value, f"user_settings.{field}")
+    if field in {"default_snooze_days", "medication_reminder_minutes"}:
+        return _int(value, f"user_settings.{field}")
+    return _nullable_time(value, f"user_settings.{field}")
+
+
+def _str(value: Any, field: str) -> str:
+    if not isinstance(value, str):
+        _invalid(f"{field} must be a string")
+    return value
+
+
+def _nullable_str(value: Any, field: str) -> str | None:
+    if value is None:
+        return None
+    return _str(value, field)
+
+
+def _int(value: Any, field: str) -> int:
+    if not isinstance(value, int) or isinstance(value, bool):
+        _invalid(f"{field} must be an integer")
+    return value
+
+
+def _bool(value: Any, field: str) -> bool:
+    if not isinstance(value, bool):
+        _invalid(f"{field} must be a boolean")
+    return value
+
+
+def _enum(cls: type[_E], value: Any, field: str) -> _E:
+    s = _str(value, field)
+    try:
+        return cls(s)  # type: ignore[call-arg]
+    except ValueError:
+        valid = ", ".join(m.value for m in cls)  # type: ignore[attr-defined]
+        _invalid(f"{field} has invalid value '{s}'; expected one of: {valid}")
+
+
+def _list(value: Any, field: str) -> list[Any]:
+    if value is None:
+        return []
+    if not isinstance(value, list):
+        _invalid(f"{field} must be a list")
+    return value
+
+
+def _date(value: Any, field: str) -> date:
+    if not isinstance(value, str):
+        _invalid(f"{field} must be an ISO date string")
+    try:
+        return date.fromisoformat(value)
+    except ValueError:
+        _invalid(f"{field} must be an ISO date string")
+
+
+def _time(value: Any, field: str) -> time:
+    if not isinstance(value, str):
+        _invalid(f"{field} must be an ISO time string")
+    try:
+        return time.fromisoformat(value)
+    except ValueError:
+        _invalid(f"{field} must be an ISO time string")
+
+
+def _nullable_time(value: Any, field: str) -> time | None:
+    if value is None:
+        return None
+    return _time(value, field)
+
+
+def _datetime(value: Any, field: str) -> datetime:
+    if not isinstance(value, str):
+        _invalid(f"{field} must be an ISO datetime string")
+    try:
+        return datetime.fromisoformat(value)
+    except ValueError:
+        _invalid(f"{field} must be an ISO datetime string")
+
+
+def _nullable_datetime(value: Any, field: str) -> datetime | None:
+    if value is None:
+        return None
+    return _datetime(value, field)
+
+
+def _invalid(detail: str) -> NoReturn:
+    raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=detail)

--- a/backend/app/services/export_import_service.py
+++ b/backend/app/services/export_import_service.py
@@ -3,15 +3,19 @@ from __future__ import annotations
 import csv
 import enum
 import json
+import logging
 from collections.abc import Iterable, Mapping
 from datetime import date, datetime, time, timezone
 from io import StringIO
 from typing import Any, NoReturn, TypeVar
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 from fastapi import HTTPException, status
 from sqlalchemy import delete
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
+
+logger = logging.getLogger(__name__)
 
 from app.core.enums import ChoreStatus, MedicationDoseStatus, Priority, TaskStatus
 from app.models.chore_instance import ChoreInstance
@@ -227,7 +231,7 @@ def import_user_export(db: Session, user: User, payload: Mapping[str, Any], *, r
             created_at=_datetime(row.get("created_at"), "routine_templates.created_at"),
         )
         db.add(item)
-        db.flush()
+        _flush(db)
         routine_id_map[old_id] = item.id
         counts["routine_templates"] += 1
 
@@ -246,7 +250,7 @@ def import_user_export(db: Session, user: User, payload: Mapping[str, Any], *, r
             created_at=_datetime(row.get("created_at"), "chore_templates.created_at"),
         )
         db.add(item)
-        db.flush()
+        _flush(db)
         chore_id_map[old_id] = item.id
         counts["chore_templates"] += 1
 
@@ -263,7 +267,7 @@ def import_user_export(db: Session, user: User, payload: Mapping[str, Any], *, r
             created_at=_datetime(row.get("created_at"), "medication_plans.created_at"),
         )
         db.add(item)
-        db.flush()
+        _flush(db)
         medication_id_map[old_id] = item.id
         counts["medication_plans"] += 1
 
@@ -339,11 +343,24 @@ def import_user_export(db: Session, user: User, payload: Mapping[str, Any], *, r
         db.commit()
     except IntegrityError as exc:
         db.rollback()
+        logger.error("Import IntegrityError during commit", exc_info=exc)
         raise HTTPException(
             status_code=status.HTTP_409_CONFLICT,
-            detail=f"Import conflicts with existing data: {exc.orig}",
+            detail="Import conflicts with existing data",
         ) from exc
     return counts
+
+
+def _flush(db: Session) -> None:
+    try:
+        db.flush()
+    except IntegrityError as exc:
+        db.rollback()
+        logger.error("Import IntegrityError during flush", exc_info=exc)
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="Import conflicts with existing data",
+        ) from exc
 
 
 def _delete_user_data(db: Session, user_id: int) -> None:
@@ -402,10 +419,23 @@ def _mapped_id(mapping: Mapping[int, int], value: Any, field: str) -> int:
 
 
 def _coerce_setting(field: str, value: Any) -> Any:
-    if field in {"timezone"}:
-        return _str(value, f"user_settings.{field}")
-    if field in {"default_snooze_days", "medication_reminder_minutes"}:
-        return _int(value, f"user_settings.{field}")
+    if field == "timezone":
+        tz_str = _str(value, f"user_settings.{field}")
+        try:
+            ZoneInfo(tz_str)
+        except ZoneInfoNotFoundError:
+            _invalid(f"user_settings.{field} is not a valid IANA timezone: {tz_str!r}")
+        return tz_str
+    if field == "default_snooze_days":
+        v = _int(value, f"user_settings.{field}")
+        if v < 1 or v > 365:
+            _invalid(f"user_settings.{field} must be between 1 and 365")
+        return v
+    if field == "medication_reminder_minutes":
+        v = _int(value, f"user_settings.{field}")
+        if v < 0 or v > 1440:
+            _invalid(f"user_settings.{field} must be between 0 and 1440")
+        return v
     return _nullable_time(value, f"user_settings.{field}")
 
 

--- a/backend/app/services/export_import_service.py
+++ b/backend/app/services/export_import_service.py
@@ -12,8 +12,6 @@ from sqlalchemy import delete
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
-_E = TypeVar("_E")
-
 from app.core.enums import ChoreStatus, MedicationDoseStatus, Priority, TaskStatus
 from app.models.chore_instance import ChoreInstance
 from app.models.chore_template import ChoreTemplate
@@ -23,6 +21,8 @@ from app.models.planned_item import PlannedItem
 from app.models.routine_template import RoutineTemplate
 from app.models.task_instance import TaskInstance
 from app.models.user import User
+
+_E = TypeVar("_E")
 
 EXPORT_VERSION = 1
 

--- a/backend/app/services/today_service.py
+++ b/backend/app/services/today_service.py
@@ -450,6 +450,8 @@ class TodayService:
                 linked_source=request.linked_source,
                 linked_ref=request.linked_ref,
                 planned_for=request.planned_for,
+                priority=request.priority,
+                tags=request.tags,
                 is_done=False,
             )
         )
@@ -464,6 +466,8 @@ class TodayService:
         item.linked_source = request.linked_source
         item.linked_ref = request.linked_ref
         item.planned_for = request.planned_for
+        item.priority = request.priority
+        item.tags = request.tags
         if request.is_done and not item.is_done:
             item.completed_at = self.repository.utcnow()
         elif not request.is_done:
@@ -595,6 +599,8 @@ class TodayService:
             recurrence_hint=item.recurrence_hint,
             linked_source=item.linked_source,
             linked_ref=item.linked_ref,
+            priority=item.priority,
+            tags=item.tags or [],
             is_done=item.is_done,
         )
 
@@ -644,6 +650,7 @@ class TodayService:
         name: str,
         start_date: date,
         every_n_days: int | None,
+        rrule: str | None,
         description: str | None,
         due_time: time | None,
         is_active: bool | None,
@@ -659,6 +666,7 @@ class TodayService:
             description=description if description is not None else template.description,
             start_date=start_date,
             every_n_days=every_n_days if every_n_days is not None else template.every_n_days,
+            rrule=rrule,
             due_time=due_time if due_time is not None else template.due_time,
             is_active=is_active if is_active is not None else template.is_active,
         )
@@ -703,6 +711,9 @@ class TodayService:
         name: str,
         start_date: date,
         every_n_days: int | None,
+        rrule: str | None,
+        priority: str,
+        tags: list,
         description: str | None,
         is_active: bool | None,
     ) -> ChoreTemplate:
@@ -717,6 +728,9 @@ class TodayService:
             description=description if description is not None else template.description,
             start_date=start_date,
             every_n_days=every_n_days if every_n_days is not None else template.every_n_days,
+            rrule=rrule,
+            priority=priority,
+            tags=tags,
             is_active=is_active if is_active is not None else template.is_active,
         )
 

--- a/backend/app/services/today_service.py
+++ b/backend/app/services/today_service.py
@@ -245,6 +245,8 @@ class TodayService:
                     recurrence_hint=item.recurrence_hint,
                     linked_source=item.linked_source,
                     linked_ref=item.linked_ref,
+                    priority=item.priority,
+                    tags=item.tags or [],
                     is_done=item.is_done,
                 )
                 for item in planned

--- a/backend/app/services/today_service.py
+++ b/backend/app/services/today_service.py
@@ -9,7 +9,14 @@ from zoneinfo import ZoneInfo
 from fastapi import HTTPException, status
 
 from app.core.config import AppSettings
-from app.core.enums import ChoreStatus, MedicationDoseStatus, TaskStatus
+from app.core.enums import ChoreStatus, MedicationDoseStatus, Priority, TaskStatus
+
+_PRIORITY_RANK: dict[str, int] = {
+    Priority.urgent: 0,
+    Priority.high: 1,
+    Priority.normal: 2,
+    Priority.low: 3,
+}
 from app.models.chore_instance import ChoreInstance
 from app.models.chore_template import ChoreTemplate
 from app.models.medication_dose_instance import MedicationDoseInstance
@@ -326,6 +333,7 @@ class TodayService:
                     recurrence_hint=plan.recurrence_hint,
                     linked_source=plan.linked_source,
                     linked_ref=plan.linked_ref,
+                    priority=cast(Priority, plan.priority),
                 )
             )
 
@@ -333,6 +341,7 @@ class TodayService:
             key=lambda value: (
                 value.scheduled_at is None,
                 value.scheduled_at or datetime.min.replace(tzinfo=timezone.utc),
+                _PRIORITY_RANK.get(value.priority, 2),
                 value.item_type,
                 value.item_id,
             )
@@ -476,10 +485,10 @@ class TodayService:
         self.repository.save()
         return self._planned_item_to_schema(item)
 
-    def list_planned_items(self, user_id: int, start_date: date | None = None, end_date: date | None = None) -> list[PlannedTodayItem]:
+    def list_planned_items(self, user_id: int, start_date: date | None = None, end_date: date | None = None, tags: list[str] | None = None) -> list[PlannedTodayItem]:
         return [
             self._planned_item_to_schema(item)
-            for item in self.repository.list_planned_items(user_id=user_id, start_date=start_date, end_date=end_date)
+            for item in self.repository.list_planned_items(user_id=user_id, start_date=start_date, end_date=end_date, tags=tags)
         ]
 
     def mark_planned_done(self, user_id: int, planned_item_id: int) -> None:

--- a/backend/app/services/today_service.py
+++ b/backend/app/services/today_service.py
@@ -10,13 +10,6 @@ from fastapi import HTTPException, status
 
 from app.core.config import AppSettings
 from app.core.enums import ChoreStatus, MedicationDoseStatus, Priority, TaskStatus
-
-_PRIORITY_RANK: dict[str, int] = {
-    Priority.urgent: 0,
-    Priority.high: 1,
-    Priority.normal: 2,
-    Priority.low: 3,
-}
 from app.models.chore_instance import ChoreInstance
 from app.models.chore_template import ChoreTemplate
 from app.models.medication_dose_instance import MedicationDoseInstance
@@ -45,6 +38,13 @@ from app.schemas.today import (
     UnifiedDayItem,
     UpcomingTodayItem,
 )
+
+_PRIORITY_RANK: dict[str, int] = {
+    Priority.urgent: 0,
+    Priority.high: 1,
+    Priority.normal: 2,
+    Priority.low: 3,
+}
 
 logger = logging.getLogger(__name__)
 
@@ -333,7 +333,7 @@ class TodayService:
                     recurrence_hint=plan.recurrence_hint,
                     linked_source=plan.linked_source,
                     linked_ref=plan.linked_ref,
-                    priority=cast(Priority, plan.priority),
+                    priority=plan.priority,
                 )
             )
 
@@ -491,23 +491,28 @@ class TodayService:
             for item in self.repository.list_planned_items(user_id=user_id, start_date=start_date, end_date=end_date, tags=tags)
         ]
 
-    def mark_planned_done(self, user_id: int, planned_item_id: int) -> None:
+    def save(self) -> None:
+        self.repository.save()
+
+    def mark_planned_done(self, user_id: int, planned_item_id: int, *, persist: bool = True) -> None:
         item = self._get_user_planned_item(user_id=user_id, planned_item_id=planned_item_id)
         if not item.is_done:
             item.is_done = True
             item.completed_at = self.repository.utcnow()
-            self.repository.save()
+            if persist:
+                self.repository.save()
 
     def delete_planned_item(self, user_id: int, planned_item_id: int) -> None:
         item = self._get_user_planned_item(user_id=user_id, planned_item_id=planned_item_id)
         self.repository.delete_planned_item(item)
 
-    def complete_chore(self, user_id: int, chore_instance_id: int) -> ChoreInstanceMutationResponse:
+    def complete_chore(self, user_id: int, chore_instance_id: int, *, persist: bool = True) -> ChoreInstanceMutationResponse:
         instance = self._get_user_chore(user_id, chore_instance_id)
         instance.status = ChoreStatus.completed
         instance.completed_at = self.repository.utcnow()
         instance.skipped_at = None
-        self.repository.save()
+        if persist:
+            self.repository.save()
         return ChoreInstanceMutationResponse(
             chore_instance_id=instance.id,
             status=instance.status,
@@ -548,12 +553,13 @@ class TodayService:
         self.repository.save()
         return self._task_instance_to_response(instance)
 
-    def skip_chore(self, user_id: int, chore_instance_id: int) -> ChoreInstanceMutationResponse:
+    def skip_chore(self, user_id: int, chore_instance_id: int, *, persist: bool = True) -> ChoreInstanceMutationResponse:
         instance = self._get_user_chore(user_id, chore_instance_id)
         instance.status = ChoreStatus.skipped
         instance.skipped_at = self.repository.utcnow()
         instance.completed_at = None
-        self.repository.save()
+        if persist:
+            self.repository.save()
         return ChoreInstanceMutationResponse(
             chore_instance_id=instance.id,
             status=instance.status,
@@ -721,7 +727,7 @@ class TodayService:
         start_date: date,
         every_n_days: int | None,
         rrule: str | None,
-        priority: str,
+        priority: Priority,
         tags: list,
         description: str | None,
         is_active: bool | None,

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = [
     "pydantic-settings==2.14.1",
     "cryptography>=48.0.0",
     "pyjwt==2.12.1",
+    "python-dateutil>=2.9.0",
     "sentry-sdk[fastapi]==2.60.0",
     "sqlalchemy==2.0.49",
     "uvicorn[standard]==0.47.0",

--- a/backend/tests/test_analytics_api.py
+++ b/backend/tests/test_analytics_api.py
@@ -4,13 +4,15 @@ from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
 
 from app.api.dependencies.auth import get_current_user
-from app.core.enums import ChoreStatus, MedicationDoseStatus
+from app.core.enums import ChoreStatus, MedicationDoseStatus, TaskStatus
 from app.main import app
 from app.models.chore_instance import ChoreInstance
 from app.models.chore_template import ChoreTemplate
 from app.models.medication_dose_instance import MedicationDoseInstance
 from app.models.medication_plan import MedicationPlan
 from app.models.planned_item import PlannedItem
+from app.models.routine_template import RoutineTemplate
+from app.models.task_instance import TaskInstance
 from app.models.user import User
 
 
@@ -231,3 +233,107 @@ def test_analytics_streaks_use_bounded_recent_history(client: TestClient, db_ses
     assert response.json()["chores"]["streaks"] == [
         {"chore_id": chore_template.id, "name": "Dishes", "current_streak": 3, "longest_streak": 3}
     ]
+
+
+def _add_task(
+    db_session: Session,
+    user: User,
+    template: RoutineTemplate,
+    scheduled_date: date,
+    status: TaskStatus,
+) -> None:
+    db_session.add(
+        TaskInstance(
+            user_id=user.id,
+            routine_template_id=template.id,
+            title=template.name,
+            scheduled_date=scheduled_date,
+            status=status,
+            completed_at=datetime.now(timezone.utc) if status == TaskStatus.completed else None,
+        )
+    )
+
+
+def test_analytics_includes_routine_streaks(client: TestClient, db_session: Session) -> None:
+    user = _create_user(db_session, email="analytics-routine-streaks@example.com")
+    today = date.today()
+
+    routine = RoutineTemplate(
+        user_id=user.id,
+        name="Morning stretches",
+        description=None,
+        start_date=today - timedelta(days=6),
+        every_n_days=1,
+        is_active=True,
+    )
+    db_session.add(routine)
+    db_session.commit()
+    db_session.refresh(routine)
+
+    # completed 3 days ago; skipped 2 days ago; completed yesterday and today → current streak = 2, longest = 2
+    _add_task(db_session, user, routine, today - timedelta(days=3), TaskStatus.completed)
+    _add_task(db_session, user, routine, today - timedelta(days=2), TaskStatus.skipped)
+    _add_task(db_session, user, routine, today - timedelta(days=1), TaskStatus.completed)
+    _add_task(db_session, user, routine, today, TaskStatus.completed)
+    db_session.commit()
+
+    _auth_as(user)
+    try:
+        response = client.get("/api/v1/analytics/summary?period=week")
+    finally:
+        _clear_auth()
+
+    assert response.status_code == 200
+    routines = response.json()["routines"]
+    assert routines["total_completed"] == 3
+    assert routines["total_scheduled"] == 4
+    assert routines["completion_rate"] == 0.75
+    assert len(routines["daily_completions"]) == 7
+    assert routines["streaks"] == [
+        {"routine_id": routine.id, "name": "Morning stretches", "current_streak": 2, "longest_streak": 2}
+    ]
+
+
+def test_analytics_routine_streaks_do_not_leak_across_users(client: TestClient, db_session: Session) -> None:
+    owner = _create_user(db_session, email="analytics-routine-owner@example.com")
+    other = _create_user(db_session, email="analytics-routine-other@example.com")
+    today = date.today()
+
+    routine = RoutineTemplate(
+        user_id=owner.id,
+        name="Owner routine",
+        description=None,
+        start_date=today,
+        every_n_days=1,
+        is_active=True,
+    )
+    db_session.add(routine)
+    db_session.commit()
+    db_session.refresh(routine)
+    _add_task(db_session, owner, routine, today, TaskStatus.completed)
+    db_session.commit()
+
+    _auth_as(other)
+    try:
+        response = client.get("/api/v1/analytics/summary?period=week")
+    finally:
+        _clear_auth()
+
+    assert response.status_code == 200
+    assert response.json()["routines"]["streaks"] == []
+    assert response.json()["routines"]["total_completed"] == 0
+
+
+def test_analytics_summary_response_includes_routines_key(client: TestClient, db_session: Session) -> None:
+    user = _create_user(db_session, email="analytics-routines-key@example.com")
+    _auth_as(user)
+    try:
+        response = client.get("/api/v1/analytics/summary")
+    finally:
+        _clear_auth()
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert "routines" in payload
+    assert "streaks" in payload["routines"]
+    assert "daily_completions" in payload["routines"]

--- a/backend/tests/test_analytics_api.py
+++ b/backend/tests/test_analytics_api.py
@@ -1,0 +1,233 @@
+from datetime import date, datetime, time, timedelta, timezone
+
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+from app.api.dependencies.auth import get_current_user
+from app.core.enums import ChoreStatus, MedicationDoseStatus
+from app.main import app
+from app.models.chore_instance import ChoreInstance
+from app.models.chore_template import ChoreTemplate
+from app.models.medication_dose_instance import MedicationDoseInstance
+from app.models.medication_plan import MedicationPlan
+from app.models.planned_item import PlannedItem
+from app.models.user import User
+
+
+def _create_user(db_session: Session, email: str) -> User:
+    user = User(email=email, full_name="Test User", is_active=True)
+    db_session.add(user)
+    db_session.commit()
+    db_session.refresh(user)
+    return user
+
+
+def _auth_as(user: User) -> None:
+    async def _dep() -> User:
+        return user
+
+    app.dependency_overrides[get_current_user] = _dep
+
+
+def _clear_auth() -> None:
+    app.dependency_overrides.pop(get_current_user, None)
+
+
+def _add_chore(
+    db_session: Session,
+    user: User,
+    template: ChoreTemplate,
+    scheduled_date: date,
+    status: ChoreStatus,
+) -> None:
+    db_session.add(
+        ChoreInstance(
+            user_id=user.id,
+            chore_template_id=template.id,
+            title=template.name,
+            scheduled_date=scheduled_date,
+            status=status,
+            completed_at=datetime.now(timezone.utc) if status == ChoreStatus.completed else None,
+            skipped_at=datetime.now(timezone.utc) if status == ChoreStatus.skipped else None,
+        )
+    )
+
+
+def _add_medication_dose(
+    db_session: Session,
+    user: User,
+    plan: MedicationPlan,
+    scheduled_date: date,
+    status: MedicationDoseStatus,
+) -> None:
+    scheduled_at = datetime.combine(scheduled_date, plan.schedule_time, tzinfo=timezone.utc)
+    db_session.add(
+        MedicationDoseInstance(
+            user_id=user.id,
+            medication_plan_id=plan.id,
+            name=plan.name,
+            instructions=plan.instructions,
+            scheduled_date=scheduled_date,
+            scheduled_at=scheduled_at,
+            status=status,
+            taken_at=datetime.now(timezone.utc) if status == MedicationDoseStatus.taken else None,
+            skipped_at=datetime.now(timezone.utc) if status == MedicationDoseStatus.skipped else None,
+            missed_at=datetime.now(timezone.utc) if status == MedicationDoseStatus.missed else None,
+        )
+    )
+
+
+def test_analytics_summary_requires_authentication(client: TestClient) -> None:
+    response = client.get("/api/v1/analytics/summary")
+    assert response.status_code == 401
+
+
+def test_analytics_summary_rejects_unknown_period(client: TestClient, db_session: Session) -> None:
+    user = _create_user(db_session, email="analytics-period@example.com")
+    _auth_as(user)
+    try:
+        response = client.get("/api/v1/analytics/summary?period=quarter")
+    finally:
+        _clear_auth()
+
+    assert response.status_code == 422
+
+
+def test_analytics_summary_aggregates_user_history(client: TestClient, db_session: Session) -> None:
+    user = _create_user(db_session, email="analytics@example.com")
+    other_user = _create_user(db_session, email="analytics-other@example.com")
+    today = date.today()
+
+    chore_template = ChoreTemplate(
+        user_id=user.id,
+        name="Laundry",
+        description=None,
+        start_date=today,
+        every_n_days=1,
+        is_active=True,
+    )
+    other_chore_template = ChoreTemplate(
+        user_id=other_user.id,
+        name="Other laundry",
+        description=None,
+        start_date=today,
+        every_n_days=1,
+        is_active=True,
+    )
+    medication_plan = MedicationPlan(
+        user_id=user.id,
+        name="Vitamin D",
+        instructions="Take with breakfast",
+        start_date=today,
+        schedule_time=time(9, 0),
+        every_n_days=1,
+        is_active=True,
+    )
+    db_session.add_all([chore_template, other_chore_template, medication_plan])
+    db_session.commit()
+    db_session.refresh(chore_template)
+    db_session.refresh(other_chore_template)
+    db_session.refresh(medication_plan)
+
+    _add_chore(db_session, user, chore_template, today, ChoreStatus.completed)
+    _add_chore(db_session, user, chore_template, today - timedelta(days=1), ChoreStatus.skipped)
+    _add_chore(db_session, user, chore_template, today - timedelta(days=4), ChoreStatus.completed)
+    _add_chore(db_session, user, chore_template, today - timedelta(days=5), ChoreStatus.completed)
+    _add_chore(db_session, other_user, other_chore_template, today, ChoreStatus.completed)
+
+    _add_medication_dose(db_session, user, medication_plan, today, MedicationDoseStatus.skipped)
+    _add_medication_dose(db_session, user, medication_plan, today - timedelta(days=1), MedicationDoseStatus.taken)
+    _add_medication_dose(db_session, user, medication_plan, today - timedelta(days=2), MedicationDoseStatus.missed)
+
+    db_session.add_all(
+        [
+            PlannedItem(user_id=user.id, title="Meal prep", planned_for=today, is_done=True),
+            PlannedItem(
+                user_id=user.id,
+                title="Review bills",
+                planned_for=today - timedelta(days=1),
+                is_done=False,
+            ),
+            PlannedItem(
+                user_id=user.id,
+                title="Outside window",
+                planned_for=today - timedelta(days=8),
+                is_done=True,
+            ),
+            PlannedItem(user_id=other_user.id, title="Other plan", planned_for=today, is_done=True),
+        ]
+    )
+    db_session.commit()
+
+    _auth_as(user)
+    try:
+        response = client.get("/api/v1/analytics/summary?period=week")
+    finally:
+        _clear_auth()
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["period"] == "week"
+    assert payload["start_date"] == (today - timedelta(days=6)).isoformat()
+    assert payload["end_date"] == today.isoformat()
+
+    chores = payload["chores"]
+    assert chores["completion_rate"] == 0.75
+    assert chores["total_completed"] == 3
+    assert chores["total_scheduled"] == 4
+    assert chores["streaks"] == [
+        {"chore_id": chore_template.id, "name": "Laundry", "current_streak": 1, "longest_streak": 2}
+    ]
+    assert chores["most_skipped"] == [{"chore_id": chore_template.id, "name": "Laundry", "skip_count": 1}]
+    assert len(chores["daily_completions"]) == 7
+    assert chores["daily_completions"][-1] == {
+        "date": today.isoformat(),
+        "completed": 1,
+        "total": 1,
+        "completion_rate": 1.0,
+    }
+
+    medications = payload["medications"]
+    assert medications["adherence_rate"] == 0.3333
+    assert medications["total_taken"] == 1
+    assert medications["total_scheduled"] == 3
+
+    planned_items = payload["planned_items"]
+    assert planned_items["completion_rate"] == 0.5
+    assert planned_items["total_completed"] == 1
+    assert planned_items["total_scheduled"] == 2
+
+
+def test_analytics_streaks_use_bounded_recent_history(client: TestClient, db_session: Session) -> None:
+    user = _create_user(db_session, email="analytics-streak-window@example.com")
+    today = date.today()
+
+    chore_template = ChoreTemplate(
+        user_id=user.id,
+        name="Dishes",
+        description=None,
+        start_date=today - timedelta(days=140),
+        every_n_days=1,
+        is_active=True,
+    )
+    db_session.add(chore_template)
+    db_session.commit()
+    db_session.refresh(chore_template)
+
+    for offset in range(130, 120, -1):
+        _add_chore(db_session, user, chore_template, today - timedelta(days=offset), ChoreStatus.completed)
+    _add_chore(db_session, user, chore_template, today - timedelta(days=2), ChoreStatus.completed)
+    _add_chore(db_session, user, chore_template, today - timedelta(days=1), ChoreStatus.completed)
+    _add_chore(db_session, user, chore_template, today, ChoreStatus.completed)
+    db_session.commit()
+
+    _auth_as(user)
+    try:
+        response = client.get("/api/v1/analytics/summary?period=week")
+    finally:
+        _clear_auth()
+
+    assert response.status_code == 200
+    assert response.json()["chores"]["streaks"] == [
+        {"chore_id": chore_template.id, "name": "Dishes", "current_streak": 3, "longest_streak": 3}
+    ]

--- a/backend/tests/test_export_import.py
+++ b/backend/tests/test_export_import.py
@@ -1,0 +1,220 @@
+from datetime import date, datetime, time, timezone
+
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+from app.api.dependencies.auth import get_current_user
+from app.core.enums import ChoreStatus, MedicationDoseStatus, Priority, TaskStatus
+from app.main import app
+from app.models.chore_instance import ChoreInstance
+from app.models.chore_template import ChoreTemplate
+from app.models.medication_dose_instance import MedicationDoseInstance
+from app.models.medication_plan import MedicationPlan
+from app.models.planned_item import PlannedItem
+from app.models.routine_template import RoutineTemplate
+from app.models.task_instance import TaskInstance
+from app.models.user import User
+
+
+def _create_user(db_session: Session, email: str) -> User:
+    user = User(email=email, full_name="Export User", is_active=True)
+    db_session.add(user)
+    db_session.commit()
+    db_session.refresh(user)
+    return user
+
+
+def _auth_as(user: User) -> None:
+    async def _dep() -> User:
+        return user
+
+    app.dependency_overrides[get_current_user] = _dep
+
+
+def _clear_auth() -> None:
+    app.dependency_overrides.pop(get_current_user, None)
+
+
+def _seed_export_data(db_session: Session, user: User) -> None:
+    user.timezone = "Europe/Brussels"
+    user.default_snooze_days = 2
+    user.medication_reminder_minutes = 45
+    user.quiet_hours_start = time(22, 0)
+    user.quiet_hours_end = time(7, 0)
+
+    routine = RoutineTemplate(
+        user_id=user.id,
+        name="Morning reset",
+        description="Tidy kitchen",
+        start_date=date(2026, 5, 1),
+        every_n_days=1,
+        rrule="FREQ=WEEKLY;BYDAY=MO",
+        due_time=time(8, 0),
+        is_active=True,
+    )
+    chore = ChoreTemplate(
+        user_id=user.id,
+        name="Laundry",
+        description="Wash towels",
+        start_date=date(2026, 5, 2),
+        every_n_days=7,
+        rrule=None,
+        priority=Priority.high,
+        tags=["home", "weekly"],
+        is_active=True,
+    )
+    medication = MedicationPlan(
+        user_id=user.id,
+        name="Vitamin D",
+        instructions="Take with breakfast",
+        start_date=date(2026, 5, 1),
+        schedule_time=time(9, 30),
+        every_n_days=1,
+        is_active=True,
+    )
+    db_session.add_all([routine, chore, medication])
+    db_session.commit()
+    db_session.refresh(routine)
+    db_session.refresh(chore)
+    db_session.refresh(medication)
+
+    db_session.add_all(
+        [
+            TaskInstance(
+                user_id=user.id,
+                routine_template_id=routine.id,
+                title=routine.name,
+                scheduled_date=date(2026, 5, 4),
+                due_at=datetime(2026, 5, 4, 8, 0, tzinfo=timezone.utc),
+                status=TaskStatus.completed,
+                completed_at=datetime(2026, 5, 4, 8, 10, tzinfo=timezone.utc),
+            ),
+            ChoreInstance(
+                user_id=user.id,
+                chore_template_id=chore.id,
+                title=chore.name,
+                scheduled_date=date(2026, 5, 2),
+                status=ChoreStatus.skipped,
+                skipped_at=datetime(2026, 5, 2, 11, 0, tzinfo=timezone.utc),
+            ),
+            MedicationDoseInstance(
+                user_id=user.id,
+                medication_plan_id=medication.id,
+                name=medication.name,
+                instructions=medication.instructions,
+                scheduled_date=date(2026, 5, 1),
+                scheduled_at=datetime(2026, 5, 1, 9, 30, tzinfo=timezone.utc),
+                status=MedicationDoseStatus.taken,
+                taken_at=datetime(2026, 5, 1, 9, 35, tzinfo=timezone.utc),
+            ),
+            PlannedItem(
+                user_id=user.id,
+                title="Meal prep",
+                notes="Sunday batch",
+                module_key="meal_planning",
+                recurrence_hint="weekly",
+                linked_source="manual",
+                linked_ref="prep-1",
+                planned_for=date(2026, 5, 3),
+                priority=Priority.urgent,
+                tags=["food"],
+                is_done=True,
+                completed_at=datetime(2026, 5, 3, 16, 0, tzinfo=timezone.utc),
+            ),
+        ]
+    )
+    db_session.commit()
+
+
+def test_export_user_data_returns_full_json_backup(client: TestClient, db_session: Session) -> None:
+    user = _create_user(db_session, "export@example.com")
+    _seed_export_data(db_session, user)
+    _auth_as(user)
+
+    try:
+        response = client.get("/api/v1/users/me/export")
+    finally:
+        _clear_auth()
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["version"] == 1
+    assert payload["user_settings"]["timezone"] == "Europe/Brussels"
+    assert payload["user_settings"]["quiet_hours_start"] == "22:00:00"
+    assert payload["routine_templates"][0]["name"] == "Morning reset"
+    assert payload["chore_templates"][0]["priority"] == "high"
+    assert payload["chore_templates"][0]["tags"] == ["home", "weekly"]
+    assert payload["medication_plans"][0]["name"] == "Vitamin D"
+    assert payload["task_instances"][0]["status"] == "completed"
+    assert payload["chore_instances"][0]["status"] == "skipped"
+    assert payload["medication_dose_instances"][0]["status"] == "taken"
+    assert payload["planned_items"][0]["priority"] == "urgent"
+
+
+def test_export_user_data_can_return_csv(client: TestClient, db_session: Session) -> None:
+    user = _create_user(db_session, "export-csv@example.com")
+    _seed_export_data(db_session, user)
+    _auth_as(user)
+
+    try:
+        response = client.get("/api/v1/users/me/export?format=csv")
+    finally:
+        _clear_auth()
+
+    assert response.status_code == 200
+    assert response.headers["content-type"].startswith("text/csv")
+    assert "table" in response.text
+    assert "user_settings" in response.text
+    assert "chore_templates" in response.text
+    assert "Laundry" in response.text
+
+
+def test_import_user_data_restores_export_for_current_user(client: TestClient, db_session: Session) -> None:
+    source = _create_user(db_session, "source@example.com")
+    target = _create_user(db_session, "target@example.com")
+    _seed_export_data(db_session, source)
+
+    _auth_as(source)
+    try:
+        payload = client.get("/api/v1/users/me/export").json()
+    finally:
+        _clear_auth()
+
+    _auth_as(target)
+    try:
+        response = client.post("/api/v1/users/me/import", json=payload)
+    finally:
+        _clear_auth()
+
+    assert response.status_code == 200
+    assert response.json()["imported"] == {
+        "routine_templates": 1,
+        "chore_templates": 1,
+        "medication_plans": 1,
+        "task_instances": 1,
+        "chore_instances": 1,
+        "medication_dose_instances": 1,
+        "planned_items": 1,
+    }
+
+    db_session.refresh(target)
+    assert target.timezone == "Europe/Brussels"
+    assert target.default_snooze_days == 2
+    imported_routine = db_session.query(RoutineTemplate).filter_by(user_id=target.id).one()
+    imported_task = db_session.query(TaskInstance).filter_by(user_id=target.id).one()
+    imported_chore = db_session.query(ChoreTemplate).filter_by(user_id=target.id).one()
+    imported_chore_instance = db_session.query(ChoreInstance).filter_by(user_id=target.id).one()
+    imported_plan = db_session.query(MedicationPlan).filter_by(user_id=target.id).one()
+    imported_dose = db_session.query(MedicationDoseInstance).filter_by(user_id=target.id).one()
+    imported_planned = db_session.query(PlannedItem).filter_by(user_id=target.id).one()
+
+    assert imported_task.routine_template_id == imported_routine.id
+    assert imported_chore_instance.chore_template_id == imported_chore.id
+    assert imported_dose.medication_plan_id == imported_plan.id
+    assert imported_planned.title == "Meal prep"
+    assert imported_planned.tags == ["food"]
+
+
+def test_export_requires_authentication(client: TestClient) -> None:
+    response = client.get("/api/v1/users/me/export")
+    assert response.status_code == 401

--- a/backend/tests/test_search.py
+++ b/backend/tests/test_search.py
@@ -1,0 +1,209 @@
+from datetime import date, time
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+from app.api.dependencies.auth import get_current_user
+from app.core.enums import Priority
+from app.main import app
+from app.models.chore_template import ChoreTemplate
+from app.models.medication_plan import MedicationPlan
+from app.models.planned_item import PlannedItem
+from app.models.routine_template import RoutineTemplate
+from app.models.user import User
+
+
+def _create_user(db: Session, email: str) -> User:
+    user = User(email=email, full_name="Search User", is_active=True)
+    db.add(user)
+    db.commit()
+    db.refresh(user)
+    return user
+
+
+def _auth_as(user: User) -> None:
+    async def _dep() -> User:
+        return user
+
+    app.dependency_overrides[get_current_user] = _dep
+
+
+def _clear_auth() -> None:
+    app.dependency_overrides.pop(get_current_user, None)
+
+
+def _seed(db: Session, user: User) -> None:
+    db.add_all(
+        [
+            RoutineTemplate(
+                user_id=user.id,
+                name="Morning stretches",
+                description="Light yoga flow",
+                start_date=date(2026, 1, 1),
+                every_n_days=1,
+                is_active=True,
+            ),
+            RoutineTemplate(
+                user_id=user.id,
+                name="Evening reading",
+                description=None,
+                start_date=date(2026, 1, 1),
+                every_n_days=1,
+                is_active=True,
+            ),
+            ChoreTemplate(
+                user_id=user.id,
+                name="Vacuum living room",
+                description="Including under sofa",
+                start_date=date(2026, 1, 1),
+                every_n_days=7,
+                priority=Priority.normal,
+                tags=["home"],
+                is_active=True,
+            ),
+            ChoreTemplate(
+                user_id=user.id,
+                name="Laundry",
+                description=None,
+                start_date=date(2026, 1, 1),
+                every_n_days=7,
+                priority=Priority.high,
+                tags=[],
+                is_active=True,
+            ),
+            MedicationPlan(
+                user_id=user.id,
+                name="Vitamin D",
+                instructions="Take with breakfast",
+                start_date=date(2026, 1, 1),
+                schedule_time=time(9, 0),
+                every_n_days=1,
+                is_active=True,
+            ),
+            PlannedItem(
+                user_id=user.id,
+                title="Meal prep Sunday",
+                notes="Batch cook rice and veggies",
+                planned_for=date(2026, 5, 5),
+                priority=Priority.normal,
+                tags=[],
+                is_done=False,
+            ),
+            PlannedItem(
+                user_id=user.id,
+                title="Buy groceries",
+                notes=None,
+                planned_for=date(2026, 5, 6),
+                priority=Priority.normal,
+                tags=[],
+                is_done=False,
+            ),
+        ]
+    )
+    db.commit()
+
+
+@pytest.fixture(autouse=True)
+def _cleanup():
+    yield
+    _clear_auth()
+
+
+def test_search_returns_grouped_results(client: TestClient, db_session: Session) -> None:
+    user = _create_user(db_session, "search1@example.com")
+    _seed(db_session, user)
+    _auth_as(user)
+
+    response = client.get("/api/v1/search?q=vitamin")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["query"] == "vitamin"
+    assert len(data["medication_plans"]) == 1
+    assert data["medication_plans"][0]["name"] == "Vitamin D"
+    assert data["routine_templates"] == []
+    assert data["chore_templates"] == []
+    assert data["planned_items"] == []
+
+
+def test_search_matches_description_field(client: TestClient, db_session: Session) -> None:
+    user = _create_user(db_session, "search2@example.com")
+    _seed(db_session, user)
+    _auth_as(user)
+
+    response = client.get("/api/v1/search?q=yoga")
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data["routine_templates"]) == 1
+    assert data["routine_templates"][0]["name"] == "Morning stretches"
+
+
+def test_search_is_case_insensitive(client: TestClient, db_session: Session) -> None:
+    user = _create_user(db_session, "search3@example.com")
+    _seed(db_session, user)
+    _auth_as(user)
+
+    response = client.get("/api/v1/search?q=MEAL")
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data["planned_items"]) == 1
+    assert data["planned_items"][0]["title"] == "Meal prep Sunday"
+
+
+def test_search_matches_planned_item_notes(client: TestClient, db_session: Session) -> None:
+    user = _create_user(db_session, "search4@example.com")
+    _seed(db_session, user)
+    _auth_as(user)
+
+    response = client.get("/api/v1/search?q=batch+cook")
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data["planned_items"]) == 1
+    assert data["planned_items"][0]["title"] == "Meal prep Sunday"
+
+
+def test_search_does_not_leak_other_users_data(client: TestClient, db_session: Session) -> None:
+    owner = _create_user(db_session, "search-owner@example.com")
+    other = _create_user(db_session, "search-other@example.com")
+    _seed(db_session, owner)
+    _auth_as(other)
+
+    response = client.get("/api/v1/search?q=vitamin")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["medication_plans"] == []
+
+
+def test_search_rejects_query_shorter_than_two_chars(client: TestClient, db_session: Session) -> None:
+    user = _create_user(db_session, "search5@example.com")
+    _auth_as(user)
+
+    response = client.get("/api/v1/search?q=a")
+    assert response.status_code == 422
+
+
+def test_search_requires_authentication(client: TestClient) -> None:
+    response = client.get("/api/v1/search?q=vitamin")
+    assert response.status_code == 401
+
+
+def test_search_limit_caps_results(client: TestClient, db_session: Session) -> None:
+    user = _create_user(db_session, "search6@example.com")
+    for i in range(5):
+        db_session.add(
+            PlannedItem(
+                user_id=user.id,
+                title=f"Shopping item {i}",
+                notes=None,
+                planned_for=date(2026, 5, i + 1),
+                priority=Priority.normal,
+                tags=[],
+                is_done=False,
+            )
+        )
+    db_session.commit()
+    _auth_as(user)
+
+    response = client.get("/api/v1/search?q=shopping&limit=3")
+    assert response.status_code == 200
+    assert len(response.json()["planned_items"]) == 3

--- a/backend/tests/test_today_route_integration.py
+++ b/backend/tests/test_today_route_integration.py
@@ -372,7 +372,7 @@ def test_template_management_endpoints(client: TestClient, db_session: Session) 
 
     try:
         create_routine = client.post(
-            "/api/v1/routines",
+            "/api/v1/templates/routines",
             json={
                 "name": "Morning reset",
                 "description": "Open windows and tidy the kitchen",
@@ -385,12 +385,12 @@ def test_template_management_endpoints(client: TestClient, db_session: Session) 
         assert create_routine.status_code == 201
         routine_id = create_routine.json()["id"]
 
-        list_routines = client.get("/api/v1/routines")
+        list_routines = client.get("/api/v1/templates/routines")
         assert list_routines.status_code == 200
         assert len(list_routines.json()) == 1
 
         update_routine = client.put(
-            f"/api/v1/routines/{routine_id}",
+            f"/api/v1/templates/routines/{routine_id}",
             json={
                 "name": "Morning reset",
                 "description": "Open windows and clear counters",
@@ -405,7 +405,7 @@ def test_template_management_endpoints(client: TestClient, db_session: Session) 
         assert update_routine.json()["every_n_days"] == 2
 
         create_chore = client.post(
-            "/api/v1/chore-templates",
+            "/api/v1/templates/chores",
             json={
                 "name": "Laundry",
                 "description": "Wash towels",
@@ -417,12 +417,12 @@ def test_template_management_endpoints(client: TestClient, db_session: Session) 
         assert create_chore.status_code == 201
         chore_id = create_chore.json()["id"]
 
-        list_chores = client.get("/api/v1/chore-templates")
+        list_chores = client.get("/api/v1/templates/chores")
         assert list_chores.status_code == 200
         assert len(list_chores.json()) == 1
 
         update_chore = client.put(
-            f"/api/v1/chore-templates/{chore_id}",
+            f"/api/v1/templates/chores/{chore_id}",
             json={
                 "name": "Laundry",
                 "description": "Wash towels and bedding",
@@ -434,10 +434,10 @@ def test_template_management_endpoints(client: TestClient, db_session: Session) 
         assert update_chore.status_code == 200
         assert update_chore.json()["every_n_days"] == 14
 
-        delete_routine = client.delete(f"/api/v1/routines/{routine_id}")
+        delete_routine = client.delete(f"/api/v1/templates/routines/{routine_id}")
         assert delete_routine.status_code == 204
 
-        delete_chore = client.delete(f"/api/v1/chore-templates/{chore_id}")
+        delete_chore = client.delete(f"/api/v1/templates/chores/{chore_id}")
         assert delete_chore.status_code == 204
     finally:
         _clear_auth()

--- a/backend/tests/test_today_route_integration.py
+++ b/backend/tests/test_today_route_integration.py
@@ -6,6 +6,7 @@ from sqlalchemy.orm import Session
 
 from app.api.dependencies.auth import get_current_user
 from app.api.dependencies.today import get_today_service
+from app.api.routes import calendar as calendar_routes
 from app.core.config import settings
 from app.core.enums import ChoreStatus, MedicationDoseStatus, TaskStatus
 from app.main import app
@@ -13,10 +14,12 @@ from app.models.chore_instance import ChoreInstance
 from app.models.chore_template import ChoreTemplate
 from app.models.medication_dose_instance import MedicationDoseInstance
 from app.models.medication_plan import MedicationPlan
+from app.models.planned_item import PlannedItem
 from app.models.routine_template import RoutineTemplate
 from app.models.task_instance import TaskInstance
 from app.models.user import User
 from app.repositories.today_repository import TodayRepository
+from app.schemas.integrations import HACalendarEvent
 from app.schemas.today import TodayResponse
 from app.services.today_service import TodayService
 
@@ -95,6 +98,126 @@ def test_get_today_includes_generated_chore_sections(client: TestClient, db_sess
     assert payload["medication"][0]["instructions"] == "Take with breakfast and water"
     assert payload["routines"][0]["title"] == "Morning reset"
     assert payload["routines"][0]["status"] == "pending"
+
+
+def test_chore_generation_falls_back_for_invalid_rrule(db_session: Session) -> None:
+    user = _create_user(db_session, email="invalid-rrule@example.com")
+    template = ChoreTemplate(
+        user_id=user.id,
+        name="Fallback chore",
+        description=None,
+        start_date=date(2026, 4, 20),
+        every_n_days=2,
+        rrule="NOT_A_VALID_RRULE",
+        is_active=True,
+    )
+    db_session.add(template)
+    db_session.commit()
+    db_session.refresh(template)
+
+    repository = TodayRepository(db_session)
+    repository.ensure_chore_instances_generated(user_id=user.id, through_date=date(2026, 4, 25))
+
+    generated_dates = [
+        item.scheduled_date
+        for item in db_session.query(ChoreInstance)
+        .filter(ChoreInstance.chore_template_id == template.id)
+        .order_by(ChoreInstance.scheduled_date)
+        .all()
+    ]
+    assert generated_dates == [date(2026, 4, 20), date(2026, 4, 22), date(2026, 4, 24)]
+
+
+def test_chore_generation_does_not_fallback_for_exhausted_rrule(db_session: Session) -> None:
+    user = _create_user(db_session, email="exhausted-rrule@example.com")
+    template = ChoreTemplate(
+        user_id=user.id,
+        name="One-time chore",
+        description=None,
+        start_date=date(2026, 4, 20),
+        every_n_days=1,
+        rrule="FREQ=DAILY;COUNT=1",
+        is_active=True,
+    )
+    db_session.add(template)
+    db_session.commit()
+    db_session.refresh(template)
+
+    repository = TodayRepository(db_session)
+    repository.ensure_chore_instances_generated(user_id=user.id, through_date=date(2026, 4, 25))
+    repository.ensure_chore_instances_generated(user_id=user.id, through_date=date(2026, 4, 30))
+
+    generated_dates = [
+        item.scheduled_date
+        for item in db_session.query(ChoreInstance)
+        .filter(ChoreInstance.chore_template_id == template.id)
+        .order_by(ChoreInstance.scheduled_date)
+        .all()
+    ]
+    assert generated_dates == [date(2026, 4, 20)]
+
+
+def test_routine_generation_falls_back_for_invalid_rrule(db_session: Session) -> None:
+    user = _create_user(db_session, email="invalid-routine-rrule@example.com")
+    template = RoutineTemplate(
+        user_id=user.id,
+        name="Fallback routine",
+        description=None,
+        start_date=date(2026, 4, 20),
+        every_n_days=2,
+        rrule="NOT_A_VALID_RRULE",
+        due_time=time(7, 30),
+        is_active=True,
+    )
+    db_session.add(template)
+    db_session.commit()
+    db_session.refresh(template)
+
+    repository = TodayRepository(db_session)
+    repository.ensure_task_instances_generated(user_id=user.id, through_date=date(2026, 4, 25))
+
+    generated = (
+        db_session.query(TaskInstance)
+        .filter(TaskInstance.routine_template_id == template.id)
+        .order_by(TaskInstance.scheduled_date)
+        .all()
+    )
+    assert [item.scheduled_date for item in generated] == [date(2026, 4, 20), date(2026, 4, 22), date(2026, 4, 24)]
+    assert [item.due_at for item in generated] == [
+        datetime(2026, 4, 20, 7, 30),
+        datetime(2026, 4, 22, 7, 30),
+        datetime(2026, 4, 24, 7, 30),
+    ]
+
+
+def test_routine_generation_does_not_fallback_for_exhausted_rrule(db_session: Session) -> None:
+    user = _create_user(db_session, email="exhausted-routine-rrule@example.com")
+    template = RoutineTemplate(
+        user_id=user.id,
+        name="One-time routine",
+        description=None,
+        start_date=date(2026, 4, 20),
+        every_n_days=1,
+        rrule="FREQ=DAILY;COUNT=1",
+        due_time=time(8, 0),
+        is_active=True,
+    )
+    db_session.add(template)
+    db_session.commit()
+    db_session.refresh(template)
+
+    repository = TodayRepository(db_session)
+    repository.ensure_task_instances_generated(user_id=user.id, through_date=date(2026, 4, 25))
+    repository.ensure_task_instances_generated(user_id=user.id, through_date=date(2026, 4, 30))
+
+    generated = (
+        db_session.query(TaskInstance)
+        .filter(TaskInstance.routine_template_id == template.id)
+        .order_by(TaskInstance.scheduled_date)
+        .all()
+    )
+    assert [item.scheduled_date for item in generated] == [date(2026, 4, 20)]
+    assert generated[0].due_at == datetime(2026, 4, 20, 8, 0)
 
 
 def test_get_today_allows_today_service_dependency_override(client: TestClient, db_session: Session) -> None:
@@ -305,6 +428,141 @@ def test_calendar_and_planned_endpoints(client: TestClient, db_session: Session)
         _clear_auth()
 
 
+def test_ical_timed_events_are_formatted_as_utc() -> None:
+    event_lines = calendar_routes._format_event(
+        uid="event-1",
+        dtstamp="20260420T000000Z",
+        summary="Offset event",
+        start={"dateTime": "2026-04-20T09:00:00+02:00"},
+        end={"dateTime": "2026-04-20T10:00:00+02:00"},
+        description=None,
+        reminder_minutes=None,
+    )
+
+    assert "DTSTART:20260420T070000Z" in event_lines
+    assert "DTEND:20260420T080000Z" in event_lines
+
+
+def test_ical_export_window_uses_user_timezone(
+    client: TestClient,
+    db_session: Session,
+    monkeypatch,
+) -> None:
+    user = _create_user(db_session, email="ical-window@example.com")
+    user.calendar_token = "calendar-token"
+    user.timezone = "Pacific/Kiritimati"
+    db_session.commit()
+
+    captured: dict[str, date] = {}
+
+    class StubCalendarService:
+        def get_calendar_events(self, user_id: int, start_date: date, end_date: date) -> list[HACalendarEvent]:
+            assert user_id == user.id
+            captured["start_date"] = start_date
+            captured["end_date"] = end_date
+            return []
+
+    class FixedDatetime(datetime):
+        @classmethod
+        def now(cls, tz=None):
+            value = datetime(2026, 1, 1, 10, 0, tzinfo=timezone.utc)
+            return value.astimezone(tz) if tz else value.replace(tzinfo=None)
+
+    app.dependency_overrides[get_today_service] = lambda: StubCalendarService()
+    monkeypatch.setattr(calendar_routes, "datetime", FixedDatetime)
+    try:
+        response = client.get("/api/v1/calendar/export.ics?token=calendar-token")
+    finally:
+        app.dependency_overrides.pop(get_today_service, None)
+
+    assert response.status_code == 200
+    assert captured["start_date"] == date(2025, 11, 3)
+    assert captured["end_date"] == date(2027, 1, 2)
+
+
+def test_bulk_mutations_commit_once_for_successful_items(
+    client: TestClient,
+    db_session: Session,
+    monkeypatch,
+) -> None:
+    user = _create_user(db_session, email="bulk@example.com")
+    _auth_as(user)
+
+    template = ChoreTemplate(
+        user_id=user.id,
+        name="Laundry",
+        description=None,
+        start_date=date(2026, 4, 23),
+        every_n_days=1,
+        is_active=True,
+    )
+    db_session.add(template)
+    db_session.commit()
+    db_session.refresh(template)
+
+    complete_instance = ChoreInstance(
+        user_id=user.id,
+        chore_template_id=template.id,
+        title=template.name,
+        scheduled_date=date(2026, 4, 23),
+        status=ChoreStatus.pending,
+    )
+    skip_instance = ChoreInstance(
+        user_id=user.id,
+        chore_template_id=template.id,
+        title=template.name,
+        scheduled_date=date(2026, 4, 24),
+        status=ChoreStatus.pending,
+    )
+    planned_item = PlannedItem(
+        user_id=user.id,
+        title="Meal prep",
+        planned_for=date(2026, 4, 25),
+        is_done=False,
+    )
+    db_session.add_all([complete_instance, skip_instance, planned_item])
+    db_session.commit()
+    db_session.refresh(complete_instance)
+    db_session.refresh(skip_instance)
+    db_session.refresh(planned_item)
+
+    commit_count = 0
+    original_commit = db_session.commit
+
+    def counted_commit() -> None:
+        nonlocal commit_count
+        commit_count += 1
+        original_commit()
+
+    monkeypatch.setattr(db_session, "commit", counted_commit)
+
+    try:
+        response = client.post(
+            "/api/v1/bulk",
+            json={
+                "mutations": [
+                    {"type": "complete_chore", "id": complete_instance.id},
+                    {"type": "skip_chore", "id": skip_instance.id},
+                    {"type": "mark_planned_done", "id": planned_item.id},
+                    {"type": "complete_chore", "id": 999999},
+                ]
+            },
+        )
+    finally:
+        _clear_auth()
+
+    assert response.status_code == 200
+    assert [item["success"] for item in response.json()["results"]] == [True, True, True, False]
+    assert commit_count == 1
+
+    db_session.refresh(complete_instance)
+    db_session.refresh(skip_instance)
+    db_session.refresh(planned_item)
+    assert complete_instance.status == ChoreStatus.completed
+    assert skip_instance.status == ChoreStatus.skipped
+    assert planned_item.is_done is True
+
+
 def test_medication_plan_update_and_delete(client: TestClient, db_session: Session) -> None:
     user = _create_user(db_session, email="med-crud@example.com")
     _auth_as(user)
@@ -411,6 +669,7 @@ def test_template_management_endpoints(client: TestClient, db_session: Session) 
                 "description": "Wash towels",
                 "start_date": "2026-04-24",
                 "every_n_days": 7,
+                "tags": ["home"],
                 "is_active": True,
             },
         )
@@ -421,6 +680,10 @@ def test_template_management_endpoints(client: TestClient, db_session: Session) 
         assert list_chores.status_code == 200
         assert len(list_chores.json()) == 1
 
+        list_chores_by_tag = client.get("/api/v1/templates/chores?tags=home,%20,%20")
+        assert list_chores_by_tag.status_code == 200
+        assert [item["id"] for item in list_chores_by_tag.json()] == [chore_id]
+
         update_chore = client.put(
             f"/api/v1/templates/chores/{chore_id}",
             json={
@@ -428,6 +691,7 @@ def test_template_management_endpoints(client: TestClient, db_session: Session) 
                 "description": "Wash towels and bedding",
                 "start_date": "2026-04-24",
                 "every_n_days": 14,
+                "tags": ["home"],
                 "is_active": True,
             },
         )

--- a/backend/tests/test_today_service.py
+++ b/backend/tests/test_today_service.py
@@ -119,6 +119,8 @@ def test_get_today_shapes_chore_sections() -> None:
             recurrence_hint="weekly",
             linked_source=None,
             linked_ref=None,
+            priority="normal",
+            tags=[],
             is_done=False,
         )
     ]
@@ -158,6 +160,8 @@ def test_get_dashboard_read_model_includes_overdue_undone_planned_items() -> Non
             recurrence_hint=None,
             linked_source=None,
             linked_ref=None,
+            priority="normal",
+            tags=[],
             is_done=False,
         )
     ]
@@ -171,6 +175,8 @@ def test_get_dashboard_read_model_includes_overdue_undone_planned_items() -> Non
             recurrence_hint=None,
             linked_source=None,
             linked_ref=None,
+            priority="normal",
+            tags=[],
             is_done=False,
         )
     ]

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -199,6 +199,7 @@ dependencies = [
     { name = "pydantic" },
     { name = "pydantic-settings" },
     { name = "pyjwt" },
+    { name = "python-dateutil" },
     { name = "sentry-sdk", extra = ["fastapi"] },
     { name = "sqlalchemy" },
     { name = "uvicorn", extra = ["standard"] },
@@ -224,6 +225,7 @@ requires-dist = [
     { name = "pydantic", specifier = "==2.13.4" },
     { name = "pydantic-settings", specifier = "==2.14.1" },
     { name = "pyjwt", specifier = "==2.12.1" },
+    { name = "python-dateutil", specifier = ">=2.9.0" },
     { name = "sentry-sdk", extras = ["fastapi"], specifier = "==2.60.0" },
     { name = "sqlalchemy", specifier = "==2.0.49" },
     { name = "uvicorn", extras = ["standard"], specifier = "==0.47.0" },
@@ -283,7 +285,9 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/7a/75/7e9cd1126a1e1f0cd67b0eda02e5221b28488d352684704a78ed505bd719/greenlet-3.4.0-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:43748988b097f9c6f09364f260741aa73c80747f63389824435c7a50bfdfd5c1", size = 285856, upload-time = "2026-04-08T15:52:45.82Z" },
     { url = "https://files.pythonhosted.org/packages/9d/c4/3e2df392e5cb199527c4d9dbcaa75c14edcc394b45040f0189f649631e3c/greenlet-3.4.0-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5566e4e2cd7a880e8c27618e3eab20f3494452d12fd5129edef7b2f7aa9a36d1", size = 610208, upload-time = "2026-04-08T16:24:39.674Z" },
     { url = "https://files.pythonhosted.org/packages/da/af/750cdfda1d1bd30a6c28080245be8d0346e669a98fdbae7f4102aa95fff3/greenlet-3.4.0-cp313-cp313-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:1054c5a3c78e2ab599d452f23f7adafef55062a783a8e241d24f3b633ba6ff82", size = 621269, upload-time = "2026-04-08T16:30:59.767Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/93/c8c508d68ba93232784bbc1b5474d92371f2897dfc6bc281b419f2e0d492/greenlet-3.4.0-cp313-cp313-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:98eedd1803353daf1cd9ef23eef23eda5a4d22f99b1f998d273a8b78b70dd47f", size = 628455, upload-time = "2026-04-08T16:40:40.698Z" },
     { url = "https://files.pythonhosted.org/packages/54/78/0cbc693622cd54ebe25207efbb3a0eb07c2639cb8594f6e3aaaa0bb077a8/greenlet-3.4.0-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f82cb6cddc27dd81c96b1506f4aa7def15070c3b2a67d4e46fd19016aacce6cf", size = 617549, upload-time = "2026-04-08T15:56:34.893Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/46/cfaaa0ade435a60550fd83d07dfd5c41f873a01da17ede5c4cade0b9bab8/greenlet-3.4.0-cp313-cp313-manylinux_2_39_riscv64.whl", hash = "sha256:b7857e2202aae67bc5725e0c1f6403c20a8ff46094ece015e7d474f5f7020b55", size = 426238, upload-time = "2026-04-08T16:43:06.865Z" },
     { url = "https://files.pythonhosted.org/packages/ba/c0/8966767de01343c1ff47e8b855dc78e7d1a8ed2b7b9c83576a57e289f81d/greenlet-3.4.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:227a46251ecba4ff46ae742bc5ce95c91d5aceb4b02f885487aff269c127a729", size = 1575310, upload-time = "2026-04-08T16:26:21.671Z" },
     { url = "https://files.pythonhosted.org/packages/b8/38/bcdc71ba05e9a5fda87f63ffc2abcd1f15693b659346df994a48c968003d/greenlet-3.4.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:5b99e87be7eba788dd5b75ba1cde5639edffdec5f91fe0d734a249535ec3408c", size = 1640435, upload-time = "2026-04-08T15:57:32.572Z" },
     { url = "https://files.pythonhosted.org/packages/a1/c2/19b664b7173b9e4ef5f77e8cef9f14c20ec7fce7920dc1ccd7afd955d093/greenlet-3.4.0-cp313-cp313-win_amd64.whl", hash = "sha256:849f8bc17acd6295fcb5de8e46d55cc0e52381c56eaf50a2afd258e97bc65940", size = 238760, upload-time = "2026-04-08T17:04:03.878Z" },
@@ -291,7 +295,9 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/78/02/bde66806e8f169cf90b14d02c500c44cdbe02c8e224c9c67bafd1b8cadd1/greenlet-3.4.0-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:10a07aca6babdd18c16a3f4f8880acfffc2b88dfe431ad6aa5f5740759d7d75e", size = 286291, upload-time = "2026-04-08T17:09:34.307Z" },
     { url = "https://files.pythonhosted.org/packages/05/1f/39da1c336a87d47c58352fb8a78541ce63d63ae57c5b9dae1fe02801bbc2/greenlet-3.4.0-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:076e21040b3a917d3ce4ad68fb5c3c6b32f1405616c4a57aa83120979649bd3d", size = 656749, upload-time = "2026-04-08T16:24:41.721Z" },
     { url = "https://files.pythonhosted.org/packages/d3/6c/90ee29a4ee27af7aa2e2ec408799eeb69ee3fcc5abcecac6ddd07a5cd0f2/greenlet-3.4.0-cp314-cp314-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e82689eea4a237e530bb5cb41b180ef81fa2160e1f89422a67be7d90da67f615", size = 669084, upload-time = "2026-04-08T16:31:01.372Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/4a/74078d3936712cff6d3c91a930016f476ce4198d84e224fe6d81d3e02880/greenlet-3.4.0-cp314-cp314-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:06c2d3b89e0c62ba50bd7adf491b14f39da9e7e701647cb7b9ff4c99bee04b19", size = 673405, upload-time = "2026-04-08T16:40:42.527Z" },
     { url = "https://files.pythonhosted.org/packages/07/49/d4cad6e5381a50947bb973d2f6cf6592621451b09368b8c20d9b8af49c5b/greenlet-3.4.0-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4df3b0b2289ec686d3c821a5fee44259c05cfe824dd5e6e12c8e5f5df23085cf", size = 665621, upload-time = "2026-04-08T15:56:35.995Z" },
+    { url = "https://files.pythonhosted.org/packages/79/3e/df8a83ab894751bc31e1106fdfaa80ca9753222f106b04de93faaa55feb7/greenlet-3.4.0-cp314-cp314-manylinux_2_39_riscv64.whl", hash = "sha256:070b8bac2ff3b4d9e0ff36a0d19e42103331d9737e8504747cd1e659f76297bd", size = 471670, upload-time = "2026-04-08T16:43:08.512Z" },
     { url = "https://files.pythonhosted.org/packages/37/31/d1edd54f424761b5d47718822f506b435b6aab2f3f93b465441143ea5119/greenlet-3.4.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:8bff29d586ea415688f4cec96a591fcc3bf762d046a796cdadc1fdb6e7f2d5bf", size = 1622259, upload-time = "2026-04-08T16:26:23.201Z" },
     { url = "https://files.pythonhosted.org/packages/b0/c6/6d3f9cdcb21c4e12a79cb332579f1c6aa1af78eb68059c5a957c7812d95e/greenlet-3.4.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:8a569c2fb840c53c13a2b8967c63621fafbd1a0e015b9c82f408c33d626a2fda", size = 1686916, upload-time = "2026-04-08T15:57:34.282Z" },
     { url = "https://files.pythonhosted.org/packages/63/45/c1ca4a1ad975de4727e52d3ffe641ae23e1d7a8ffaa8ff7a0477e1827b92/greenlet-3.4.0-cp314-cp314-win_amd64.whl", hash = "sha256:207ba5b97ea8b0b60eb43ffcacf26969dd83726095161d676aac03ff913ee50d", size = 239821, upload-time = "2026-04-08T17:03:48.423Z" },
@@ -299,7 +305,9 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/d4/8f/18d72b629783f5e8d045a76f5325c1e938e659a9e4da79c7dcd10169a48d/greenlet-3.4.0-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:d70012e51df2dbbccfaf63a40aaf9b40c8bed37c3e3a38751c926301ce538ece", size = 294681, upload-time = "2026-04-08T15:52:35.778Z" },
     { url = "https://files.pythonhosted.org/packages/9e/ad/5fa86ec46769c4153820d58a04062285b3b9e10ba3d461ee257b68dcbf53/greenlet-3.4.0-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a58bec0751f43068cd40cff31bb3ca02ad6000b3a51ca81367af4eb5abc480c8", size = 658899, upload-time = "2026-04-08T16:24:43.32Z" },
     { url = "https://files.pythonhosted.org/packages/43/f0/4e8174ca0e87ae748c409f055a1ba161038c43cc0a5a6f1433a26ac2e5bf/greenlet-3.4.0-cp314-cp314t-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:05fa0803561028f4b2e3b490ee41216a842eaee11aed004cc343a996d9523aa2", size = 665284, upload-time = "2026-04-08T16:31:02.833Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/92/466b0d9afd44b8af623139a3599d651c7564fa4152f25f117e1ee5949ffb/greenlet-3.4.0-cp314-cp314t-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:c4cd56a9eb7a6444edbc19062f7b6fbc8f287c663b946e3171d899693b1c19fa", size = 665872, upload-time = "2026-04-08T16:40:43.912Z" },
     { url = "https://files.pythonhosted.org/packages/19/da/991cf7cd33662e2df92a1274b7eb4d61769294d38a1bba8a45f31364845e/greenlet-3.4.0-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e60d38719cb80b3ab5e85f9f1aed4960acfde09868af6762ccb27b260d68f4ed", size = 661861, upload-time = "2026-04-08T15:56:37.269Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/14/3395a7ef3e260de0325152ddfe19dffb3e49fe10873b94654352b53ad48e/greenlet-3.4.0-cp314-cp314t-manylinux_2_39_riscv64.whl", hash = "sha256:1f85f204c4d54134ae850d401fa435c89cd667d5ce9dc567571776b45941af72", size = 489237, upload-time = "2026-04-08T16:43:09.993Z" },
     { url = "https://files.pythonhosted.org/packages/36/c5/6c2c708e14db3d9caea4b459d8464f58c32047451142fe2cfd90e7458f41/greenlet-3.4.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:7f50c804733b43eded05ae694691c9aa68bca7d0a867d67d4a3f514742a2d53f", size = 1622182, upload-time = "2026-04-08T16:26:24.777Z" },
     { url = "https://files.pythonhosted.org/packages/7a/4c/50c5fed19378e11a29fabab1f6be39ea95358f4a0a07e115a51ca93385d8/greenlet-3.4.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:2d4f0635dc4aa638cda4b2f5a07ae9a2cff9280327b581a3fcb6f317b4fbc38a", size = 1685050, upload-time = "2026-04-08T15:57:36.453Z" },
     { url = "https://files.pythonhosted.org/packages/db/72/85ae954d734703ab48e622c59d4ce35d77ce840c265814af9c078cacc7aa/greenlet-3.4.0-cp314-cp314t-win_amd64.whl", hash = "sha256:1a4a48f24681300c640f143ba7c404270e1ebbbcf34331d7104a4ff40f8ea705", size = 245554, upload-time = "2026-04-08T17:03:50.044Z" },
@@ -705,6 +713,18 @@ wheels = [
 ]
 
 [[package]]
+name = "python-dateutil"
+version = "2.9.0.post0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892, upload-time = "2024-03-01T18:36:18.57Z" },
+]
+
+[[package]]
 name = "python-dotenv"
 version = "1.2.2"
 source = { registry = "https://pypi.org/simple" }
@@ -891,6 +911,15 @@ wheels = [
 [package.optional-dependencies]
 fastapi = [
     { name = "fastapi" },
+]
+
+[[package]]
+name = "six"
+version = "1.17.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Implements the backend batch and includes the stacked backend follow-up work for calendar export, analytics, data export/import, global search, and gamification streaks.

This PR covers:

- **#243** — Template CRUD REST API moved to `/api/v1/templates/routines` and `/api/v1/templates/chores` (was at `/api/v1/routines` and `/api/v1/chore-templates`)
- **#250** — Optional `rrule` field (RFC 5545 string, e.g. `FREQ=WEEKLY;BYDAY=MO,WE,FR`) on `RoutineTemplate` and `ChoreTemplate`; instance generation uses `python-dateutil` when set, falls back to `every_n_days` for backward compatibility
- **#254** — iCal calendar export endpoint with per-user calendar token
- **#274** — `GET /api/v1/users/me/settings` + `PATCH /api/v1/users/me/settings` for timezone (IANA-validated), default snooze days, medication reminder minutes, and quiet hours
- **#275** — `POST /api/v1/bulk` accepting up to 100 mutations (`complete_chore`, `skip_chore`, `mark_planned_done`); returns per-item success/error, continues past individual failures
- **#276** — Analytics and completion history summary API
- **#277** — `priority` enum (`low/normal/high/urgent`) and `tags` JSON array on `PlannedItem` and `ChoreTemplate`; `GET /api/v1/templates/chores?tags=home,health` filters by OR-match
- **#282** — `GET /api/v1/search?q=` returning results grouped by type (routine templates, chore templates, medication plans, planned items); case-insensitive match across name/title and description/notes, with per-type limit and special-char escaping _(frontend search UI remains open)_
- **#287** — Routine streaks (current + longest) added to `GET /api/v1/analytics/summary`; chore streaks were already present _(frontend badges, confetti, and Android push notifications remain open)_
- **#288** — `GET /api/v1/users/me/export` (JSON + CSV) and `POST /api/v1/users/me/import` for full data backup and cross-instance migration

Closes #243
Closes #250
Closes #254
Closes #274
Closes #275
Closes #276
Closes #277
Closes #282
Closes #287
Closes #288

## Stack

- #293: `feat/backend-batch1-274-275-277-243-250` -> `main`
- #294: `feat/254-ical-export` -> `feat/backend-batch1-274-275-277-243-250`
- #295: `feat/276-analytics-api` -> `feat/254-ical-export`
- #296: `feat/export-import-288` -> `feat/backend-batch1-274-275-277-243-250`
- #297: `feat/search-backend-282` -> `feat/export-import-288`
- #298: `feat/streaks-287` -> `feat/search-backend-282`

## Migrations

| Revision | Change |
|---|---|
| `20260521_0002` | `priority` + `tags` on `planned_items` and `chore_templates` |
| `20260521_0003` | `rrule` on `routine_templates` and `chore_templates` |
| `20260521_0004` | `default_snooze_days`, `medication_reminder_minutes`, `quiet_hours_start/end` on `users` |
| `20260521_0005` | `calendar_token` on `users` |

## Test plan

- [ ] All backend tests pass (`uv run pytest`)
- [ ] Backend lint passes (`uv run ruff check app tests`)
- [ ] Backend type-check passes (`uv run ty check app`)
- [ ] `GET /api/v1/templates/routines` and `/chores` return 200
- [ ] `POST /api/v1/templates/chores` with `priority: "urgent"` and `tags: ["home"]` persists correctly
- [ ] `PATCH /api/v1/users/me/settings` with invalid timezone returns 422
- [ ] `POST /api/v1/bulk` with mixed valid/invalid IDs returns partial success
- [ ] Template with `rrule: "FREQ=WEEKLY;BYDAY=MO,WE,FR"` generates instances only on those weekdays
- [ ] `every_n_days` templates still generate correctly (no regression)
- [ ] `GET /api/v1/calendar/export.ics` returns valid iCal
- [ ] `GET /api/v1/analytics/summary?period=week|month|year` returns summary metrics including routine streaks
- [ ] `GET /api/v1/users/me/export` returns full JSON backup; `?format=csv` returns CSV
- [ ] `POST /api/v1/users/me/import` with invalid enum value returns 422; duplicate medication name returns 409
- [ ] `GET /api/v1/search?q=vitamin` returns grouped results scoped to authenticated user
- [ ] `GET /api/v1/search?q=a` (single char) returns 422
- [ ] Run `alembic upgrade head` against a dev database