### PR TITLE
feat: data export/import endpoints (#288)

### DIFF
--- a/backend/app/api/routes/analytics.py
+++ b/backend/app/api/routes/analytics.py
@@ -7,7 +7,7 @@ from sqlalchemy.orm import Session
 from app.api.dependencies.auth import get_current_user
 from app.db.session import get_db
 from app.models.user import User
-from app.repositories.analytics_repository import get_chore_stats, get_medication_stats, get_planned_item_stats
+from app.repositories.analytics_repository import get_chore_stats, get_medication_stats, get_planned_item_stats, get_routine_stats
 from app.schemas.analytics import AnalyticsSummaryResponse
 
 router = APIRouter(prefix="/analytics", tags=["analytics"])
@@ -38,4 +38,5 @@ def get_analytics_summary(
         chores=get_chore_stats(db, current_user.id, start_date, end_date),
         medications=get_medication_stats(db, current_user.id, start_date, end_date),
         planned_items=get_planned_item_stats(db, current_user.id, start_date, end_date),
+        routines=get_routine_stats(db, current_user.id, start_date, end_date),
     )

--- a/backend/app/api/routes/search.py
+++ b/backend/app/api/routes/search.py
@@ -1,0 +1,175 @@
+from __future__ import annotations
+
+from datetime import date, datetime
+
+from fastapi import APIRouter, Depends, Query
+from pydantic import BaseModel
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from app.api.dependencies.auth import get_current_user
+from app.db.session import get_db
+from app.models.chore_template import ChoreTemplate
+from app.models.medication_plan import MedicationPlan
+from app.models.planned_item import PlannedItem
+from app.models.routine_template import RoutineTemplate
+from app.models.user import User
+
+router = APIRouter(prefix="/search", tags=["search"])
+
+_DEFAULT_LIMIT = 20
+_ESCAPE_CHAR = "\\"
+
+
+def _like_pattern(q: str) -> str:
+    escaped = q.replace(_ESCAPE_CHAR, _ESCAPE_CHAR * 2).replace("%", f"{_ESCAPE_CHAR}%").replace("_", f"{_ESCAPE_CHAR}_")
+    return f"%{escaped}%"
+
+
+class RoutineSearchResult(BaseModel):
+    id: int
+    name: str
+    description: str | None
+    is_active: bool
+    created_at: datetime
+
+
+class ChoreSearchResult(BaseModel):
+    id: int
+    name: str
+    description: str | None
+    priority: str
+    tags: list[str]
+    is_active: bool
+    created_at: datetime
+
+
+class MedicationSearchResult(BaseModel):
+    id: int
+    name: str
+    instructions: str
+    is_active: bool
+    created_at: datetime
+
+
+class PlannedItemSearchResult(BaseModel):
+    id: int
+    title: str
+    notes: str | None
+    planned_for: date
+    priority: str
+    tags: list[str]
+    is_done: bool
+    created_at: datetime
+
+
+class SearchResponse(BaseModel):
+    query: str
+    routine_templates: list[RoutineSearchResult]
+    chore_templates: list[ChoreSearchResult]
+    medication_plans: list[MedicationSearchResult]
+    planned_items: list[PlannedItemSearchResult]
+
+
+@router.get("", response_model=SearchResponse)
+def search(
+    q: str = Query(min_length=2, max_length=100),
+    limit: int = Query(default=_DEFAULT_LIMIT, ge=1, le=100),
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+) -> SearchResponse:
+    pattern = _like_pattern(q)
+    uid = current_user.id
+
+    routines = db.scalars(
+        select(RoutineTemplate)
+        .where(
+            RoutineTemplate.user_id == uid,
+            (RoutineTemplate.name.ilike(pattern, escape=_ESCAPE_CHAR))
+            | (RoutineTemplate.description.ilike(pattern, escape=_ESCAPE_CHAR)),
+        )
+        .order_by(RoutineTemplate.name)
+        .limit(limit)
+    ).all()
+
+    chores = db.scalars(
+        select(ChoreTemplate)
+        .where(
+            ChoreTemplate.user_id == uid,
+            (ChoreTemplate.name.ilike(pattern, escape=_ESCAPE_CHAR))
+            | (ChoreTemplate.description.ilike(pattern, escape=_ESCAPE_CHAR)),
+        )
+        .order_by(ChoreTemplate.name)
+        .limit(limit)
+    ).all()
+
+    medications = db.scalars(
+        select(MedicationPlan)
+        .where(
+            MedicationPlan.user_id == uid,
+            (MedicationPlan.name.ilike(pattern, escape=_ESCAPE_CHAR))
+            | (MedicationPlan.instructions.ilike(pattern, escape=_ESCAPE_CHAR)),
+        )
+        .order_by(MedicationPlan.name)
+        .limit(limit)
+    ).all()
+
+    planned = db.scalars(
+        select(PlannedItem)
+        .where(
+            PlannedItem.user_id == uid,
+            (PlannedItem.title.ilike(pattern, escape=_ESCAPE_CHAR))
+            | (PlannedItem.notes.ilike(pattern, escape=_ESCAPE_CHAR)),
+        )
+        .order_by(PlannedItem.planned_for.desc(), PlannedItem.title)
+        .limit(limit)
+    ).all()
+
+    return SearchResponse(
+        query=q,
+        routine_templates=[
+            RoutineSearchResult(
+                id=r.id,
+                name=r.name,
+                description=r.description,
+                is_active=r.is_active,
+                created_at=r.created_at,
+            )
+            for r in routines
+        ],
+        chore_templates=[
+            ChoreSearchResult(
+                id=c.id,
+                name=c.name,
+                description=c.description,
+                priority=c.priority,
+                tags=c.tags or [],
+                is_active=c.is_active,
+                created_at=c.created_at,
+            )
+            for c in chores
+        ],
+        medication_plans=[
+            MedicationSearchResult(
+                id=m.id,
+                name=m.name,
+                instructions=m.instructions,
+                is_active=m.is_active,
+                created_at=m.created_at,
+            )
+            for m in medications
+        ],
+        planned_items=[
+            PlannedItemSearchResult(
+                id=p.id,
+                title=p.title,
+                notes=p.notes,
+                planned_for=p.planned_for,
+                priority=p.priority,
+                tags=p.tags or [],
+                is_done=p.is_done,
+                created_at=p.created_at,
+            )
+            for p in planned
+        ],
+    )

--- a/backend/app/api/routes/users.py
+++ b/backend/app/api/routes/users.py
@@ -1,12 +1,14 @@
+from typing import Any
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Body, Depends, HTTPException, Query, Response, status
 from sqlalchemy.orm import Session
 
 from app.api.dependencies.auth import get_current_user
 from app.db.session import get_db
 from app.models.user import User
 from app.schemas.users import UserSettingsPatchRequest, UserSettingsResponse
+from app.services.export_import_service import build_user_export, import_user_export, user_export_to_csv
 
 router = APIRouter(prefix="/users", tags=["users"])
 
@@ -49,3 +51,30 @@ def update_settings(
     db.commit()
     db.refresh(current_user)
     return _to_response(current_user)
+
+
+@router.get("/me/export", response_model=None)
+def export_user_data(
+    format: str = Query(default="json", pattern="^(json|csv)$"),
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+) -> dict[str, Any] | Response:
+    payload = build_user_export(db, current_user)
+    if format == "csv":
+        return Response(
+            content=user_export_to_csv(payload),
+            media_type="text/csv",
+            headers={"Content-Disposition": 'attachment; filename="daynest-export.csv"'},
+        )
+    return payload
+
+
+@router.post("/me/import")
+def import_user_data(
+    payload: dict[str, Any] = Body(...),
+    replace: bool = Query(default=False),
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+) -> dict[str, Any]:
+    counts = import_user_export(db, current_user, payload, replace=replace)
+    return {"imported": counts}

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -9,6 +9,7 @@ from app.api.routes.auth import router as auth_router
 from app.api.routes.analytics import router as analytics_router
 from app.api.routes.bulk import router as bulk_router
 from app.api.routes.calendar import router as calendar_router
+from app.api.routes.search import router as search_router
 from app.api.routes.health import router as system_router
 from app.api.routes.integrations.clients import router as integration_clients_router
 from app.api.routes.integrations.home_assistant import router as home_assistant_router
@@ -65,6 +66,7 @@ app.include_router(medications_router, prefix=settings.api_prefix)
 app.include_router(templates_router, prefix=f"{settings.api_prefix}/templates")
 app.include_router(bulk_router, prefix=settings.api_prefix)
 app.include_router(calendar_router, prefix=settings.api_prefix)
+app.include_router(search_router, prefix=settings.api_prefix)
 if _mcp is not None:
     app.mount("/mcp", _mcp.streamable_http_app())
 

--- a/backend/app/repositories/analytics_repository.py
+++ b/backend/app/repositories/analytics_repository.py
@@ -4,11 +4,13 @@ from datetime import date, timedelta
 from sqlalchemy import case, func, select
 from sqlalchemy.orm import Session
 
-from app.core.enums import ChoreStatus, MedicationDoseStatus
+from app.core.enums import ChoreStatus, MedicationDoseStatus, TaskStatus
 from app.models.chore_instance import ChoreInstance
 from app.models.chore_template import ChoreTemplate
 from app.models.medication_dose_instance import MedicationDoseInstance
 from app.models.planned_item import PlannedItem
+from app.models.routine_template import RoutineTemplate
+from app.models.task_instance import TaskInstance
 from app.schemas.analytics import (
     ChoreStats,
     ChoreStreak,
@@ -16,6 +18,8 @@ from app.schemas.analytics import (
     DailyCount,
     MedicationStats,
     PlannedItemStats,
+    RoutineStats,
+    RoutineStreak,
     SkippedChore,
 )
 
@@ -204,4 +208,86 @@ def get_planned_item_stats(db: Session, user_id: int, start_date: date, end_date
         total_completed=total_completed,
         total_scheduled=total_scheduled,
         daily_completions=daily_completions,
+    )
+
+
+def get_routine_stats(db: Session, user_id: int, start_date: date, end_date: date) -> RoutineStats:
+    daily_rows = db.execute(
+        select(
+            TaskInstance.scheduled_date,
+            func.count(TaskInstance.id),
+            func.sum(case((TaskInstance.status == TaskStatus.completed, 1), else_=0)),
+        )
+        .where(TaskInstance.user_id == user_id)
+        .where(TaskInstance.scheduled_date >= start_date)
+        .where(TaskInstance.scheduled_date <= end_date)
+        .group_by(TaskInstance.scheduled_date)
+    ).all()
+
+    by_date = {row[0]: {"total": int(row[1]), "completed": int(row[2] or 0)} for row in daily_rows}
+
+    dates = _date_range(start_date, end_date)
+    daily_completions = []
+    for d in dates:
+        total = by_date.get(d, {}).get("total", 0)
+        completed = by_date.get(d, {}).get("completed", 0)
+        daily_completions.append(DailyCount(date=d, completed=completed, total=total, completion_rate=_rate(completed, total)))
+
+    total_completed = sum(day["completed"] for day in by_date.values())
+    total_scheduled = sum(day["total"] for day in by_date.values())
+    completion_rate = _rate(total_completed, total_scheduled)
+
+    streak_start_date = _streak_lookback_start(start_date, end_date)
+    templates = {
+        t.id: t.name
+        for t in db.scalars(select(RoutineTemplate).where(RoutineTemplate.user_id == user_id)).all()
+    }
+
+    all_resolved = db.scalars(
+        select(TaskInstance)
+        .where(TaskInstance.user_id == user_id)
+        .where(TaskInstance.scheduled_date >= streak_start_date)
+        .where(TaskInstance.scheduled_date <= end_date)
+        .where(TaskInstance.status.notin_([TaskStatus.pending, TaskStatus.in_progress]))
+        .order_by(TaskInstance.routine_template_id, TaskInstance.scheduled_date)
+    ).all()
+
+    by_template: dict[int, list[TaskInstance]] = defaultdict(list)
+    for inst in all_resolved:
+        by_template[inst.routine_template_id].append(inst)
+
+    streaks: list[RoutineStreak] = []
+    for template_id, insts in by_template.items():
+        name = templates.get(template_id, f"Routine #{template_id}")
+
+        current = 0
+        for inst in reversed(insts):
+            if inst.status == TaskStatus.completed:
+                current += 1
+            else:
+                break
+
+        longest, run = 0, 0
+        for inst in insts:
+            if inst.status == TaskStatus.completed:
+                run += 1
+                longest = max(longest, run)
+            else:
+                run = 0
+
+        streaks.append(RoutineStreak(
+            routine_id=template_id,
+            name=name,
+            current_streak=current,
+            longest_streak=longest,
+        ))
+
+    streaks.sort(key=lambda x: x.current_streak, reverse=True)
+
+    return RoutineStats(
+        completion_rate=round(completion_rate, 4),
+        total_completed=total_completed,
+        total_scheduled=total_scheduled,
+        daily_completions=daily_completions,
+        streaks=streaks,
     )

--- a/backend/app/schemas/analytics.py
+++ b/backend/app/schemas/analytics.py
@@ -54,6 +54,21 @@ class PlannedItemStats(BaseModel):
     daily_completions: list[DailyCount]
 
 
+class RoutineStreak(BaseModel):
+    routine_id: int
+    name: str
+    current_streak: int
+    longest_streak: int
+
+
+class RoutineStats(BaseModel):
+    completion_rate: float
+    total_completed: int
+    total_scheduled: int
+    daily_completions: list[DailyCount]
+    streaks: list[RoutineStreak]
+
+
 class AnalyticsSummaryResponse(BaseModel):
     period: Literal["week", "month", "year"]
     start_date: date
@@ -61,3 +76,4 @@ class AnalyticsSummaryResponse(BaseModel):
     chores: ChoreStats
     medications: MedicationStats
     planned_items: PlannedItemStats
+    routines: RoutineStats

--- a/backend/app/services/export_import_service.py
+++ b/backend/app/services/export_import_service.py
@@ -1,0 +1,473 @@
+from __future__ import annotations
+
+import csv
+import json
+from collections.abc import Iterable, Mapping
+from datetime import date, datetime, time, timezone
+from io import StringIO
+from typing import Any, NoReturn
+
+from fastapi import HTTPException, status
+from sqlalchemy import delete
+from sqlalchemy.orm import Session
+
+from app.core.enums import ChoreStatus, MedicationDoseStatus, Priority, TaskStatus
+from app.models.chore_instance import ChoreInstance
+from app.models.chore_template import ChoreTemplate
+from app.models.medication_dose_instance import MedicationDoseInstance
+from app.models.medication_plan import MedicationPlan
+from app.models.planned_item import PlannedItem
+from app.models.routine_template import RoutineTemplate
+from app.models.task_instance import TaskInstance
+from app.models.user import User
+
+EXPORT_VERSION = 1
+
+_USER_SETTING_FIELDS = (
+    "timezone",
+    "default_snooze_days",
+    "medication_reminder_minutes",
+    "quiet_hours_start",
+    "quiet_hours_end",
+)
+_ROUTINE_TEMPLATE_FIELDS = (
+    "id",
+    "name",
+    "description",
+    "start_date",
+    "every_n_days",
+    "rrule",
+    "due_time",
+    "is_active",
+    "created_at",
+)
+_CHORE_TEMPLATE_FIELDS = (
+    "id",
+    "name",
+    "description",
+    "start_date",
+    "every_n_days",
+    "rrule",
+    "priority",
+    "tags",
+    "is_active",
+    "created_at",
+)
+_MEDICATION_PLAN_FIELDS = (
+    "id",
+    "name",
+    "instructions",
+    "start_date",
+    "schedule_time",
+    "every_n_days",
+    "is_active",
+    "created_at",
+)
+_TASK_INSTANCE_FIELDS = (
+    "id",
+    "routine_template_id",
+    "title",
+    "scheduled_date",
+    "due_at",
+    "status",
+    "completed_at",
+    "created_at",
+)
+_CHORE_INSTANCE_FIELDS = (
+    "id",
+    "chore_template_id",
+    "title",
+    "scheduled_date",
+    "status",
+    "completed_at",
+    "skipped_at",
+    "created_at",
+)
+_MEDICATION_DOSE_FIELDS = (
+    "id",
+    "medication_plan_id",
+    "name",
+    "instructions",
+    "scheduled_date",
+    "scheduled_at",
+    "status",
+    "taken_at",
+    "skipped_at",
+    "missed_at",
+    "created_at",
+)
+_PLANNED_ITEM_FIELDS = (
+    "id",
+    "title",
+    "notes",
+    "module_key",
+    "recurrence_hint",
+    "linked_source",
+    "linked_ref",
+    "planned_for",
+    "priority",
+    "tags",
+    "is_done",
+    "completed_at",
+    "created_at",
+)
+
+
+def build_user_export(db: Session, user: User) -> dict[str, Any]:
+    return {
+        "version": EXPORT_VERSION,
+        "exported_at": datetime.now(timezone.utc).isoformat(),
+        "user_settings": _fields_to_dict(user, _USER_SETTING_FIELDS),
+        "routine_templates": _export_rows(
+            db.query(RoutineTemplate).filter(RoutineTemplate.user_id == user.id).order_by(RoutineTemplate.id).all(),
+            _ROUTINE_TEMPLATE_FIELDS,
+        ),
+        "chore_templates": _export_rows(
+            db.query(ChoreTemplate).filter(ChoreTemplate.user_id == user.id).order_by(ChoreTemplate.id).all(),
+            _CHORE_TEMPLATE_FIELDS,
+        ),
+        "medication_plans": _export_rows(
+            db.query(MedicationPlan).filter(MedicationPlan.user_id == user.id).order_by(MedicationPlan.id).all(),
+            _MEDICATION_PLAN_FIELDS,
+        ),
+        "task_instances": _export_rows(
+            db.query(TaskInstance).filter(TaskInstance.user_id == user.id).order_by(TaskInstance.id).all(),
+            _TASK_INSTANCE_FIELDS,
+        ),
+        "chore_instances": _export_rows(
+            db.query(ChoreInstance).filter(ChoreInstance.user_id == user.id).order_by(ChoreInstance.id).all(),
+            _CHORE_INSTANCE_FIELDS,
+        ),
+        "medication_dose_instances": _export_rows(
+            db.query(MedicationDoseInstance)
+            .filter(MedicationDoseInstance.user_id == user.id)
+            .order_by(MedicationDoseInstance.id)
+            .all(),
+            _MEDICATION_DOSE_FIELDS,
+        ),
+        "planned_items": _export_rows(
+            db.query(PlannedItem).filter(PlannedItem.user_id == user.id).order_by(PlannedItem.id).all(),
+            _PLANNED_ITEM_FIELDS,
+        ),
+    }
+
+
+def user_export_to_csv(payload: Mapping[str, Any]) -> str:
+    rows: list[dict[str, Any]] = []
+    settings = payload.get("user_settings")
+    if isinstance(settings, Mapping):
+        rows.append({"table": "user_settings", **settings})
+
+    for table in (
+        "routine_templates",
+        "chore_templates",
+        "medication_plans",
+        "task_instances",
+        "chore_instances",
+        "medication_dose_instances",
+        "planned_items",
+    ):
+        values = payload.get(table)
+        if isinstance(values, list):
+            rows.extend({"table": table, **row} for row in values if isinstance(row, Mapping))
+
+    fieldnames = ["table", *sorted({key for row in rows for key in row if key != "table"})]
+    out = StringIO()
+    writer = csv.DictWriter(out, fieldnames=fieldnames, extrasaction="ignore")
+    writer.writeheader()
+    for row in rows:
+        writer.writerow({key: _csv_value(row.get(key)) for key in fieldnames})
+    return out.getvalue()
+
+
+def import_user_export(db: Session, user: User, payload: Mapping[str, Any], *, replace: bool = False) -> dict[str, int]:
+    if payload.get("version") != EXPORT_VERSION:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=f"Unsupported export version: {payload.get('version')}",
+        )
+
+    if replace:
+        _delete_user_data(db, user.id)
+
+    settings = _mapping(payload.get("user_settings"), "user_settings")
+    for field in _USER_SETTING_FIELDS:
+        if field in settings:
+            setattr(user, field, _coerce_setting(field, settings[field]))
+
+    routine_id_map: dict[int, int] = {}
+    chore_id_map: dict[int, int] = {}
+    medication_id_map: dict[int, int] = {}
+
+    counts = {
+        "routine_templates": 0,
+        "chore_templates": 0,
+        "medication_plans": 0,
+        "task_instances": 0,
+        "chore_instances": 0,
+        "medication_dose_instances": 0,
+        "planned_items": 0,
+    }
+
+    for row in _rows(payload, "routine_templates"):
+        old_id = _int(row.get("id"), "routine_templates.id")
+        item = RoutineTemplate(
+            user_id=user.id,
+            name=_str(row.get("name"), "routine_templates.name"),
+            description=_nullable_str(row.get("description"), "routine_templates.description"),
+            start_date=_date(row.get("start_date"), "routine_templates.start_date"),
+            every_n_days=_int(row.get("every_n_days"), "routine_templates.every_n_days"),
+            rrule=_nullable_str(row.get("rrule"), "routine_templates.rrule"),
+            due_time=_nullable_time(row.get("due_time"), "routine_templates.due_time"),
+            is_active=_bool(row.get("is_active"), "routine_templates.is_active"),
+            created_at=_datetime(row.get("created_at"), "routine_templates.created_at"),
+        )
+        db.add(item)
+        db.flush()
+        routine_id_map[old_id] = item.id
+        counts["routine_templates"] += 1
+
+    for row in _rows(payload, "chore_templates"):
+        old_id = _int(row.get("id"), "chore_templates.id")
+        item = ChoreTemplate(
+            user_id=user.id,
+            name=_str(row.get("name"), "chore_templates.name"),
+            description=_nullable_str(row.get("description"), "chore_templates.description"),
+            start_date=_date(row.get("start_date"), "chore_templates.start_date"),
+            every_n_days=_int(row.get("every_n_days"), "chore_templates.every_n_days"),
+            rrule=_nullable_str(row.get("rrule"), "chore_templates.rrule"),
+            priority=Priority(_str(row.get("priority", Priority.normal.value), "chore_templates.priority")),
+            tags=_list(row.get("tags"), "chore_templates.tags"),
+            is_active=_bool(row.get("is_active"), "chore_templates.is_active"),
+            created_at=_datetime(row.get("created_at"), "chore_templates.created_at"),
+        )
+        db.add(item)
+        db.flush()
+        chore_id_map[old_id] = item.id
+        counts["chore_templates"] += 1
+
+    for row in _rows(payload, "medication_plans"):
+        old_id = _int(row.get("id"), "medication_plans.id")
+        item = MedicationPlan(
+            user_id=user.id,
+            name=_str(row.get("name"), "medication_plans.name"),
+            instructions=_str(row.get("instructions"), "medication_plans.instructions"),
+            start_date=_date(row.get("start_date"), "medication_plans.start_date"),
+            schedule_time=_time(row.get("schedule_time"), "medication_plans.schedule_time"),
+            every_n_days=_int(row.get("every_n_days"), "medication_plans.every_n_days"),
+            is_active=_bool(row.get("is_active"), "medication_plans.is_active"),
+            created_at=_datetime(row.get("created_at"), "medication_plans.created_at"),
+        )
+        db.add(item)
+        db.flush()
+        medication_id_map[old_id] = item.id
+        counts["medication_plans"] += 1
+
+    for row in _rows(payload, "task_instances"):
+        item = TaskInstance(
+            user_id=user.id,
+            routine_template_id=_mapped_id(routine_id_map, row.get("routine_template_id"), "task_instances.routine_template_id"),
+            title=_str(row.get("title"), "task_instances.title"),
+            scheduled_date=_date(row.get("scheduled_date"), "task_instances.scheduled_date"),
+            due_at=_nullable_datetime(row.get("due_at"), "task_instances.due_at"),
+            status=TaskStatus(_str(row.get("status"), "task_instances.status")),
+            completed_at=_nullable_datetime(row.get("completed_at"), "task_instances.completed_at"),
+            created_at=_datetime(row.get("created_at"), "task_instances.created_at"),
+        )
+        db.add(item)
+        counts["task_instances"] += 1
+
+    for row in _rows(payload, "chore_instances"):
+        item = ChoreInstance(
+            user_id=user.id,
+            chore_template_id=_mapped_id(chore_id_map, row.get("chore_template_id"), "chore_instances.chore_template_id"),
+            title=_str(row.get("title"), "chore_instances.title"),
+            scheduled_date=_date(row.get("scheduled_date"), "chore_instances.scheduled_date"),
+            status=ChoreStatus(_str(row.get("status"), "chore_instances.status")),
+            completed_at=_nullable_datetime(row.get("completed_at"), "chore_instances.completed_at"),
+            skipped_at=_nullable_datetime(row.get("skipped_at"), "chore_instances.skipped_at"),
+            created_at=_datetime(row.get("created_at"), "chore_instances.created_at"),
+        )
+        db.add(item)
+        counts["chore_instances"] += 1
+
+    for row in _rows(payload, "medication_dose_instances"):
+        item = MedicationDoseInstance(
+            user_id=user.id,
+            medication_plan_id=_mapped_id(
+                medication_id_map,
+                row.get("medication_plan_id"),
+                "medication_dose_instances.medication_plan_id",
+            ),
+            name=_str(row.get("name"), "medication_dose_instances.name"),
+            instructions=_str(row.get("instructions"), "medication_dose_instances.instructions"),
+            scheduled_date=_date(row.get("scheduled_date"), "medication_dose_instances.scheduled_date"),
+            scheduled_at=_datetime(row.get("scheduled_at"), "medication_dose_instances.scheduled_at"),
+            status=MedicationDoseStatus(_str(row.get("status"), "medication_dose_instances.status")),
+            taken_at=_nullable_datetime(row.get("taken_at"), "medication_dose_instances.taken_at"),
+            skipped_at=_nullable_datetime(row.get("skipped_at"), "medication_dose_instances.skipped_at"),
+            missed_at=_nullable_datetime(row.get("missed_at"), "medication_dose_instances.missed_at"),
+            created_at=_datetime(row.get("created_at"), "medication_dose_instances.created_at"),
+        )
+        db.add(item)
+        counts["medication_dose_instances"] += 1
+
+    for row in _rows(payload, "planned_items"):
+        item = PlannedItem(
+            user_id=user.id,
+            title=_str(row.get("title"), "planned_items.title"),
+            notes=_nullable_str(row.get("notes"), "planned_items.notes"),
+            module_key=_nullable_str(row.get("module_key"), "planned_items.module_key"),
+            recurrence_hint=_nullable_str(row.get("recurrence_hint"), "planned_items.recurrence_hint"),
+            linked_source=_nullable_str(row.get("linked_source"), "planned_items.linked_source"),
+            linked_ref=_nullable_str(row.get("linked_ref"), "planned_items.linked_ref"),
+            planned_for=_date(row.get("planned_for"), "planned_items.planned_for"),
+            priority=Priority(_str(row.get("priority", Priority.normal.value), "planned_items.priority")),
+            tags=_list(row.get("tags"), "planned_items.tags"),
+            is_done=_bool(row.get("is_done"), "planned_items.is_done"),
+            completed_at=_nullable_datetime(row.get("completed_at"), "planned_items.completed_at"),
+            created_at=_datetime(row.get("created_at"), "planned_items.created_at"),
+        )
+        db.add(item)
+        counts["planned_items"] += 1
+
+    db.commit()
+    return counts
+
+
+def _delete_user_data(db: Session, user_id: int) -> None:
+    for model in (
+        MedicationDoseInstance,
+        ChoreInstance,
+        TaskInstance,
+        PlannedItem,
+        MedicationPlan,
+        ChoreTemplate,
+        RoutineTemplate,
+    ):
+        db.execute(delete(model).where(model.user_id == user_id))
+
+
+def _export_rows(rows: Iterable[Any], fields: tuple[str, ...]) -> list[dict[str, Any]]:
+    return [_fields_to_dict(row, fields) for row in rows]
+
+
+def _fields_to_dict(row: Any, fields: tuple[str, ...]) -> dict[str, Any]:
+    return {field: _json_value(getattr(row, field)) for field in fields}
+
+
+def _json_value(value: Any) -> Any:
+    if isinstance(value, datetime | date | time):
+        return value.isoformat()
+    if hasattr(value, "value"):
+        return value.value
+    return value
+
+
+def _csv_value(value: Any) -> Any:
+    if isinstance(value, list | dict):
+        return json.dumps(value, separators=(",", ":"))
+    return value
+
+
+def _rows(payload: Mapping[str, Any], key: str) -> list[Mapping[str, Any]]:
+    values = payload.get(key, [])
+    if not isinstance(values, list):
+        _invalid(f"{key} must be a list")
+    return [_mapping(value, key) for value in values]
+
+
+def _mapping(value: Any, field: str) -> Mapping[str, Any]:
+    if not isinstance(value, Mapping):
+        _invalid(f"{field} must be an object")
+    return value
+
+
+def _mapped_id(mapping: Mapping[int, int], value: Any, field: str) -> int:
+    old_id = _int(value, field)
+    if old_id not in mapping:
+        _invalid(f"{field} references an item missing from this import")
+    return mapping[old_id]
+
+
+def _coerce_setting(field: str, value: Any) -> Any:
+    if field in {"timezone"}:
+        return _str(value, f"user_settings.{field}")
+    if field in {"default_snooze_days", "medication_reminder_minutes"}:
+        return _int(value, f"user_settings.{field}")
+    return _nullable_time(value, f"user_settings.{field}")
+
+
+def _str(value: Any, field: str) -> str:
+    if not isinstance(value, str):
+        _invalid(f"{field} must be a string")
+    return value
+
+
+def _nullable_str(value: Any, field: str) -> str | None:
+    if value is None:
+        return None
+    return _str(value, field)
+
+
+def _int(value: Any, field: str) -> int:
+    if not isinstance(value, int) or isinstance(value, bool):
+        _invalid(f"{field} must be an integer")
+    return value
+
+
+def _bool(value: Any, field: str) -> bool:
+    if not isinstance(value, bool):
+        _invalid(f"{field} must be a boolean")
+    return value
+
+
+def _list(value: Any, field: str) -> list[Any]:
+    if value is None:
+        return []
+    if not isinstance(value, list):
+        _invalid(f"{field} must be a list")
+    return value
+
+
+def _date(value: Any, field: str) -> date:
+    if not isinstance(value, str):
+        _invalid(f"{field} must be an ISO date string")
+    try:
+        return date.fromisoformat(value)
+    except ValueError:
+        _invalid(f"{field} must be an ISO date string")
+
+
+def _time(value: Any, field: str) -> time:
+    if not isinstance(value, str):
+        _invalid(f"{field} must be an ISO time string")
+    try:
+        return time.fromisoformat(value)
+    except ValueError:
+        _invalid(f"{field} must be an ISO time string")
+
+
+def _nullable_time(value: Any, field: str) -> time | None:
+    if value is None:
+        return None
+    return _time(value, field)
+
+
+def _datetime(value: Any, field: str) -> datetime:
+    if not isinstance(value, str):
+        _invalid(f"{field} must be an ISO datetime string")
+    try:
+        return datetime.fromisoformat(value)
+    except ValueError:
+        _invalid(f"{field} must be an ISO datetime string")
+
+
+def _nullable_datetime(value: Any, field: str) -> datetime | None:
+    if value is None:
+        return None
+    return _datetime(value, field)
+
+
+def _invalid(detail: str) -> NoReturn:
+    raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=detail)

--- a/backend/app/services/export_import_service.py
+++ b/backend/app/services/export_import_service.py
@@ -5,11 +5,14 @@ import json
 from collections.abc import Iterable, Mapping
 from datetime import date, datetime, time, timezone
 from io import StringIO
-from typing import Any, NoReturn
+from typing import Any, NoReturn, TypeVar
 
 from fastapi import HTTPException, status
 from sqlalchemy import delete
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
+
+_E = TypeVar("_E")
 
 from app.core.enums import ChoreStatus, MedicationDoseStatus, Priority, TaskStatus
 from app.models.chore_instance import ChoreInstance
@@ -236,7 +239,7 @@ def import_user_export(db: Session, user: User, payload: Mapping[str, Any], *, r
             start_date=_date(row.get("start_date"), "chore_templates.start_date"),
             every_n_days=_int(row.get("every_n_days"), "chore_templates.every_n_days"),
             rrule=_nullable_str(row.get("rrule"), "chore_templates.rrule"),
-            priority=Priority(_str(row.get("priority", Priority.normal.value), "chore_templates.priority")),
+            priority=_enum(Priority, row.get("priority", Priority.normal.value), "chore_templates.priority"),
             tags=_list(row.get("tags"), "chore_templates.tags"),
             is_active=_bool(row.get("is_active"), "chore_templates.is_active"),
             created_at=_datetime(row.get("created_at"), "chore_templates.created_at"),
@@ -270,7 +273,7 @@ def import_user_export(db: Session, user: User, payload: Mapping[str, Any], *, r
             title=_str(row.get("title"), "task_instances.title"),
             scheduled_date=_date(row.get("scheduled_date"), "task_instances.scheduled_date"),
             due_at=_nullable_datetime(row.get("due_at"), "task_instances.due_at"),
-            status=TaskStatus(_str(row.get("status"), "task_instances.status")),
+            status=_enum(TaskStatus, row.get("status"), "task_instances.status"),
             completed_at=_nullable_datetime(row.get("completed_at"), "task_instances.completed_at"),
             created_at=_datetime(row.get("created_at"), "task_instances.created_at"),
         )
@@ -283,7 +286,7 @@ def import_user_export(db: Session, user: User, payload: Mapping[str, Any], *, r
             chore_template_id=_mapped_id(chore_id_map, row.get("chore_template_id"), "chore_instances.chore_template_id"),
             title=_str(row.get("title"), "chore_instances.title"),
             scheduled_date=_date(row.get("scheduled_date"), "chore_instances.scheduled_date"),
-            status=ChoreStatus(_str(row.get("status"), "chore_instances.status")),
+            status=_enum(ChoreStatus, row.get("status"), "chore_instances.status"),
             completed_at=_nullable_datetime(row.get("completed_at"), "chore_instances.completed_at"),
             skipped_at=_nullable_datetime(row.get("skipped_at"), "chore_instances.skipped_at"),
             created_at=_datetime(row.get("created_at"), "chore_instances.created_at"),
@@ -303,7 +306,7 @@ def import_user_export(db: Session, user: User, payload: Mapping[str, Any], *, r
             instructions=_str(row.get("instructions"), "medication_dose_instances.instructions"),
             scheduled_date=_date(row.get("scheduled_date"), "medication_dose_instances.scheduled_date"),
             scheduled_at=_datetime(row.get("scheduled_at"), "medication_dose_instances.scheduled_at"),
-            status=MedicationDoseStatus(_str(row.get("status"), "medication_dose_instances.status")),
+            status=_enum(MedicationDoseStatus, row.get("status"), "medication_dose_instances.status"),
             taken_at=_nullable_datetime(row.get("taken_at"), "medication_dose_instances.taken_at"),
             skipped_at=_nullable_datetime(row.get("skipped_at"), "medication_dose_instances.skipped_at"),
             missed_at=_nullable_datetime(row.get("missed_at"), "medication_dose_instances.missed_at"),
@@ -322,7 +325,7 @@ def import_user_export(db: Session, user: User, payload: Mapping[str, Any], *, r
             linked_source=_nullable_str(row.get("linked_source"), "planned_items.linked_source"),
             linked_ref=_nullable_str(row.get("linked_ref"), "planned_items.linked_ref"),
             planned_for=_date(row.get("planned_for"), "planned_items.planned_for"),
-            priority=Priority(_str(row.get("priority", Priority.normal.value), "planned_items.priority")),
+            priority=_enum(Priority, row.get("priority", Priority.normal.value), "planned_items.priority"),
             tags=_list(row.get("tags"), "planned_items.tags"),
             is_done=_bool(row.get("is_done"), "planned_items.is_done"),
             completed_at=_nullable_datetime(row.get("completed_at"), "planned_items.completed_at"),
@@ -331,7 +334,14 @@ def import_user_export(db: Session, user: User, payload: Mapping[str, Any], *, r
         db.add(item)
         counts["planned_items"] += 1
 
-    db.commit()
+    try:
+        db.commit()
+    except IntegrityError as exc:
+        db.rollback()
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=f"Import conflicts with existing data: {exc.orig}",
+        ) from exc
     return counts
 
 
@@ -420,6 +430,15 @@ def _bool(value: Any, field: str) -> bool:
     if not isinstance(value, bool):
         _invalid(f"{field} must be a boolean")
     return value
+
+
+def _enum(cls: type[_E], value: Any, field: str) -> _E:
+    s = _str(value, field)
+    try:
+        return cls(s)  # type: ignore[call-arg]
+    except ValueError:
+        valid = ", ".join(m.value for m in cls)  # type: ignore[attr-defined]
+        _invalid(f"{field} has invalid value '{s}'; expected one of: {valid}")
 
 
 def _list(value: Any, field: str) -> list[Any]:

--- a/backend/tests/test_analytics_api.py
+++ b/backend/tests/test_analytics_api.py
@@ -4,13 +4,15 @@ from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
 
 from app.api.dependencies.auth import get_current_user
-from app.core.enums import ChoreStatus, MedicationDoseStatus
+from app.core.enums import ChoreStatus, MedicationDoseStatus, TaskStatus
 from app.main import app
 from app.models.chore_instance import ChoreInstance
 from app.models.chore_template import ChoreTemplate
 from app.models.medication_dose_instance import MedicationDoseInstance
 from app.models.medication_plan import MedicationPlan
 from app.models.planned_item import PlannedItem
+from app.models.routine_template import RoutineTemplate
+from app.models.task_instance import TaskInstance
 from app.models.user import User
 
 
@@ -231,3 +233,107 @@ def test_analytics_streaks_use_bounded_recent_history(client: TestClient, db_ses
     assert response.json()["chores"]["streaks"] == [
         {"chore_id": chore_template.id, "name": "Dishes", "current_streak": 3, "longest_streak": 3}
     ]
+
+
+def _add_task(
+    db_session: Session,
+    user: User,
+    template: RoutineTemplate,
+    scheduled_date: date,
+    status: TaskStatus,
+) -> None:
+    db_session.add(
+        TaskInstance(
+            user_id=user.id,
+            routine_template_id=template.id,
+            title=template.name,
+            scheduled_date=scheduled_date,
+            status=status,
+            completed_at=datetime.now(timezone.utc) if status == TaskStatus.completed else None,
+        )
+    )
+
+
+def test_analytics_includes_routine_streaks(client: TestClient, db_session: Session) -> None:
+    user = _create_user(db_session, email="analytics-routine-streaks@example.com")
+    today = date.today()
+
+    routine = RoutineTemplate(
+        user_id=user.id,
+        name="Morning stretches",
+        description=None,
+        start_date=today - timedelta(days=6),
+        every_n_days=1,
+        is_active=True,
+    )
+    db_session.add(routine)
+    db_session.commit()
+    db_session.refresh(routine)
+
+    # completed 3 days ago; skipped 2 days ago; completed yesterday and today → current streak = 2, longest = 2
+    _add_task(db_session, user, routine, today - timedelta(days=3), TaskStatus.completed)
+    _add_task(db_session, user, routine, today - timedelta(days=2), TaskStatus.skipped)
+    _add_task(db_session, user, routine, today - timedelta(days=1), TaskStatus.completed)
+    _add_task(db_session, user, routine, today, TaskStatus.completed)
+    db_session.commit()
+
+    _auth_as(user)
+    try:
+        response = client.get("/api/v1/analytics/summary?period=week")
+    finally:
+        _clear_auth()
+
+    assert response.status_code == 200
+    routines = response.json()["routines"]
+    assert routines["total_completed"] == 3
+    assert routines["total_scheduled"] == 4
+    assert routines["completion_rate"] == 0.75
+    assert len(routines["daily_completions"]) == 7
+    assert routines["streaks"] == [
+        {"routine_id": routine.id, "name": "Morning stretches", "current_streak": 2, "longest_streak": 2}
+    ]
+
+
+def test_analytics_routine_streaks_do_not_leak_across_users(client: TestClient, db_session: Session) -> None:
+    owner = _create_user(db_session, email="analytics-routine-owner@example.com")
+    other = _create_user(db_session, email="analytics-routine-other@example.com")
+    today = date.today()
+
+    routine = RoutineTemplate(
+        user_id=owner.id,
+        name="Owner routine",
+        description=None,
+        start_date=today,
+        every_n_days=1,
+        is_active=True,
+    )
+    db_session.add(routine)
+    db_session.commit()
+    db_session.refresh(routine)
+    _add_task(db_session, owner, routine, today, TaskStatus.completed)
+    db_session.commit()
+
+    _auth_as(other)
+    try:
+        response = client.get("/api/v1/analytics/summary?period=week")
+    finally:
+        _clear_auth()
+
+    assert response.status_code == 200
+    assert response.json()["routines"]["streaks"] == []
+    assert response.json()["routines"]["total_completed"] == 0
+
+
+def test_analytics_summary_response_includes_routines_key(client: TestClient, db_session: Session) -> None:
+    user = _create_user(db_session, email="analytics-routines-key@example.com")
+    _auth_as(user)
+    try:
+        response = client.get("/api/v1/analytics/summary")
+    finally:
+        _clear_auth()
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert "routines" in payload
+    assert "streaks" in payload["routines"]
+    assert "daily_completions" in payload["routines"]

--- a/backend/tests/test_export_import.py
+++ b/backend/tests/test_export_import.py
@@ -1,0 +1,220 @@
+from datetime import date, datetime, time, timezone
+
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+from app.api.dependencies.auth import get_current_user
+from app.core.enums import ChoreStatus, MedicationDoseStatus, Priority, TaskStatus
+from app.main import app
+from app.models.chore_instance import ChoreInstance
+from app.models.chore_template import ChoreTemplate
+from app.models.medication_dose_instance import MedicationDoseInstance
+from app.models.medication_plan import MedicationPlan
+from app.models.planned_item import PlannedItem
+from app.models.routine_template import RoutineTemplate
+from app.models.task_instance import TaskInstance
+from app.models.user import User
+
+
+def _create_user(db_session: Session, email: str) -> User:
+    user = User(email=email, full_name="Export User", is_active=True)
+    db_session.add(user)
+    db_session.commit()
+    db_session.refresh(user)
+    return user
+
+
+def _auth_as(user: User) -> None:
+    async def _dep() -> User:
+        return user
+
+    app.dependency_overrides[get_current_user] = _dep
+
+
+def _clear_auth() -> None:
+    app.dependency_overrides.pop(get_current_user, None)
+
+
+def _seed_export_data(db_session: Session, user: User) -> None:
+    user.timezone = "Europe/Brussels"
+    user.default_snooze_days = 2
+    user.medication_reminder_minutes = 45
+    user.quiet_hours_start = time(22, 0)
+    user.quiet_hours_end = time(7, 0)
+
+    routine = RoutineTemplate(
+        user_id=user.id,
+        name="Morning reset",
+        description="Tidy kitchen",
+        start_date=date(2026, 5, 1),
+        every_n_days=1,
+        rrule="FREQ=WEEKLY;BYDAY=MO",
+        due_time=time(8, 0),
+        is_active=True,
+    )
+    chore = ChoreTemplate(
+        user_id=user.id,
+        name="Laundry",
+        description="Wash towels",
+        start_date=date(2026, 5, 2),
+        every_n_days=7,
+        rrule=None,
+        priority=Priority.high,
+        tags=["home", "weekly"],
+        is_active=True,
+    )
+    medication = MedicationPlan(
+        user_id=user.id,
+        name="Vitamin D",
+        instructions="Take with breakfast",
+        start_date=date(2026, 5, 1),
+        schedule_time=time(9, 30),
+        every_n_days=1,
+        is_active=True,
+    )
+    db_session.add_all([routine, chore, medication])
+    db_session.commit()
+    db_session.refresh(routine)
+    db_session.refresh(chore)
+    db_session.refresh(medication)
+
+    db_session.add_all(
+        [
+            TaskInstance(
+                user_id=user.id,
+                routine_template_id=routine.id,
+                title=routine.name,
+                scheduled_date=date(2026, 5, 4),
+                due_at=datetime(2026, 5, 4, 8, 0, tzinfo=timezone.utc),
+                status=TaskStatus.completed,
+                completed_at=datetime(2026, 5, 4, 8, 10, tzinfo=timezone.utc),
+            ),
+            ChoreInstance(
+                user_id=user.id,
+                chore_template_id=chore.id,
+                title=chore.name,
+                scheduled_date=date(2026, 5, 2),
+                status=ChoreStatus.skipped,
+                skipped_at=datetime(2026, 5, 2, 11, 0, tzinfo=timezone.utc),
+            ),
+            MedicationDoseInstance(
+                user_id=user.id,
+                medication_plan_id=medication.id,
+                name=medication.name,
+                instructions=medication.instructions,
+                scheduled_date=date(2026, 5, 1),
+                scheduled_at=datetime(2026, 5, 1, 9, 30, tzinfo=timezone.utc),
+                status=MedicationDoseStatus.taken,
+                taken_at=datetime(2026, 5, 1, 9, 35, tzinfo=timezone.utc),
+            ),
+            PlannedItem(
+                user_id=user.id,
+                title="Meal prep",
+                notes="Sunday batch",
+                module_key="meal_planning",
+                recurrence_hint="weekly",
+                linked_source="manual",
+                linked_ref="prep-1",
+                planned_for=date(2026, 5, 3),
+                priority=Priority.urgent,
+                tags=["food"],
+                is_done=True,
+                completed_at=datetime(2026, 5, 3, 16, 0, tzinfo=timezone.utc),
+            ),
+        ]
+    )
+    db_session.commit()
+
+
+def test_export_user_data_returns_full_json_backup(client: TestClient, db_session: Session) -> None:
+    user = _create_user(db_session, "export@example.com")
+    _seed_export_data(db_session, user)
+    _auth_as(user)
+
+    try:
+        response = client.get("/api/v1/users/me/export")
+    finally:
+        _clear_auth()
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["version"] == 1
+    assert payload["user_settings"]["timezone"] == "Europe/Brussels"
+    assert payload["user_settings"]["quiet_hours_start"] == "22:00:00"
+    assert payload["routine_templates"][0]["name"] == "Morning reset"
+    assert payload["chore_templates"][0]["priority"] == "high"
+    assert payload["chore_templates"][0]["tags"] == ["home", "weekly"]
+    assert payload["medication_plans"][0]["name"] == "Vitamin D"
+    assert payload["task_instances"][0]["status"] == "completed"
+    assert payload["chore_instances"][0]["status"] == "skipped"
+    assert payload["medication_dose_instances"][0]["status"] == "taken"
+    assert payload["planned_items"][0]["priority"] == "urgent"
+
+
+def test_export_user_data_can_return_csv(client: TestClient, db_session: Session) -> None:
+    user = _create_user(db_session, "export-csv@example.com")
+    _seed_export_data(db_session, user)
+    _auth_as(user)
+
+    try:
+        response = client.get("/api/v1/users/me/export?format=csv")
+    finally:
+        _clear_auth()
+
+    assert response.status_code == 200
+    assert response.headers["content-type"].startswith("text/csv")
+    assert "table" in response.text
+    assert "user_settings" in response.text
+    assert "chore_templates" in response.text
+    assert "Laundry" in response.text
+
+
+def test_import_user_data_restores_export_for_current_user(client: TestClient, db_session: Session) -> None:
+    source = _create_user(db_session, "source@example.com")
+    target = _create_user(db_session, "target@example.com")
+    _seed_export_data(db_session, source)
+
+    _auth_as(source)
+    try:
+        payload = client.get("/api/v1/users/me/export").json()
+    finally:
+        _clear_auth()
+
+    _auth_as(target)
+    try:
+        response = client.post("/api/v1/users/me/import", json=payload)
+    finally:
+        _clear_auth()
+
+    assert response.status_code == 200
+    assert response.json()["imported"] == {
+        "routine_templates": 1,
+        "chore_templates": 1,
+        "medication_plans": 1,
+        "task_instances": 1,
+        "chore_instances": 1,
+        "medication_dose_instances": 1,
+        "planned_items": 1,
+    }
+
+    db_session.refresh(target)
+    assert target.timezone == "Europe/Brussels"
+    assert target.default_snooze_days == 2
+    imported_routine = db_session.query(RoutineTemplate).filter_by(user_id=target.id).one()
+    imported_task = db_session.query(TaskInstance).filter_by(user_id=target.id).one()
+    imported_chore = db_session.query(ChoreTemplate).filter_by(user_id=target.id).one()
+    imported_chore_instance = db_session.query(ChoreInstance).filter_by(user_id=target.id).one()
+    imported_plan = db_session.query(MedicationPlan).filter_by(user_id=target.id).one()
+    imported_dose = db_session.query(MedicationDoseInstance).filter_by(user_id=target.id).one()
+    imported_planned = db_session.query(PlannedItem).filter_by(user_id=target.id).one()
+
+    assert imported_task.routine_template_id == imported_routine.id
+    assert imported_chore_instance.chore_template_id == imported_chore.id
+    assert imported_dose.medication_plan_id == imported_plan.id
+    assert imported_planned.title == "Meal prep"
+    assert imported_planned.tags == ["food"]
+
+
+def test_export_requires_authentication(client: TestClient) -> None:
+    response = client.get("/api/v1/users/me/export")
+    assert response.status_code == 401

--- a/backend/tests/test_search.py
+++ b/backend/tests/test_search.py
@@ -1,0 +1,209 @@
+from datetime import date, time
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+from app.api.dependencies.auth import get_current_user
+from app.core.enums import Priority
+from app.main import app
+from app.models.chore_template import ChoreTemplate
+from app.models.medication_plan import MedicationPlan
+from app.models.planned_item import PlannedItem
+from app.models.routine_template import RoutineTemplate
+from app.models.user import User
+
+
+def _create_user(db: Session, email: str) -> User:
+    user = User(email=email, full_name="Search User", is_active=True)
+    db.add(user)
+    db.commit()
+    db.refresh(user)
+    return user
+
+
+def _auth_as(user: User) -> None:
+    async def _dep() -> User:
+        return user
+
+    app.dependency_overrides[get_current_user] = _dep
+
+
+def _clear_auth() -> None:
+    app.dependency_overrides.pop(get_current_user, None)
+
+
+def _seed(db: Session, user: User) -> None:
+    db.add_all(
+        [
+            RoutineTemplate(
+                user_id=user.id,
+                name="Morning stretches",
+                description="Light yoga flow",
+                start_date=date(2026, 1, 1),
+                every_n_days=1,
+                is_active=True,
+            ),
+            RoutineTemplate(
+                user_id=user.id,
+                name="Evening reading",
+                description=None,
+                start_date=date(2026, 1, 1),
+                every_n_days=1,
+                is_active=True,
+            ),
+            ChoreTemplate(
+                user_id=user.id,
+                name="Vacuum living room",
+                description="Including under sofa",
+                start_date=date(2026, 1, 1),
+                every_n_days=7,
+                priority=Priority.normal,
+                tags=["home"],
+                is_active=True,
+            ),
+            ChoreTemplate(
+                user_id=user.id,
+                name="Laundry",
+                description=None,
+                start_date=date(2026, 1, 1),
+                every_n_days=7,
+                priority=Priority.high,
+                tags=[],
+                is_active=True,
+            ),
+            MedicationPlan(
+                user_id=user.id,
+                name="Vitamin D",
+                instructions="Take with breakfast",
+                start_date=date(2026, 1, 1),
+                schedule_time=time(9, 0),
+                every_n_days=1,
+                is_active=True,
+            ),
+            PlannedItem(
+                user_id=user.id,
+                title="Meal prep Sunday",
+                notes="Batch cook rice and veggies",
+                planned_for=date(2026, 5, 5),
+                priority=Priority.normal,
+                tags=[],
+                is_done=False,
+            ),
+            PlannedItem(
+                user_id=user.id,
+                title="Buy groceries",
+                notes=None,
+                planned_for=date(2026, 5, 6),
+                priority=Priority.normal,
+                tags=[],
+                is_done=False,
+            ),
+        ]
+    )
+    db.commit()
+
+
+@pytest.fixture(autouse=True)
+def _cleanup():
+    yield
+    _clear_auth()
+
+
+def test_search_returns_grouped_results(client: TestClient, db_session: Session) -> None:
+    user = _create_user(db_session, "search1@example.com")
+    _seed(db_session, user)
+    _auth_as(user)
+
+    response = client.get("/api/v1/search?q=vitamin")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["query"] == "vitamin"
+    assert len(data["medication_plans"]) == 1
+    assert data["medication_plans"][0]["name"] == "Vitamin D"
+    assert data["routine_templates"] == []
+    assert data["chore_templates"] == []
+    assert data["planned_items"] == []
+
+
+def test_search_matches_description_field(client: TestClient, db_session: Session) -> None:
+    user = _create_user(db_session, "search2@example.com")
+    _seed(db_session, user)
+    _auth_as(user)
+
+    response = client.get("/api/v1/search?q=yoga")
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data["routine_templates"]) == 1
+    assert data["routine_templates"][0]["name"] == "Morning stretches"
+
+
+def test_search_is_case_insensitive(client: TestClient, db_session: Session) -> None:
+    user = _create_user(db_session, "search3@example.com")
+    _seed(db_session, user)
+    _auth_as(user)
+
+    response = client.get("/api/v1/search?q=MEAL")
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data["planned_items"]) == 1
+    assert data["planned_items"][0]["title"] == "Meal prep Sunday"
+
+
+def test_search_matches_planned_item_notes(client: TestClient, db_session: Session) -> None:
+    user = _create_user(db_session, "search4@example.com")
+    _seed(db_session, user)
+    _auth_as(user)
+
+    response = client.get("/api/v1/search?q=batch+cook")
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data["planned_items"]) == 1
+    assert data["planned_items"][0]["title"] == "Meal prep Sunday"
+
+
+def test_search_does_not_leak_other_users_data(client: TestClient, db_session: Session) -> None:
+    owner = _create_user(db_session, "search-owner@example.com")
+    other = _create_user(db_session, "search-other@example.com")
+    _seed(db_session, owner)
+    _auth_as(other)
+
+    response = client.get("/api/v1/search?q=vitamin")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["medication_plans"] == []
+
+
+def test_search_rejects_query_shorter_than_two_chars(client: TestClient, db_session: Session) -> None:
+    user = _create_user(db_session, "search5@example.com")
+    _auth_as(user)
+
+    response = client.get("/api/v1/search?q=a")
+    assert response.status_code == 422
+
+
+def test_search_requires_authentication(client: TestClient) -> None:
+    response = client.get("/api/v1/search?q=vitamin")
+    assert response.status_code == 401
+
+
+def test_search_limit_caps_results(client: TestClient, db_session: Session) -> None:
+    user = _create_user(db_session, "search6@example.com")
+    for i in range(5):
+        db_session.add(
+            PlannedItem(
+                user_id=user.id,
+                title=f"Shopping item {i}",
+                notes=None,
+                planned_for=date(2026, 5, i + 1),
+                priority=Priority.normal,
+                tags=[],
+                is_done=False,
+            )
+        )
+    db_session.commit()
+    _auth_as(user)
+
+    response = client.get("/api/v1/search?q=shopping&limit=3")
+    assert response.status_code == 200
+    assert len(response.json()["planned_items"]) == 3


### PR DESCRIPTION
## Summary

- Adds `GET /users/me/export` returning a full JSON backup of all user data (templates, instances, planned items, settings); optional `?format=csv` for spreadsheet-friendly output
- Adds `POST /users/me/import` accepting the same JSON format for migration between instances, with optional `?replace=true` to wipe existing data first
- Fixes FastAPI startup error caused by `dict | Response` return type annotation (added `response_model=None`)

## Test plan

- [ ] `test_export_user_data_returns_full_json_backup` — full JSON export contains all seeded records and settings
- [ ] `test_export_user_data_can_return_csv` — CSV export has correct content-type and expected rows
- [ ] `test_import_user_data_restores_export_for_current_user` — round-trip: export from source user, import to target user, verify counts and FK remapping
- [ ] `test_export_requires_authentication` — unauthenticated request returns 401

Closes #288