### PR TITLE
feat: add iCal calendar export endpoint

### DIFF
--- a/backend/alembic/versions/20260521_0005_calendar_token.py
+++ b/backend/alembic/versions/20260521_0005_calendar_token.py
@@ -1,0 +1,26 @@
+"""add calendar_token to users
+
+Revision ID: 20260521_0005
+Revises: 20260521_0004
+Create Date: 2026-05-21 00:00:00.000000
+"""
+
+from typing import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "20260521_0005"
+down_revision: str | None = "20260521_0004"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column("users", sa.Column("calendar_token", sa.String(64), nullable=True))
+    op.create_index("ix_users_calendar_token", "users", ["calendar_token"], unique=True)
+
+
+def downgrade() -> None:
+    op.drop_index("ix_users_calendar_token", table_name="users")
+    op.drop_column("users", "calendar_token")

--- a/backend/app/api/dependencies/auth.py
+++ b/backend/app/api/dependencies/auth.py
@@ -9,6 +9,28 @@ from app.models.user import User
 bearer_scheme = HTTPBearer(auto_error=False)
 
 
+async def get_current_user_optional(
+    request: Request,
+    credentials: HTTPAuthorizationCredentials | None = Depends(bearer_scheme),
+    db: Session = Depends(get_db),
+) -> User | None:
+    if credentials is None:
+        return None
+    try:
+        claims = await decode_oidc_token(credentials.credentials)
+    except OIDCTokenError:
+        return None
+    subject: str | None = claims.get("sub")
+    if not subject:
+        return None
+    user = get_or_create_local_user(subject, claims, db)
+    if not user.is_active:
+        return None
+    request.state.user_id = user.id
+    request.state.roles = _extract_roles(claims)
+    return user
+
+
 async def get_current_user(
     request: Request,
     credentials: HTTPAuthorizationCredentials | None = Depends(bearer_scheme),

--- a/backend/app/api/routes/analytics.py
+++ b/backend/app/api/routes/analytics.py
@@ -1,0 +1,41 @@
+from datetime import date, timedelta
+from typing import Literal
+
+from fastapi import APIRouter, Depends, Query
+from sqlalchemy.orm import Session
+
+from app.api.dependencies.auth import get_current_user
+from app.db.session import get_db
+from app.models.user import User
+from app.repositories.analytics_repository import get_chore_stats, get_medication_stats, get_planned_item_stats
+from app.schemas.analytics import AnalyticsSummaryResponse
+
+router = APIRouter(prefix="/analytics", tags=["analytics"])
+
+AnalyticsPeriod = Literal["week", "month", "year"]
+
+
+def _period_start(today: date, period: AnalyticsPeriod) -> date:
+    if period == "week":
+        return today - timedelta(days=6)
+    if period == "month":
+        return today - timedelta(days=29)
+    return today - timedelta(days=364)
+
+
+@router.get("/summary", response_model=AnalyticsSummaryResponse)
+def get_analytics_summary(
+    period: AnalyticsPeriod = Query(default="week"),
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+) -> AnalyticsSummaryResponse:
+    end_date = date.today()
+    start_date = _period_start(end_date, period)
+    return AnalyticsSummaryResponse(
+        period=period,
+        start_date=start_date,
+        end_date=end_date,
+        chores=get_chore_stats(db, current_user.id, start_date, end_date),
+        medications=get_medication_stats(db, current_user.id, start_date, end_date),
+        planned_items=get_planned_item_stats(db, current_user.id, start_date, end_date),
+    )

--- a/backend/app/api/routes/bulk.py
+++ b/backend/app/api/routes/bulk.py
@@ -11,11 +11,11 @@ router = APIRouter(tags=["bulk"])
 
 def _apply_mutation(service: TodayService, user_id: int, mutation: BulkMutationItem) -> None:
     if mutation.type == MutationType.complete_chore:
-        service.complete_chore(user_id=user_id, chore_instance_id=mutation.id)
+        service.complete_chore(user_id=user_id, chore_instance_id=mutation.id, persist=False)
     elif mutation.type == MutationType.skip_chore:
-        service.skip_chore(user_id=user_id, chore_instance_id=mutation.id)
+        service.skip_chore(user_id=user_id, chore_instance_id=mutation.id, persist=False)
     elif mutation.type == MutationType.mark_planned_done:
-        service.mark_planned_done(user_id=user_id, planned_item_id=mutation.id)
+        service.mark_planned_done(user_id=user_id, planned_item_id=mutation.id, persist=False)
 
 
 @router.post("/bulk", response_model=BulkMutationResponse)
@@ -25,12 +25,16 @@ def bulk_mutate(
     current_user: User = Depends(get_current_user),
 ) -> BulkMutationResponse:
     results: list[BulkMutationResult] = []
+    has_success = False
     for mutation in request.mutations:
         try:
             _apply_mutation(service, current_user.id, mutation)
             results.append(BulkMutationResult(type=mutation.type, id=mutation.id, success=True))
+            has_success = True
         except HTTPException as exc:
             results.append(BulkMutationResult(type=mutation.type, id=mutation.id, success=False, error=exc.detail))
         except Exception as exc:
             results.append(BulkMutationResult(type=mutation.type, id=mutation.id, success=False, error=str(exc)))
+    if has_success:
+        service.save()
     return BulkMutationResponse(results=results)

--- a/backend/app/api/routes/calendar.py
+++ b/backend/app/api/routes/calendar.py
@@ -1,5 +1,6 @@
 from datetime import date, datetime, timedelta, timezone
 from secrets import token_urlsafe
+from zoneinfo import ZoneInfo
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Response, status
 from sqlalchemy import select
@@ -51,6 +52,13 @@ def _build_ical(event_lines: list[str]) -> str:
     return "\r\n".join(_fold_line(line) for line in all_lines) + "\r\n"
 
 
+def _format_utc_ical_datetime(value: str) -> str:
+    dt = datetime.fromisoformat(value)
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt.astimezone(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+
+
 def _format_event(
     *,
     uid: str,
@@ -67,10 +75,8 @@ def _format_event(
         f"DTSTAMP:{dtstamp}",
     ]
     if "dateTime" in start:
-        dt = datetime.fromisoformat(start["dateTime"])
-        dt_end = datetime.fromisoformat(end["dateTime"])
-        lines.append(f"DTSTART:{dt.strftime('%Y%m%dT%H%M%SZ')}")
-        lines.append(f"DTEND:{dt_end.strftime('%Y%m%dT%H%M%SZ')}")
+        lines.append(f"DTSTART:{_format_utc_ical_datetime(start['dateTime'])}")
+        lines.append(f"DTEND:{_format_utc_ical_datetime(end['dateTime'])}")
     else:
         d = date.fromisoformat(start["date"])
         d_end = date.fromisoformat(end["date"])
@@ -98,10 +104,11 @@ def generate_calendar_token(
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ) -> CalendarTokenResponse:
-    current_user.calendar_token = token_urlsafe(32)
+    token = token_urlsafe(32)
+    current_user.calendar_token = token
     db.commit()
     db.refresh(current_user)
-    return CalendarTokenResponse(token=current_user.calendar_token)
+    return CalendarTokenResponse(token=token)
 
 
 @router.get("/users/me/calendar-token", response_model=CalendarTokenResponse)
@@ -150,7 +157,7 @@ async def export_ical(
 ) -> Response:
     user = _resolve_user(token, bearer_user, db)
 
-    today = date.today()
+    today = datetime.now(ZoneInfo(user.timezone)).date()
     start_date = today - timedelta(days=_EXPORT_PAST_DAYS)
     end_date = today + timedelta(days=_EXPORT_FUTURE_DAYS)
 

--- a/backend/app/api/routes/calendar.py
+++ b/backend/app/api/routes/calendar.py
@@ -1,0 +1,178 @@
+from datetime import date, datetime, timedelta, timezone
+from secrets import token_urlsafe
+
+from fastapi import APIRouter, Depends, HTTPException, Query, Response, status
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from app.api.dependencies.auth import get_current_user, get_current_user_optional
+from app.api.dependencies.today import get_today_service
+from app.db.session import get_db
+from app.models.user import User
+from app.schemas.calendar import CalendarTokenResponse
+from app.services.today_service import TodayService
+
+router = APIRouter(tags=["calendar"])
+
+_EXPORT_PAST_DAYS = 60
+_EXPORT_FUTURE_DAYS = 365
+
+
+# --- iCal formatting helpers ---
+
+def _ical_escape(text: str) -> str:
+    return text.replace("\\", "\\\\").replace(";", "\\;").replace(",", "\\,").replace("\n", "\\n")
+
+
+def _fold_line(line: str) -> str:
+    """Fold long content-lines per RFC 5545 (max 75 octets per line)."""
+    result = []
+    while len(line.encode("utf-8")) > 75:
+        n = 75
+        while len(line[:n].encode("utf-8")) > 75:
+            n -= 1
+        result.append(line[:n])
+        line = " " + line[n:]
+    result.append(line)
+    return "\r\n".join(result)
+
+
+def _build_ical(event_lines: list[str]) -> str:
+    header = [
+        "BEGIN:VCALENDAR",
+        "VERSION:2.0",
+        "PRODID:-//Daynest//Daynest Calendar//EN",
+        "CALSCALE:GREGORIAN",
+        "METHOD:PUBLISH",
+        "X-WR-CALNAME:Daynest",
+    ]
+    footer = ["END:VCALENDAR"]
+    all_lines = header + event_lines + footer
+    return "\r\n".join(_fold_line(line) for line in all_lines) + "\r\n"
+
+
+def _format_event(
+    *,
+    uid: str,
+    dtstamp: str,
+    summary: str,
+    start: dict[str, str],
+    end: dict[str, str],
+    description: str | None,
+    reminder_minutes: int | None,
+) -> list[str]:
+    lines = [
+        "BEGIN:VEVENT",
+        f"UID:{_ical_escape(uid)}",
+        f"DTSTAMP:{dtstamp}",
+    ]
+    if "dateTime" in start:
+        dt = datetime.fromisoformat(start["dateTime"])
+        dt_end = datetime.fromisoformat(end["dateTime"])
+        lines.append(f"DTSTART:{dt.strftime('%Y%m%dT%H%M%SZ')}")
+        lines.append(f"DTEND:{dt_end.strftime('%Y%m%dT%H%M%SZ')}")
+    else:
+        d = date.fromisoformat(start["date"])
+        d_end = date.fromisoformat(end["date"])
+        lines.append(f"DTSTART;VALUE=DATE:{d.strftime('%Y%m%d')}")
+        lines.append(f"DTEND;VALUE=DATE:{d_end.strftime('%Y%m%d')}")
+    lines.append(f"SUMMARY:{_ical_escape(summary)}")
+    if description:
+        lines.append(f"DESCRIPTION:{_ical_escape(description)}")
+    if reminder_minutes and reminder_minutes > 0:
+        lines += [
+            "BEGIN:VALARM",
+            "ACTION:DISPLAY",
+            f"TRIGGER:-PT{reminder_minutes}M",
+            f"DESCRIPTION:{_ical_escape(summary)}",
+            "END:VALARM",
+        ]
+    lines.append("END:VEVENT")
+    return lines
+
+
+# --- Calendar token endpoints ---
+
+@router.post("/users/me/calendar-token", response_model=CalendarTokenResponse, status_code=status.HTTP_201_CREATED)
+def generate_calendar_token(
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+) -> CalendarTokenResponse:
+    current_user.calendar_token = token_urlsafe(32)
+    db.commit()
+    db.refresh(current_user)
+    return CalendarTokenResponse(token=current_user.calendar_token)
+
+
+@router.get("/users/me/calendar-token", response_model=CalendarTokenResponse)
+def get_calendar_token(current_user: User = Depends(get_current_user)) -> CalendarTokenResponse:
+    if not current_user.calendar_token:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="No calendar token exists; POST to generate one")
+    return CalendarTokenResponse(token=current_user.calendar_token)
+
+
+@router.delete("/users/me/calendar-token", status_code=status.HTTP_204_NO_CONTENT)
+def revoke_calendar_token(
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+) -> Response:
+    current_user.calendar_token = None
+    db.commit()
+    return Response(status_code=status.HTTP_204_NO_CONTENT)
+
+
+# --- iCal export ---
+
+def _resolve_user(
+    token: str | None,
+    bearer_user: User | None,
+    db: Session,
+) -> User:
+    if bearer_user is not None:
+        return bearer_user
+    if token:
+        user = db.scalar(select(User).where(User.calendar_token == token).where(User.is_active.is_(True)))
+        if user:
+            return user
+    raise HTTPException(
+        status_code=status.HTTP_401_UNAUTHORIZED,
+        detail="Provide a Bearer token or a valid ?token= calendar token",
+        headers={"WWW-Authenticate": "Bearer"},
+    )
+
+
+@router.get("/calendar/export.ics")
+async def export_ical(
+    token: str | None = Query(default=None, description="Per-user calendar subscription token"),
+    db: Session = Depends(get_db),
+    service: TodayService = Depends(get_today_service),
+    bearer_user: User | None = Depends(get_current_user_optional),
+) -> Response:
+    user = _resolve_user(token, bearer_user, db)
+
+    today = date.today()
+    start_date = today - timedelta(days=_EXPORT_PAST_DAYS)
+    end_date = today + timedelta(days=_EXPORT_FUTURE_DAYS)
+
+    events = service.get_calendar_events(user_id=user.id, start_date=start_date, end_date=end_date)
+    reminder_minutes = user.medication_reminder_minutes
+    dtstamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+
+    event_lines: list[str] = []
+    for event in events:
+        is_medication = event.uid.startswith("daynest_medication_")
+        event_lines.extend(_format_event(
+            uid=event.uid,
+            dtstamp=dtstamp,
+            summary=event.summary,
+            start=event.start,
+            end=event.end,
+            description=event.description,
+            reminder_minutes=reminder_minutes if is_medication else None,
+        ))
+
+    return Response(
+        content=_build_ical(event_lines),
+        media_type="text/calendar; charset=utf-8",
+        headers={"Content-Disposition": 'attachment; filename="daynest.ics"'},
+    )

--- a/backend/app/api/routes/templates.py
+++ b/backend/app/api/routes/templates.py
@@ -134,7 +134,7 @@ def list_chore_templates(
     current_user: User = Depends(get_current_user),
 ) -> list[ChoreTemplateResponse]:
     repository = TodayRepository(db)
-    tag_list = [t.strip() for t in tags.split(",")] if tags else None
+    tag_list = [t.strip() for t in tags.split(",") if t.strip()] if tags else None
     return [_chore_to_response(item) for item in repository.list_chore_templates(current_user.id, tags=tag_list)]
 
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -7,6 +7,7 @@ from fastapi.middleware.trustedhost import TrustedHostMiddleware
 from app.api.routes.auth import close_http_client as close_auth_http_client
 from app.api.routes.auth import router as auth_router
 from app.api.routes.bulk import router as bulk_router
+from app.api.routes.calendar import router as calendar_router
 from app.api.routes.health import router as system_router
 from app.api.routes.integrations.clients import router as integration_clients_router
 from app.api.routes.integrations.home_assistant import router as home_assistant_router
@@ -61,6 +62,7 @@ app.include_router(today_router, prefix=settings.api_prefix)
 app.include_router(medications_router, prefix=settings.api_prefix)
 app.include_router(templates_router, prefix=f"{settings.api_prefix}/templates")
 app.include_router(bulk_router, prefix=settings.api_prefix)
+app.include_router(calendar_router, prefix=settings.api_prefix)
 if _mcp is not None:
     app.mount("/mcp", _mcp.streamable_http_app())
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -6,6 +6,7 @@ from fastapi.middleware.trustedhost import TrustedHostMiddleware
 
 from app.api.routes.auth import close_http_client as close_auth_http_client
 from app.api.routes.auth import router as auth_router
+from app.api.routes.analytics import router as analytics_router
 from app.api.routes.bulk import router as bulk_router
 from app.api.routes.calendar import router as calendar_router
 from app.api.routes.health import router as system_router
@@ -56,6 +57,7 @@ if settings.cors_allow_origins:
 app.include_router(system_router, prefix=settings.api_prefix)
 app.include_router(auth_router, prefix=settings.api_prefix)
 app.include_router(users_router, prefix=settings.api_prefix)
+app.include_router(analytics_router, prefix=settings.api_prefix)
 app.include_router(integration_clients_router, prefix=settings.api_prefix)
 app.include_router(home_assistant_router, prefix=settings.api_prefix)
 app.include_router(today_router, prefix=settings.api_prefix)

--- a/backend/app/mcp_server.py
+++ b/backend/app/mcp_server.py
@@ -27,6 +27,7 @@ from app.api.dependencies.integration_auth import (
     hash_integration_key,
 )
 from app.core.config import settings
+from app.core.enums import Priority
 from app.db.session import SessionLocal
 from app.models.integration_client import IntegrationClient
 from app.models.user import User
@@ -455,7 +456,7 @@ class DaynestMcpBackend:
                     start_date=parsed_start,
                     every_n_days=every_n_days,
                     rrule=None,
-                    priority="normal",
+                    priority=Priority.normal,
                     tags=[],
                     description=description,
                     is_active=is_active,

--- a/backend/app/models/chore_template.py
+++ b/backend/app/models/chore_template.py
@@ -7,6 +7,7 @@ import sqlalchemy as sa
 from sqlalchemy import Boolean, Date, DateTime, ForeignKey, Integer, JSON, String, Text, func
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
+from app.core.enums import Priority
 from app.db.base import Base
 
 if TYPE_CHECKING:
@@ -24,7 +25,12 @@ class ChoreTemplate(Base):
     start_date: Mapped[date] = mapped_column(Date, nullable=False)
     every_n_days: Mapped[int] = mapped_column(Integer, nullable=False, default=1, server_default="1")
     rrule: Mapped[str | None] = mapped_column(String(500), nullable=True)
-    priority: Mapped[str] = mapped_column(String(20), nullable=False, default="normal", server_default="normal")
+    priority: Mapped[Priority] = mapped_column(
+        String(20),
+        nullable=False,
+        default=Priority.normal,
+        server_default="normal",
+    )
     tags: Mapped[list] = mapped_column(JSON, nullable=False, default=list, server_default="[]")
     is_active: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True, server_default=sa.text("true"))
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False, server_default=func.now())

--- a/backend/app/models/planned_item.py
+++ b/backend/app/models/planned_item.py
@@ -7,6 +7,7 @@ import sqlalchemy as sa
 from sqlalchemy import Boolean, Date, DateTime, ForeignKey, JSON, String, Text, func
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
+from app.core.enums import Priority
 from app.db.base import Base
 
 if TYPE_CHECKING:
@@ -25,7 +26,12 @@ class PlannedItem(Base):
     linked_source: Mapped[str | None] = mapped_column(String(120), nullable=True)
     linked_ref: Mapped[str | None] = mapped_column(String(255), nullable=True)
     planned_for: Mapped[date] = mapped_column(Date, nullable=False, index=True)
-    priority: Mapped[str] = mapped_column(String(20), nullable=False, default="normal", server_default="normal")
+    priority: Mapped[Priority] = mapped_column(
+        String(20),
+        nullable=False,
+        default=Priority.normal,
+        server_default="normal",
+    )
     tags: Mapped[list] = mapped_column(JSON, nullable=False, default=list, server_default="[]")
     is_done: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False, server_default=sa.text("false"))
     completed_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)

--- a/backend/app/models/user.py
+++ b/backend/app/models/user.py
@@ -35,6 +35,7 @@ class User(Base):
     medication_reminder_minutes: Mapped[int] = mapped_column(Integer, nullable=False, default=30, server_default="30")
     quiet_hours_start: Mapped[time | None] = mapped_column(Time, nullable=True)
     quiet_hours_end: Mapped[time | None] = mapped_column(Time, nullable=True)
+    calendar_token: Mapped[str | None] = mapped_column(String(64), nullable=True, unique=True, index=True)
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False, server_default=func.now())
 
     routine_templates: Mapped[list["RoutineTemplate"]] = relationship(back_populates="user", cascade="all, delete-orphan")

--- a/backend/app/repositories/analytics_repository.py
+++ b/backend/app/repositories/analytics_repository.py
@@ -1,0 +1,207 @@
+from collections import defaultdict
+from datetime import date, timedelta
+
+from sqlalchemy import case, func, select
+from sqlalchemy.orm import Session
+
+from app.core.enums import ChoreStatus, MedicationDoseStatus
+from app.models.chore_instance import ChoreInstance
+from app.models.chore_template import ChoreTemplate
+from app.models.medication_dose_instance import MedicationDoseInstance
+from app.models.planned_item import PlannedItem
+from app.schemas.analytics import (
+    ChoreStats,
+    ChoreStreak,
+    DailyAdherence,
+    DailyCount,
+    MedicationStats,
+    PlannedItemStats,
+    SkippedChore,
+)
+
+_MIN_STREAK_LOOKBACK_DAYS = 90
+
+
+def _date_range(start: date, end: date) -> list[date]:
+    return [start + timedelta(days=i) for i in range((end - start).days + 1)]
+
+
+def _rate(numerator: int, denominator: int) -> float:
+    return round(numerator / denominator, 4) if denominator else 0.0
+
+
+def _streak_lookback_start(start_date: date, end_date: date) -> date:
+    period_days = (end_date - start_date).days + 1
+    lookback_days = max(period_days, _MIN_STREAK_LOOKBACK_DAYS)
+    return end_date - timedelta(days=lookback_days - 1)
+
+
+def get_chore_stats(db: Session, user_id: int, start_date: date, end_date: date) -> ChoreStats:
+    daily_rows = db.execute(
+        select(
+            ChoreInstance.scheduled_date,
+            func.count(ChoreInstance.id),
+            func.sum(case((ChoreInstance.status == ChoreStatus.completed, 1), else_=0)),
+        )
+        .where(ChoreInstance.user_id == user_id)
+        .where(ChoreInstance.scheduled_date >= start_date)
+        .where(ChoreInstance.scheduled_date <= end_date)
+        .group_by(ChoreInstance.scheduled_date)
+    ).all()
+
+    by_date = {row[0]: {"total": int(row[1]), "completed": int(row[2] or 0)} for row in daily_rows}
+
+    dates = _date_range(start_date, end_date)
+    daily_completions = []
+    for d in dates:
+        total = by_date.get(d, {}).get("total", 0)
+        completed = by_date.get(d, {}).get("completed", 0)
+        daily_completions.append(DailyCount(date=d, completed=completed, total=total, completion_rate=_rate(completed, total)))
+
+    total_completed = sum(day["completed"] for day in by_date.values())
+    total_scheduled = sum(day["total"] for day in by_date.values())
+    completion_rate = _rate(total_completed, total_scheduled)
+
+    streak_start_date = _streak_lookback_start(start_date, end_date)
+    templates = {
+        t.id: t.name
+        for t in db.scalars(select(ChoreTemplate).where(ChoreTemplate.user_id == user_id)).all()
+    }
+
+    all_resolved = db.scalars(
+        select(ChoreInstance)
+        .where(ChoreInstance.user_id == user_id)
+        .where(ChoreInstance.scheduled_date >= streak_start_date)
+        .where(ChoreInstance.scheduled_date <= end_date)
+        .where(ChoreInstance.status != ChoreStatus.pending)
+        .order_by(ChoreInstance.chore_template_id, ChoreInstance.scheduled_date)
+    ).all()
+
+    by_template: dict[int, list[ChoreInstance]] = defaultdict(list)
+    for inst in all_resolved:
+        by_template[inst.chore_template_id].append(inst)
+
+    streaks: list[ChoreStreak] = []
+
+    for template_id, insts in by_template.items():
+        name = templates.get(template_id, f"Chore #{template_id}")
+        sorted_insts = insts
+
+        current = 0
+        for inst in reversed(sorted_insts):
+            if inst.status == ChoreStatus.completed:
+                current += 1
+            else:
+                break
+
+        longest, run = 0, 0
+        for inst in sorted_insts:
+            if inst.status == ChoreStatus.completed:
+                run += 1
+                longest = max(longest, run)
+            else:
+                run = 0
+
+        streaks.append(ChoreStreak(
+            chore_id=template_id,
+            name=name,
+            current_streak=current,
+            longest_streak=longest,
+        ))
+
+    skipped_rows = db.execute(
+        select(ChoreInstance.chore_template_id, func.count(ChoreInstance.id))
+        .where(ChoreInstance.user_id == user_id)
+        .where(ChoreInstance.scheduled_date >= start_date)
+        .where(ChoreInstance.scheduled_date <= end_date)
+        .where(ChoreInstance.status == ChoreStatus.skipped)
+        .group_by(ChoreInstance.chore_template_id)
+    ).all()
+    most_skipped = [
+        SkippedChore(
+            chore_id=row[0],
+            name=templates.get(row[0], f"Chore #{row[0]}"),
+            skip_count=int(row[1]),
+        )
+        for row in skipped_rows
+    ]
+
+    streaks.sort(key=lambda x: x.current_streak, reverse=True)
+    most_skipped.sort(key=lambda x: x.skip_count, reverse=True)
+
+    return ChoreStats(
+        completion_rate=round(completion_rate, 4),
+        total_completed=total_completed,
+        total_scheduled=total_scheduled,
+        daily_completions=daily_completions,
+        streaks=streaks,
+        most_skipped=most_skipped,
+    )
+
+
+def get_medication_stats(db: Session, user_id: int, start_date: date, end_date: date) -> MedicationStats:
+    daily_rows = db.execute(
+        select(
+            MedicationDoseInstance.scheduled_date,
+            func.count(MedicationDoseInstance.id),
+            func.sum(case((MedicationDoseInstance.status == MedicationDoseStatus.taken, 1), else_=0)),
+        )
+        .where(MedicationDoseInstance.user_id == user_id)
+        .where(MedicationDoseInstance.scheduled_date >= start_date)
+        .where(MedicationDoseInstance.scheduled_date <= end_date)
+        .group_by(MedicationDoseInstance.scheduled_date)
+    ).all()
+
+    by_date = {row[0]: {"total": int(row[1]), "taken": int(row[2] or 0)} for row in daily_rows}
+
+    dates = _date_range(start_date, end_date)
+    daily_adherence = []
+    for d in dates:
+        total = by_date.get(d, {}).get("total", 0)
+        taken = by_date.get(d, {}).get("taken", 0)
+        daily_adherence.append(DailyAdherence(date=d, taken=taken, total=total, adherence_rate=_rate(taken, total)))
+
+    total_taken = sum(day["taken"] for day in by_date.values())
+    total_scheduled = sum(day["total"] for day in by_date.values())
+    adherence_rate = _rate(total_taken, total_scheduled)
+
+    return MedicationStats(
+        adherence_rate=round(adherence_rate, 4),
+        total_taken=total_taken,
+        total_scheduled=total_scheduled,
+        daily_adherence=daily_adherence,
+    )
+
+
+def get_planned_item_stats(db: Session, user_id: int, start_date: date, end_date: date) -> PlannedItemStats:
+    daily_rows = db.execute(
+        select(
+            PlannedItem.planned_for,
+            func.count(PlannedItem.id),
+            func.sum(case((PlannedItem.is_done.is_(True), 1), else_=0)),
+        )
+        .where(PlannedItem.user_id == user_id)
+        .where(PlannedItem.planned_for >= start_date)
+        .where(PlannedItem.planned_for <= end_date)
+        .group_by(PlannedItem.planned_for)
+    ).all()
+
+    by_date = {row[0]: {"total": int(row[1]), "completed": int(row[2] or 0)} for row in daily_rows}
+
+    dates = _date_range(start_date, end_date)
+    daily_completions = []
+    for d in dates:
+        total = by_date.get(d, {}).get("total", 0)
+        completed = by_date.get(d, {}).get("completed", 0)
+        daily_completions.append(DailyCount(date=d, completed=completed, total=total, completion_rate=_rate(completed, total)))
+
+    total_completed = sum(day["completed"] for day in by_date.values())
+    total_scheduled = sum(day["total"] for day in by_date.values())
+    completion_rate = _rate(total_completed, total_scheduled)
+
+    return PlannedItemStats(
+        completion_rate=round(completion_rate, 4),
+        total_completed=total_completed,
+        total_scheduled=total_scheduled,
+        daily_completions=daily_completions,
+    )

--- a/backend/app/repositories/today_repository.py
+++ b/backend/app/repositories/today_repository.py
@@ -11,7 +11,7 @@ from sqlalchemy import and_, func, insert, select, update
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.orm import Session
 
-from app.core.enums import ChoreStatus, MedicationDoseStatus, TaskStatus
+from app.core.enums import ChoreStatus, MedicationDoseStatus, Priority, TaskStatus
 from app.models.user import User
 from app.models.chore_instance import ChoreInstance
 from app.models.chore_template import ChoreTemplate
@@ -52,23 +52,28 @@ class TodayRepository:
 
             last = last_generated_map.get(template.id)
 
+            rrule_generated = False
+            rrule_failed = False
             if template.rrule and _DATEUTIL_AVAILABLE:
-                dtstart = datetime.combine(template.start_date, time.min)
-                rule = _rrulestr(template.rrule, dtstart=dtstart, ignoretz=True)
-                for dt in rule:
-                    d = dt.date()
-                    if d > through_date:
-                        break
-                    if last is not None and d <= last:
-                        continue
-                    rows.append({
-                        "user_id": user_id,
-                        "chore_template_id": template.id,
-                        "title": template.name,
-                        "scheduled_date": d,
-                        "status": ChoreStatus.pending,
-                    })
-            else:
+                try:
+                    dtstart = datetime.combine(template.start_date, time.min)
+                    rule = _rrulestr(template.rrule, dtstart=dtstart, ignoretz=True)
+                    start_search = datetime.combine(last, time.max) if last else dtstart - timedelta(seconds=1)
+                    occurrences = rule.between(start_search, datetime.combine(through_date, time.max), inc=False)
+                except Exception:
+                    rrule_failed = True
+                else:
+                    rrule_generated = True
+                    for dt in occurrences:
+                        rows.append({
+                            "user_id": user_id,
+                            "chore_template_id": template.id,
+                            "title": template.name,
+                            "scheduled_date": dt.date(),
+                            "status": ChoreStatus.pending,
+                        })
+
+            if not template.rrule or not _DATEUTIL_AVAILABLE or rrule_failed:
                 step = max(template.every_n_days, 1)
                 cursor = template.start_date if last is None else date.fromordinal(last.toordinal() + step)
                 while cursor <= through_date:
@@ -80,6 +85,8 @@ class TodayRepository:
                         "status": ChoreStatus.pending,
                     })
                     cursor = date.fromordinal(cursor.toordinal() + step)
+            elif rrule_generated:
+                continue
 
         if rows:
             dialect_name = self.db.connection().dialect.name
@@ -218,25 +225,31 @@ class TodayRepository:
 
             last = last_generated_map.get(template.id)
 
+            rrule_generated = False
+            rrule_failed = False
             if template.rrule and _DATEUTIL_AVAILABLE:
-                dtstart = datetime.combine(template.start_date, time.min)
-                rule = _rrulestr(template.rrule, dtstart=dtstart, ignoretz=True)
-                for dt in rule:
-                    cursor = dt.date()
-                    if cursor > through_date:
-                        break
-                    if last is not None and cursor <= last:
-                        continue
-                    due_at = datetime.combine(cursor, template.due_time, tzinfo=timezone.utc) if template.due_time else None
-                    rows.append({
-                        "user_id": user_id,
-                        "routine_template_id": template.id,
-                        "title": template.name,
-                        "scheduled_date": cursor,
-                        "due_at": due_at,
-                        "status": TaskStatus.pending,
-                    })
-            else:
+                try:
+                    dtstart = datetime.combine(template.start_date, time.min)
+                    rule = _rrulestr(template.rrule, dtstart=dtstart, ignoretz=True)
+                    start_search = datetime.combine(last, time.max) if last else dtstart - timedelta(seconds=1)
+                    occurrences = rule.between(start_search, datetime.combine(through_date, time.max), inc=False)
+                except Exception:
+                    rrule_failed = True
+                else:
+                    rrule_generated = True
+                    for dt in occurrences:
+                        cursor = dt.date()
+                        due_at = datetime.combine(cursor, template.due_time, tzinfo=timezone.utc) if template.due_time else None
+                        rows.append({
+                            "user_id": user_id,
+                            "routine_template_id": template.id,
+                            "title": template.name,
+                            "scheduled_date": cursor,
+                            "due_at": due_at,
+                            "status": TaskStatus.pending,
+                        })
+
+            if not template.rrule or not _DATEUTIL_AVAILABLE or rrule_failed:
                 step = max(template.every_n_days, 1)
                 cursor = template.start_date if last is None else date.fromordinal(last.toordinal() + step)
                 while cursor <= through_date:
@@ -250,6 +263,8 @@ class TodayRepository:
                         "status": TaskStatus.pending,
                     })
                     cursor = date.fromordinal(cursor.toordinal() + step)
+            elif rrule_generated:
+                continue
 
         if rows:
             dialect_name = self.db.connection().dialect.name
@@ -323,7 +338,7 @@ class TodayRepository:
         start_date: date,
         every_n_days: int,
         rrule: str | None,
-        priority: str,
+        priority: Priority,
         tags: list,
         is_active: bool,
     ) -> ChoreTemplate:

--- a/backend/app/schemas/analytics.py
+++ b/backend/app/schemas/analytics.py
@@ -1,0 +1,63 @@
+from datetime import date
+from typing import Literal
+
+from pydantic import BaseModel
+
+
+class DailyCount(BaseModel):
+    date: date
+    completed: int
+    total: int
+    completion_rate: float
+
+
+class ChoreStreak(BaseModel):
+    chore_id: int
+    name: str
+    current_streak: int
+    longest_streak: int
+
+
+class SkippedChore(BaseModel):
+    chore_id: int
+    name: str
+    skip_count: int
+
+
+class ChoreStats(BaseModel):
+    completion_rate: float
+    total_completed: int
+    total_scheduled: int
+    daily_completions: list[DailyCount]
+    streaks: list[ChoreStreak]
+    most_skipped: list[SkippedChore]
+
+
+class DailyAdherence(BaseModel):
+    date: date
+    taken: int
+    total: int
+    adherence_rate: float
+
+
+class MedicationStats(BaseModel):
+    adherence_rate: float
+    total_taken: int
+    total_scheduled: int
+    daily_adherence: list[DailyAdherence]
+
+
+class PlannedItemStats(BaseModel):
+    completion_rate: float
+    total_completed: int
+    total_scheduled: int
+    daily_completions: list[DailyCount]
+
+
+class AnalyticsSummaryResponse(BaseModel):
+    period: Literal["week", "month", "year"]
+    start_date: date
+    end_date: date
+    chores: ChoreStats
+    medications: MedicationStats
+    planned_items: PlannedItemStats

--- a/backend/app/schemas/calendar.py
+++ b/backend/app/schemas/calendar.py
@@ -1,0 +1,5 @@
+from pydantic import BaseModel
+
+
+class CalendarTokenResponse(BaseModel):
+    token: str

--- a/backend/app/services/today_service.py
+++ b/backend/app/services/today_service.py
@@ -10,13 +10,6 @@ from fastapi import HTTPException, status
 
 from app.core.config import AppSettings
 from app.core.enums import ChoreStatus, MedicationDoseStatus, Priority, TaskStatus
-
-_PRIORITY_RANK: dict[str, int] = {
-    Priority.urgent: 0,
-    Priority.high: 1,
-    Priority.normal: 2,
-    Priority.low: 3,
-}
 from app.models.chore_instance import ChoreInstance
 from app.models.chore_template import ChoreTemplate
 from app.models.medication_dose_instance import MedicationDoseInstance
@@ -45,6 +38,13 @@ from app.schemas.today import (
     UnifiedDayItem,
     UpcomingTodayItem,
 )
+
+_PRIORITY_RANK: dict[str, int] = {
+    Priority.urgent: 0,
+    Priority.high: 1,
+    Priority.normal: 2,
+    Priority.low: 3,
+}
 
 logger = logging.getLogger(__name__)
 
@@ -333,7 +333,7 @@ class TodayService:
                     recurrence_hint=plan.recurrence_hint,
                     linked_source=plan.linked_source,
                     linked_ref=plan.linked_ref,
-                    priority=cast(Priority, plan.priority),
+                    priority=plan.priority,
                 )
             )
 
@@ -491,23 +491,28 @@ class TodayService:
             for item in self.repository.list_planned_items(user_id=user_id, start_date=start_date, end_date=end_date, tags=tags)
         ]
 
-    def mark_planned_done(self, user_id: int, planned_item_id: int) -> None:
+    def save(self) -> None:
+        self.repository.save()
+
+    def mark_planned_done(self, user_id: int, planned_item_id: int, *, persist: bool = True) -> None:
         item = self._get_user_planned_item(user_id=user_id, planned_item_id=planned_item_id)
         if not item.is_done:
             item.is_done = True
             item.completed_at = self.repository.utcnow()
-            self.repository.save()
+            if persist:
+                self.repository.save()
 
     def delete_planned_item(self, user_id: int, planned_item_id: int) -> None:
         item = self._get_user_planned_item(user_id=user_id, planned_item_id=planned_item_id)
         self.repository.delete_planned_item(item)
 
-    def complete_chore(self, user_id: int, chore_instance_id: int) -> ChoreInstanceMutationResponse:
+    def complete_chore(self, user_id: int, chore_instance_id: int, *, persist: bool = True) -> ChoreInstanceMutationResponse:
         instance = self._get_user_chore(user_id, chore_instance_id)
         instance.status = ChoreStatus.completed
         instance.completed_at = self.repository.utcnow()
         instance.skipped_at = None
-        self.repository.save()
+        if persist:
+            self.repository.save()
         return ChoreInstanceMutationResponse(
             chore_instance_id=instance.id,
             status=instance.status,
@@ -548,12 +553,13 @@ class TodayService:
         self.repository.save()
         return self._task_instance_to_response(instance)
 
-    def skip_chore(self, user_id: int, chore_instance_id: int) -> ChoreInstanceMutationResponse:
+    def skip_chore(self, user_id: int, chore_instance_id: int, *, persist: bool = True) -> ChoreInstanceMutationResponse:
         instance = self._get_user_chore(user_id, chore_instance_id)
         instance.status = ChoreStatus.skipped
         instance.skipped_at = self.repository.utcnow()
         instance.completed_at = None
-        self.repository.save()
+        if persist:
+            self.repository.save()
         return ChoreInstanceMutationResponse(
             chore_instance_id=instance.id,
             status=instance.status,
@@ -721,7 +727,7 @@ class TodayService:
         start_date: date,
         every_n_days: int | None,
         rrule: str | None,
-        priority: str,
+        priority: Priority,
         tags: list,
         description: str | None,
         is_active: bool | None,

--- a/backend/tests/test_analytics_api.py
+++ b/backend/tests/test_analytics_api.py
@@ -1,0 +1,233 @@
+from datetime import date, datetime, time, timedelta, timezone
+
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+from app.api.dependencies.auth import get_current_user
+from app.core.enums import ChoreStatus, MedicationDoseStatus
+from app.main import app
+from app.models.chore_instance import ChoreInstance
+from app.models.chore_template import ChoreTemplate
+from app.models.medication_dose_instance import MedicationDoseInstance
+from app.models.medication_plan import MedicationPlan
+from app.models.planned_item import PlannedItem
+from app.models.user import User
+
+
+def _create_user(db_session: Session, email: str) -> User:
+    user = User(email=email, full_name="Test User", is_active=True)
+    db_session.add(user)
+    db_session.commit()
+    db_session.refresh(user)
+    return user
+
+
+def _auth_as(user: User) -> None:
+    async def _dep() -> User:
+        return user
+
+    app.dependency_overrides[get_current_user] = _dep
+
+
+def _clear_auth() -> None:
+    app.dependency_overrides.pop(get_current_user, None)
+
+
+def _add_chore(
+    db_session: Session,
+    user: User,
+    template: ChoreTemplate,
+    scheduled_date: date,
+    status: ChoreStatus,
+) -> None:
+    db_session.add(
+        ChoreInstance(
+            user_id=user.id,
+            chore_template_id=template.id,
+            title=template.name,
+            scheduled_date=scheduled_date,
+            status=status,
+            completed_at=datetime.now(timezone.utc) if status == ChoreStatus.completed else None,
+            skipped_at=datetime.now(timezone.utc) if status == ChoreStatus.skipped else None,
+        )
+    )
+
+
+def _add_medication_dose(
+    db_session: Session,
+    user: User,
+    plan: MedicationPlan,
+    scheduled_date: date,
+    status: MedicationDoseStatus,
+) -> None:
+    scheduled_at = datetime.combine(scheduled_date, plan.schedule_time, tzinfo=timezone.utc)
+    db_session.add(
+        MedicationDoseInstance(
+            user_id=user.id,
+            medication_plan_id=plan.id,
+            name=plan.name,
+            instructions=plan.instructions,
+            scheduled_date=scheduled_date,
+            scheduled_at=scheduled_at,
+            status=status,
+            taken_at=datetime.now(timezone.utc) if status == MedicationDoseStatus.taken else None,
+            skipped_at=datetime.now(timezone.utc) if status == MedicationDoseStatus.skipped else None,
+            missed_at=datetime.now(timezone.utc) if status == MedicationDoseStatus.missed else None,
+        )
+    )
+
+
+def test_analytics_summary_requires_authentication(client: TestClient) -> None:
+    response = client.get("/api/v1/analytics/summary")
+    assert response.status_code == 401
+
+
+def test_analytics_summary_rejects_unknown_period(client: TestClient, db_session: Session) -> None:
+    user = _create_user(db_session, email="analytics-period@example.com")
+    _auth_as(user)
+    try:
+        response = client.get("/api/v1/analytics/summary?period=quarter")
+    finally:
+        _clear_auth()
+
+    assert response.status_code == 422
+
+
+def test_analytics_summary_aggregates_user_history(client: TestClient, db_session: Session) -> None:
+    user = _create_user(db_session, email="analytics@example.com")
+    other_user = _create_user(db_session, email="analytics-other@example.com")
+    today = date.today()
+
+    chore_template = ChoreTemplate(
+        user_id=user.id,
+        name="Laundry",
+        description=None,
+        start_date=today,
+        every_n_days=1,
+        is_active=True,
+    )
+    other_chore_template = ChoreTemplate(
+        user_id=other_user.id,
+        name="Other laundry",
+        description=None,
+        start_date=today,
+        every_n_days=1,
+        is_active=True,
+    )
+    medication_plan = MedicationPlan(
+        user_id=user.id,
+        name="Vitamin D",
+        instructions="Take with breakfast",
+        start_date=today,
+        schedule_time=time(9, 0),
+        every_n_days=1,
+        is_active=True,
+    )
+    db_session.add_all([chore_template, other_chore_template, medication_plan])
+    db_session.commit()
+    db_session.refresh(chore_template)
+    db_session.refresh(other_chore_template)
+    db_session.refresh(medication_plan)
+
+    _add_chore(db_session, user, chore_template, today, ChoreStatus.completed)
+    _add_chore(db_session, user, chore_template, today - timedelta(days=1), ChoreStatus.skipped)
+    _add_chore(db_session, user, chore_template, today - timedelta(days=4), ChoreStatus.completed)
+    _add_chore(db_session, user, chore_template, today - timedelta(days=5), ChoreStatus.completed)
+    _add_chore(db_session, other_user, other_chore_template, today, ChoreStatus.completed)
+
+    _add_medication_dose(db_session, user, medication_plan, today, MedicationDoseStatus.skipped)
+    _add_medication_dose(db_session, user, medication_plan, today - timedelta(days=1), MedicationDoseStatus.taken)
+    _add_medication_dose(db_session, user, medication_plan, today - timedelta(days=2), MedicationDoseStatus.missed)
+
+    db_session.add_all(
+        [
+            PlannedItem(user_id=user.id, title="Meal prep", planned_for=today, is_done=True),
+            PlannedItem(
+                user_id=user.id,
+                title="Review bills",
+                planned_for=today - timedelta(days=1),
+                is_done=False,
+            ),
+            PlannedItem(
+                user_id=user.id,
+                title="Outside window",
+                planned_for=today - timedelta(days=8),
+                is_done=True,
+            ),
+            PlannedItem(user_id=other_user.id, title="Other plan", planned_for=today, is_done=True),
+        ]
+    )
+    db_session.commit()
+
+    _auth_as(user)
+    try:
+        response = client.get("/api/v1/analytics/summary?period=week")
+    finally:
+        _clear_auth()
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["period"] == "week"
+    assert payload["start_date"] == (today - timedelta(days=6)).isoformat()
+    assert payload["end_date"] == today.isoformat()
+
+    chores = payload["chores"]
+    assert chores["completion_rate"] == 0.75
+    assert chores["total_completed"] == 3
+    assert chores["total_scheduled"] == 4
+    assert chores["streaks"] == [
+        {"chore_id": chore_template.id, "name": "Laundry", "current_streak": 1, "longest_streak": 2}
+    ]
+    assert chores["most_skipped"] == [{"chore_id": chore_template.id, "name": "Laundry", "skip_count": 1}]
+    assert len(chores["daily_completions"]) == 7
+    assert chores["daily_completions"][-1] == {
+        "date": today.isoformat(),
+        "completed": 1,
+        "total": 1,
+        "completion_rate": 1.0,
+    }
+
+    medications = payload["medications"]
+    assert medications["adherence_rate"] == 0.3333
+    assert medications["total_taken"] == 1
+    assert medications["total_scheduled"] == 3
+
+    planned_items = payload["planned_items"]
+    assert planned_items["completion_rate"] == 0.5
+    assert planned_items["total_completed"] == 1
+    assert planned_items["total_scheduled"] == 2
+
+
+def test_analytics_streaks_use_bounded_recent_history(client: TestClient, db_session: Session) -> None:
+    user = _create_user(db_session, email="analytics-streak-window@example.com")
+    today = date.today()
+
+    chore_template = ChoreTemplate(
+        user_id=user.id,
+        name="Dishes",
+        description=None,
+        start_date=today - timedelta(days=140),
+        every_n_days=1,
+        is_active=True,
+    )
+    db_session.add(chore_template)
+    db_session.commit()
+    db_session.refresh(chore_template)
+
+    for offset in range(130, 120, -1):
+        _add_chore(db_session, user, chore_template, today - timedelta(days=offset), ChoreStatus.completed)
+    _add_chore(db_session, user, chore_template, today - timedelta(days=2), ChoreStatus.completed)
+    _add_chore(db_session, user, chore_template, today - timedelta(days=1), ChoreStatus.completed)
+    _add_chore(db_session, user, chore_template, today, ChoreStatus.completed)
+    db_session.commit()
+
+    _auth_as(user)
+    try:
+        response = client.get("/api/v1/analytics/summary?period=week")
+    finally:
+        _clear_auth()
+
+    assert response.status_code == 200
+    assert response.json()["chores"]["streaks"] == [
+        {"chore_id": chore_template.id, "name": "Dishes", "current_streak": 3, "longest_streak": 3}
+    ]

--- a/backend/tests/test_today_route_integration.py
+++ b/backend/tests/test_today_route_integration.py
@@ -6,6 +6,7 @@ from sqlalchemy.orm import Session
 
 from app.api.dependencies.auth import get_current_user
 from app.api.dependencies.today import get_today_service
+from app.api.routes import calendar as calendar_routes
 from app.core.config import settings
 from app.core.enums import ChoreStatus, MedicationDoseStatus, TaskStatus
 from app.main import app
@@ -13,10 +14,12 @@ from app.models.chore_instance import ChoreInstance
 from app.models.chore_template import ChoreTemplate
 from app.models.medication_dose_instance import MedicationDoseInstance
 from app.models.medication_plan import MedicationPlan
+from app.models.planned_item import PlannedItem
 from app.models.routine_template import RoutineTemplate
 from app.models.task_instance import TaskInstance
 from app.models.user import User
 from app.repositories.today_repository import TodayRepository
+from app.schemas.integrations import HACalendarEvent
 from app.schemas.today import TodayResponse
 from app.services.today_service import TodayService
 
@@ -95,6 +98,126 @@ def test_get_today_includes_generated_chore_sections(client: TestClient, db_sess
     assert payload["medication"][0]["instructions"] == "Take with breakfast and water"
     assert payload["routines"][0]["title"] == "Morning reset"
     assert payload["routines"][0]["status"] == "pending"
+
+
+def test_chore_generation_falls_back_for_invalid_rrule(db_session: Session) -> None:
+    user = _create_user(db_session, email="invalid-rrule@example.com")
+    template = ChoreTemplate(
+        user_id=user.id,
+        name="Fallback chore",
+        description=None,
+        start_date=date(2026, 4, 20),
+        every_n_days=2,
+        rrule="NOT_A_VALID_RRULE",
+        is_active=True,
+    )
+    db_session.add(template)
+    db_session.commit()
+    db_session.refresh(template)
+
+    repository = TodayRepository(db_session)
+    repository.ensure_chore_instances_generated(user_id=user.id, through_date=date(2026, 4, 25))
+
+    generated_dates = [
+        item.scheduled_date
+        for item in db_session.query(ChoreInstance)
+        .filter(ChoreInstance.chore_template_id == template.id)
+        .order_by(ChoreInstance.scheduled_date)
+        .all()
+    ]
+    assert generated_dates == [date(2026, 4, 20), date(2026, 4, 22), date(2026, 4, 24)]
+
+
+def test_chore_generation_does_not_fallback_for_exhausted_rrule(db_session: Session) -> None:
+    user = _create_user(db_session, email="exhausted-rrule@example.com")
+    template = ChoreTemplate(
+        user_id=user.id,
+        name="One-time chore",
+        description=None,
+        start_date=date(2026, 4, 20),
+        every_n_days=1,
+        rrule="FREQ=DAILY;COUNT=1",
+        is_active=True,
+    )
+    db_session.add(template)
+    db_session.commit()
+    db_session.refresh(template)
+
+    repository = TodayRepository(db_session)
+    repository.ensure_chore_instances_generated(user_id=user.id, through_date=date(2026, 4, 25))
+    repository.ensure_chore_instances_generated(user_id=user.id, through_date=date(2026, 4, 30))
+
+    generated_dates = [
+        item.scheduled_date
+        for item in db_session.query(ChoreInstance)
+        .filter(ChoreInstance.chore_template_id == template.id)
+        .order_by(ChoreInstance.scheduled_date)
+        .all()
+    ]
+    assert generated_dates == [date(2026, 4, 20)]
+
+
+def test_routine_generation_falls_back_for_invalid_rrule(db_session: Session) -> None:
+    user = _create_user(db_session, email="invalid-routine-rrule@example.com")
+    template = RoutineTemplate(
+        user_id=user.id,
+        name="Fallback routine",
+        description=None,
+        start_date=date(2026, 4, 20),
+        every_n_days=2,
+        rrule="NOT_A_VALID_RRULE",
+        due_time=time(7, 30),
+        is_active=True,
+    )
+    db_session.add(template)
+    db_session.commit()
+    db_session.refresh(template)
+
+    repository = TodayRepository(db_session)
+    repository.ensure_task_instances_generated(user_id=user.id, through_date=date(2026, 4, 25))
+
+    generated = (
+        db_session.query(TaskInstance)
+        .filter(TaskInstance.routine_template_id == template.id)
+        .order_by(TaskInstance.scheduled_date)
+        .all()
+    )
+    assert [item.scheduled_date for item in generated] == [date(2026, 4, 20), date(2026, 4, 22), date(2026, 4, 24)]
+    assert [item.due_at for item in generated] == [
+        datetime(2026, 4, 20, 7, 30),
+        datetime(2026, 4, 22, 7, 30),
+        datetime(2026, 4, 24, 7, 30),
+    ]
+
+
+def test_routine_generation_does_not_fallback_for_exhausted_rrule(db_session: Session) -> None:
+    user = _create_user(db_session, email="exhausted-routine-rrule@example.com")
+    template = RoutineTemplate(
+        user_id=user.id,
+        name="One-time routine",
+        description=None,
+        start_date=date(2026, 4, 20),
+        every_n_days=1,
+        rrule="FREQ=DAILY;COUNT=1",
+        due_time=time(8, 0),
+        is_active=True,
+    )
+    db_session.add(template)
+    db_session.commit()
+    db_session.refresh(template)
+
+    repository = TodayRepository(db_session)
+    repository.ensure_task_instances_generated(user_id=user.id, through_date=date(2026, 4, 25))
+    repository.ensure_task_instances_generated(user_id=user.id, through_date=date(2026, 4, 30))
+
+    generated = (
+        db_session.query(TaskInstance)
+        .filter(TaskInstance.routine_template_id == template.id)
+        .order_by(TaskInstance.scheduled_date)
+        .all()
+    )
+    assert [item.scheduled_date for item in generated] == [date(2026, 4, 20)]
+    assert generated[0].due_at == datetime(2026, 4, 20, 8, 0)
 
 
 def test_get_today_allows_today_service_dependency_override(client: TestClient, db_session: Session) -> None:
@@ -305,6 +428,141 @@ def test_calendar_and_planned_endpoints(client: TestClient, db_session: Session)
         _clear_auth()
 
 
+def test_ical_timed_events_are_formatted_as_utc() -> None:
+    event_lines = calendar_routes._format_event(
+        uid="event-1",
+        dtstamp="20260420T000000Z",
+        summary="Offset event",
+        start={"dateTime": "2026-04-20T09:00:00+02:00"},
+        end={"dateTime": "2026-04-20T10:00:00+02:00"},
+        description=None,
+        reminder_minutes=None,
+    )
+
+    assert "DTSTART:20260420T070000Z" in event_lines
+    assert "DTEND:20260420T080000Z" in event_lines
+
+
+def test_ical_export_window_uses_user_timezone(
+    client: TestClient,
+    db_session: Session,
+    monkeypatch,
+) -> None:
+    user = _create_user(db_session, email="ical-window@example.com")
+    user.calendar_token = "calendar-token"
+    user.timezone = "Pacific/Kiritimati"
+    db_session.commit()
+
+    captured: dict[str, date] = {}
+
+    class StubCalendarService:
+        def get_calendar_events(self, user_id: int, start_date: date, end_date: date) -> list[HACalendarEvent]:
+            assert user_id == user.id
+            captured["start_date"] = start_date
+            captured["end_date"] = end_date
+            return []
+
+    class FixedDatetime(datetime):
+        @classmethod
+        def now(cls, tz=None):
+            value = datetime(2026, 1, 1, 10, 0, tzinfo=timezone.utc)
+            return value.astimezone(tz) if tz else value.replace(tzinfo=None)
+
+    app.dependency_overrides[get_today_service] = lambda: StubCalendarService()
+    monkeypatch.setattr(calendar_routes, "datetime", FixedDatetime)
+    try:
+        response = client.get("/api/v1/calendar/export.ics?token=calendar-token")
+    finally:
+        app.dependency_overrides.pop(get_today_service, None)
+
+    assert response.status_code == 200
+    assert captured["start_date"] == date(2025, 11, 3)
+    assert captured["end_date"] == date(2027, 1, 2)
+
+
+def test_bulk_mutations_commit_once_for_successful_items(
+    client: TestClient,
+    db_session: Session,
+    monkeypatch,
+) -> None:
+    user = _create_user(db_session, email="bulk@example.com")
+    _auth_as(user)
+
+    template = ChoreTemplate(
+        user_id=user.id,
+        name="Laundry",
+        description=None,
+        start_date=date(2026, 4, 23),
+        every_n_days=1,
+        is_active=True,
+    )
+    db_session.add(template)
+    db_session.commit()
+    db_session.refresh(template)
+
+    complete_instance = ChoreInstance(
+        user_id=user.id,
+        chore_template_id=template.id,
+        title=template.name,
+        scheduled_date=date(2026, 4, 23),
+        status=ChoreStatus.pending,
+    )
+    skip_instance = ChoreInstance(
+        user_id=user.id,
+        chore_template_id=template.id,
+        title=template.name,
+        scheduled_date=date(2026, 4, 24),
+        status=ChoreStatus.pending,
+    )
+    planned_item = PlannedItem(
+        user_id=user.id,
+        title="Meal prep",
+        planned_for=date(2026, 4, 25),
+        is_done=False,
+    )
+    db_session.add_all([complete_instance, skip_instance, planned_item])
+    db_session.commit()
+    db_session.refresh(complete_instance)
+    db_session.refresh(skip_instance)
+    db_session.refresh(planned_item)
+
+    commit_count = 0
+    original_commit = db_session.commit
+
+    def counted_commit() -> None:
+        nonlocal commit_count
+        commit_count += 1
+        original_commit()
+
+    monkeypatch.setattr(db_session, "commit", counted_commit)
+
+    try:
+        response = client.post(
+            "/api/v1/bulk",
+            json={
+                "mutations": [
+                    {"type": "complete_chore", "id": complete_instance.id},
+                    {"type": "skip_chore", "id": skip_instance.id},
+                    {"type": "mark_planned_done", "id": planned_item.id},
+                    {"type": "complete_chore", "id": 999999},
+                ]
+            },
+        )
+    finally:
+        _clear_auth()
+
+    assert response.status_code == 200
+    assert [item["success"] for item in response.json()["results"]] == [True, True, True, False]
+    assert commit_count == 1
+
+    db_session.refresh(complete_instance)
+    db_session.refresh(skip_instance)
+    db_session.refresh(planned_item)
+    assert complete_instance.status == ChoreStatus.completed
+    assert skip_instance.status == ChoreStatus.skipped
+    assert planned_item.is_done is True
+
+
 def test_medication_plan_update_and_delete(client: TestClient, db_session: Session) -> None:
     user = _create_user(db_session, email="med-crud@example.com")
     _auth_as(user)
@@ -411,6 +669,7 @@ def test_template_management_endpoints(client: TestClient, db_session: Session) 
                 "description": "Wash towels",
                 "start_date": "2026-04-24",
                 "every_n_days": 7,
+                "tags": ["home"],
                 "is_active": True,
             },
         )
@@ -421,6 +680,10 @@ def test_template_management_endpoints(client: TestClient, db_session: Session) 
         assert list_chores.status_code == 200
         assert len(list_chores.json()) == 1
 
+        list_chores_by_tag = client.get("/api/v1/templates/chores?tags=home,%20,%20")
+        assert list_chores_by_tag.status_code == 200
+        assert [item["id"] for item in list_chores_by_tag.json()] == [chore_id]
+
         update_chore = client.put(
             f"/api/v1/templates/chores/{chore_id}",
             json={
@@ -428,6 +691,7 @@ def test_template_management_endpoints(client: TestClient, db_session: Session) 
                 "description": "Wash towels and bedding",
                 "start_date": "2026-04-24",
                 "every_n_days": 14,
+                "tags": ["home"],
                 "is_active": True,
             },
         )


### PR DESCRIPTION
## Summary

Adds the #254 stack layer on top of #293.

- Adds `GET /api/v1/calendar/export.ics` for calendar subscriptions
- Adds per-user calendar tokens for unauthenticated subscription URLs
- Includes chores, medication doses, and planned items in an RFC 5545 iCal response
- Adds the calendar token migration and response schema support

## Stack

Base PR: #293
This PR: #254
Next PR: #276 analytics summary API

## Validation

Validated as part of the stacked backend branch work:

- `uv run pytest` in `backend/` passed with 106 tests

Closes #254