### PR TITLE
feat: global search endpoint (#282)

### DIFF
--- a/backend/app/api/routes/analytics.py
+++ b/backend/app/api/routes/analytics.py
@@ -7,7 +7,7 @@ from sqlalchemy.orm import Session
 from app.api.dependencies.auth import get_current_user
 from app.db.session import get_db
 from app.models.user import User
-from app.repositories.analytics_repository import get_chore_stats, get_medication_stats, get_planned_item_stats
+from app.repositories.analytics_repository import get_chore_stats, get_medication_stats, get_planned_item_stats, get_routine_stats
 from app.schemas.analytics import AnalyticsSummaryResponse
 
 router = APIRouter(prefix="/analytics", tags=["analytics"])
@@ -38,4 +38,5 @@ def get_analytics_summary(
         chores=get_chore_stats(db, current_user.id, start_date, end_date),
         medications=get_medication_stats(db, current_user.id, start_date, end_date),
         planned_items=get_planned_item_stats(db, current_user.id, start_date, end_date),
+        routines=get_routine_stats(db, current_user.id, start_date, end_date),
     )

--- a/backend/app/api/routes/search.py
+++ b/backend/app/api/routes/search.py
@@ -4,6 +4,7 @@ from datetime import date, datetime
 
 from fastapi import APIRouter, Depends, Query
 from pydantic import BaseModel
+from sqlalchemy import select
 from sqlalchemy.orm import Session
 
 from app.api.dependencies.auth import get_current_user
@@ -17,6 +18,12 @@ from app.models.user import User
 router = APIRouter(prefix="/search", tags=["search"])
 
 _DEFAULT_LIMIT = 20
+_ESCAPE_CHAR = "\\"
+
+
+def _like_pattern(q: str) -> str:
+    escaped = q.replace(_ESCAPE_CHAR, _ESCAPE_CHAR * 2).replace("%", f"{_ESCAPE_CHAR}%").replace("_", f"{_ESCAPE_CHAR}_")
+    return f"%{escaped}%"
 
 
 class RoutineSearchResult(BaseModel):
@@ -71,52 +78,52 @@ def search(
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ) -> SearchResponse:
-    pattern = f"%{q}%"
+    pattern = _like_pattern(q)
     uid = current_user.id
 
-    routines = (
-        db.query(RoutineTemplate)
-        .filter(
+    routines = db.scalars(
+        select(RoutineTemplate)
+        .where(
             RoutineTemplate.user_id == uid,
-            (RoutineTemplate.name.ilike(pattern)) | (RoutineTemplate.description.ilike(pattern)),
+            (RoutineTemplate.name.ilike(pattern, escape=_ESCAPE_CHAR))
+            | (RoutineTemplate.description.ilike(pattern, escape=_ESCAPE_CHAR)),
         )
         .order_by(RoutineTemplate.name)
         .limit(limit)
-        .all()
-    )
+    ).all()
 
-    chores = (
-        db.query(ChoreTemplate)
-        .filter(
+    chores = db.scalars(
+        select(ChoreTemplate)
+        .where(
             ChoreTemplate.user_id == uid,
-            (ChoreTemplate.name.ilike(pattern)) | (ChoreTemplate.description.ilike(pattern)),
+            (ChoreTemplate.name.ilike(pattern, escape=_ESCAPE_CHAR))
+            | (ChoreTemplate.description.ilike(pattern, escape=_ESCAPE_CHAR)),
         )
         .order_by(ChoreTemplate.name)
         .limit(limit)
-        .all()
-    )
+    ).all()
 
-    medications = (
-        db.query(MedicationPlan)
-        .filter(
+    medications = db.scalars(
+        select(MedicationPlan)
+        .where(
             MedicationPlan.user_id == uid,
-            (MedicationPlan.name.ilike(pattern)) | (MedicationPlan.instructions.ilike(pattern)),
+            (MedicationPlan.name.ilike(pattern, escape=_ESCAPE_CHAR))
+            | (MedicationPlan.instructions.ilike(pattern, escape=_ESCAPE_CHAR)),
         )
         .order_by(MedicationPlan.name)
         .limit(limit)
-        .all()
-    )
+    ).all()
 
-    planned = (
-        db.query(PlannedItem)
-        .filter(
+    planned = db.scalars(
+        select(PlannedItem)
+        .where(
             PlannedItem.user_id == uid,
-            (PlannedItem.title.ilike(pattern)) | (PlannedItem.notes.ilike(pattern)),
+            (PlannedItem.title.ilike(pattern, escape=_ESCAPE_CHAR))
+            | (PlannedItem.notes.ilike(pattern, escape=_ESCAPE_CHAR)),
         )
         .order_by(PlannedItem.planned_for.desc(), PlannedItem.title)
         .limit(limit)
-        .all()
-    )
+    ).all()
 
     return SearchResponse(
         query=q,
@@ -135,7 +142,7 @@ def search(
                 id=c.id,
                 name=c.name,
                 description=c.description,
-                priority=c.priority.value if hasattr(c.priority, "value") else c.priority,
+                priority=c.priority,
                 tags=c.tags or [],
                 is_active=c.is_active,
                 created_at=c.created_at,
@@ -158,7 +165,7 @@ def search(
                 title=p.title,
                 notes=p.notes,
                 planned_for=p.planned_for,
-                priority=p.priority.value if hasattr(p.priority, "value") else p.priority,
+                priority=p.priority,
                 tags=p.tags or [],
                 is_done=p.is_done,
                 created_at=p.created_at,

--- a/backend/app/api/routes/search.py
+++ b/backend/app/api/routes/search.py
@@ -1,0 +1,168 @@
+from __future__ import annotations
+
+from datetime import date, datetime
+
+from fastapi import APIRouter, Depends, Query
+from pydantic import BaseModel
+from sqlalchemy.orm import Session
+
+from app.api.dependencies.auth import get_current_user
+from app.db.session import get_db
+from app.models.chore_template import ChoreTemplate
+from app.models.medication_plan import MedicationPlan
+from app.models.planned_item import PlannedItem
+from app.models.routine_template import RoutineTemplate
+from app.models.user import User
+
+router = APIRouter(prefix="/search", tags=["search"])
+
+_DEFAULT_LIMIT = 20
+
+
+class RoutineSearchResult(BaseModel):
+    id: int
+    name: str
+    description: str | None
+    is_active: bool
+    created_at: datetime
+
+
+class ChoreSearchResult(BaseModel):
+    id: int
+    name: str
+    description: str | None
+    priority: str
+    tags: list[str]
+    is_active: bool
+    created_at: datetime
+
+
+class MedicationSearchResult(BaseModel):
+    id: int
+    name: str
+    instructions: str
+    is_active: bool
+    created_at: datetime
+
+
+class PlannedItemSearchResult(BaseModel):
+    id: int
+    title: str
+    notes: str | None
+    planned_for: date
+    priority: str
+    tags: list[str]
+    is_done: bool
+    created_at: datetime
+
+
+class SearchResponse(BaseModel):
+    query: str
+    routine_templates: list[RoutineSearchResult]
+    chore_templates: list[ChoreSearchResult]
+    medication_plans: list[MedicationSearchResult]
+    planned_items: list[PlannedItemSearchResult]
+
+
+@router.get("", response_model=SearchResponse)
+def search(
+    q: str = Query(min_length=2, max_length=100),
+    limit: int = Query(default=_DEFAULT_LIMIT, ge=1, le=100),
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+) -> SearchResponse:
+    pattern = f"%{q}%"
+    uid = current_user.id
+
+    routines = (
+        db.query(RoutineTemplate)
+        .filter(
+            RoutineTemplate.user_id == uid,
+            (RoutineTemplate.name.ilike(pattern)) | (RoutineTemplate.description.ilike(pattern)),
+        )
+        .order_by(RoutineTemplate.name)
+        .limit(limit)
+        .all()
+    )
+
+    chores = (
+        db.query(ChoreTemplate)
+        .filter(
+            ChoreTemplate.user_id == uid,
+            (ChoreTemplate.name.ilike(pattern)) | (ChoreTemplate.description.ilike(pattern)),
+        )
+        .order_by(ChoreTemplate.name)
+        .limit(limit)
+        .all()
+    )
+
+    medications = (
+        db.query(MedicationPlan)
+        .filter(
+            MedicationPlan.user_id == uid,
+            (MedicationPlan.name.ilike(pattern)) | (MedicationPlan.instructions.ilike(pattern)),
+        )
+        .order_by(MedicationPlan.name)
+        .limit(limit)
+        .all()
+    )
+
+    planned = (
+        db.query(PlannedItem)
+        .filter(
+            PlannedItem.user_id == uid,
+            (PlannedItem.title.ilike(pattern)) | (PlannedItem.notes.ilike(pattern)),
+        )
+        .order_by(PlannedItem.planned_for.desc(), PlannedItem.title)
+        .limit(limit)
+        .all()
+    )
+
+    return SearchResponse(
+        query=q,
+        routine_templates=[
+            RoutineSearchResult(
+                id=r.id,
+                name=r.name,
+                description=r.description,
+                is_active=r.is_active,
+                created_at=r.created_at,
+            )
+            for r in routines
+        ],
+        chore_templates=[
+            ChoreSearchResult(
+                id=c.id,
+                name=c.name,
+                description=c.description,
+                priority=c.priority.value if hasattr(c.priority, "value") else c.priority,
+                tags=c.tags or [],
+                is_active=c.is_active,
+                created_at=c.created_at,
+            )
+            for c in chores
+        ],
+        medication_plans=[
+            MedicationSearchResult(
+                id=m.id,
+                name=m.name,
+                instructions=m.instructions,
+                is_active=m.is_active,
+                created_at=m.created_at,
+            )
+            for m in medications
+        ],
+        planned_items=[
+            PlannedItemSearchResult(
+                id=p.id,
+                title=p.title,
+                notes=p.notes,
+                planned_for=p.planned_for,
+                priority=p.priority.value if hasattr(p.priority, "value") else p.priority,
+                tags=p.tags or [],
+                is_done=p.is_done,
+                created_at=p.created_at,
+            )
+            for p in planned
+        ],
+    )

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -9,6 +9,7 @@ from app.api.routes.auth import router as auth_router
 from app.api.routes.analytics import router as analytics_router
 from app.api.routes.bulk import router as bulk_router
 from app.api.routes.calendar import router as calendar_router
+from app.api.routes.search import router as search_router
 from app.api.routes.health import router as system_router
 from app.api.routes.integrations.clients import router as integration_clients_router
 from app.api.routes.integrations.home_assistant import router as home_assistant_router
@@ -65,6 +66,7 @@ app.include_router(medications_router, prefix=settings.api_prefix)
 app.include_router(templates_router, prefix=f"{settings.api_prefix}/templates")
 app.include_router(bulk_router, prefix=settings.api_prefix)
 app.include_router(calendar_router, prefix=settings.api_prefix)
+app.include_router(search_router, prefix=settings.api_prefix)
 if _mcp is not None:
     app.mount("/mcp", _mcp.streamable_http_app())
 

--- a/backend/app/repositories/analytics_repository.py
+++ b/backend/app/repositories/analytics_repository.py
@@ -4,11 +4,13 @@ from datetime import date, timedelta
 from sqlalchemy import case, func, select
 from sqlalchemy.orm import Session
 
-from app.core.enums import ChoreStatus, MedicationDoseStatus
+from app.core.enums import ChoreStatus, MedicationDoseStatus, TaskStatus
 from app.models.chore_instance import ChoreInstance
 from app.models.chore_template import ChoreTemplate
 from app.models.medication_dose_instance import MedicationDoseInstance
 from app.models.planned_item import PlannedItem
+from app.models.routine_template import RoutineTemplate
+from app.models.task_instance import TaskInstance
 from app.schemas.analytics import (
     ChoreStats,
     ChoreStreak,
@@ -16,6 +18,8 @@ from app.schemas.analytics import (
     DailyCount,
     MedicationStats,
     PlannedItemStats,
+    RoutineStats,
+    RoutineStreak,
     SkippedChore,
 )
 
@@ -204,4 +208,86 @@ def get_planned_item_stats(db: Session, user_id: int, start_date: date, end_date
         total_completed=total_completed,
         total_scheduled=total_scheduled,
         daily_completions=daily_completions,
+    )
+
+
+def get_routine_stats(db: Session, user_id: int, start_date: date, end_date: date) -> RoutineStats:
+    daily_rows = db.execute(
+        select(
+            TaskInstance.scheduled_date,
+            func.count(TaskInstance.id),
+            func.sum(case((TaskInstance.status == TaskStatus.completed, 1), else_=0)),
+        )
+        .where(TaskInstance.user_id == user_id)
+        .where(TaskInstance.scheduled_date >= start_date)
+        .where(TaskInstance.scheduled_date <= end_date)
+        .group_by(TaskInstance.scheduled_date)
+    ).all()
+
+    by_date = {row[0]: {"total": int(row[1]), "completed": int(row[2] or 0)} for row in daily_rows}
+
+    dates = _date_range(start_date, end_date)
+    daily_completions = []
+    for d in dates:
+        total = by_date.get(d, {}).get("total", 0)
+        completed = by_date.get(d, {}).get("completed", 0)
+        daily_completions.append(DailyCount(date=d, completed=completed, total=total, completion_rate=_rate(completed, total)))
+
+    total_completed = sum(day["completed"] for day in by_date.values())
+    total_scheduled = sum(day["total"] for day in by_date.values())
+    completion_rate = _rate(total_completed, total_scheduled)
+
+    streak_start_date = _streak_lookback_start(start_date, end_date)
+    templates = {
+        t.id: t.name
+        for t in db.scalars(select(RoutineTemplate).where(RoutineTemplate.user_id == user_id)).all()
+    }
+
+    all_resolved = db.scalars(
+        select(TaskInstance)
+        .where(TaskInstance.user_id == user_id)
+        .where(TaskInstance.scheduled_date >= streak_start_date)
+        .where(TaskInstance.scheduled_date <= end_date)
+        .where(TaskInstance.status.notin_([TaskStatus.pending, TaskStatus.in_progress]))
+        .order_by(TaskInstance.routine_template_id, TaskInstance.scheduled_date)
+    ).all()
+
+    by_template: dict[int, list[TaskInstance]] = defaultdict(list)
+    for inst in all_resolved:
+        by_template[inst.routine_template_id].append(inst)
+
+    streaks: list[RoutineStreak] = []
+    for template_id, insts in by_template.items():
+        name = templates.get(template_id, f"Routine #{template_id}")
+
+        current = 0
+        for inst in reversed(insts):
+            if inst.status == TaskStatus.completed:
+                current += 1
+            else:
+                break
+
+        longest, run = 0, 0
+        for inst in insts:
+            if inst.status == TaskStatus.completed:
+                run += 1
+                longest = max(longest, run)
+            else:
+                run = 0
+
+        streaks.append(RoutineStreak(
+            routine_id=template_id,
+            name=name,
+            current_streak=current,
+            longest_streak=longest,
+        ))
+
+    streaks.sort(key=lambda x: x.current_streak, reverse=True)
+
+    return RoutineStats(
+        completion_rate=round(completion_rate, 4),
+        total_completed=total_completed,
+        total_scheduled=total_scheduled,
+        daily_completions=daily_completions,
+        streaks=streaks,
     )

--- a/backend/app/schemas/analytics.py
+++ b/backend/app/schemas/analytics.py
@@ -54,6 +54,21 @@ class PlannedItemStats(BaseModel):
     daily_completions: list[DailyCount]
 
 
+class RoutineStreak(BaseModel):
+    routine_id: int
+    name: str
+    current_streak: int
+    longest_streak: int
+
+
+class RoutineStats(BaseModel):
+    completion_rate: float
+    total_completed: int
+    total_scheduled: int
+    daily_completions: list[DailyCount]
+    streaks: list[RoutineStreak]
+
+
 class AnalyticsSummaryResponse(BaseModel):
     period: Literal["week", "month", "year"]
     start_date: date
@@ -61,3 +76,4 @@ class AnalyticsSummaryResponse(BaseModel):
     chores: ChoreStats
     medications: MedicationStats
     planned_items: PlannedItemStats
+    routines: RoutineStats

--- a/backend/app/services/export_import_service.py
+++ b/backend/app/services/export_import_service.py
@@ -5,11 +5,14 @@ import json
 from collections.abc import Iterable, Mapping
 from datetime import date, datetime, time, timezone
 from io import StringIO
-from typing import Any, NoReturn
+from typing import Any, NoReturn, TypeVar
 
 from fastapi import HTTPException, status
 from sqlalchemy import delete
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
+
+_E = TypeVar("_E")
 
 from app.core.enums import ChoreStatus, MedicationDoseStatus, Priority, TaskStatus
 from app.models.chore_instance import ChoreInstance
@@ -236,7 +239,7 @@ def import_user_export(db: Session, user: User, payload: Mapping[str, Any], *, r
             start_date=_date(row.get("start_date"), "chore_templates.start_date"),
             every_n_days=_int(row.get("every_n_days"), "chore_templates.every_n_days"),
             rrule=_nullable_str(row.get("rrule"), "chore_templates.rrule"),
-            priority=Priority(_str(row.get("priority", Priority.normal.value), "chore_templates.priority")),
+            priority=_enum(Priority, row.get("priority", Priority.normal.value), "chore_templates.priority"),
             tags=_list(row.get("tags"), "chore_templates.tags"),
             is_active=_bool(row.get("is_active"), "chore_templates.is_active"),
             created_at=_datetime(row.get("created_at"), "chore_templates.created_at"),
@@ -270,7 +273,7 @@ def import_user_export(db: Session, user: User, payload: Mapping[str, Any], *, r
             title=_str(row.get("title"), "task_instances.title"),
             scheduled_date=_date(row.get("scheduled_date"), "task_instances.scheduled_date"),
             due_at=_nullable_datetime(row.get("due_at"), "task_instances.due_at"),
-            status=TaskStatus(_str(row.get("status"), "task_instances.status")),
+            status=_enum(TaskStatus, row.get("status"), "task_instances.status"),
             completed_at=_nullable_datetime(row.get("completed_at"), "task_instances.completed_at"),
             created_at=_datetime(row.get("created_at"), "task_instances.created_at"),
         )
@@ -283,7 +286,7 @@ def import_user_export(db: Session, user: User, payload: Mapping[str, Any], *, r
             chore_template_id=_mapped_id(chore_id_map, row.get("chore_template_id"), "chore_instances.chore_template_id"),
             title=_str(row.get("title"), "chore_instances.title"),
             scheduled_date=_date(row.get("scheduled_date"), "chore_instances.scheduled_date"),
-            status=ChoreStatus(_str(row.get("status"), "chore_instances.status")),
+            status=_enum(ChoreStatus, row.get("status"), "chore_instances.status"),
             completed_at=_nullable_datetime(row.get("completed_at"), "chore_instances.completed_at"),
             skipped_at=_nullable_datetime(row.get("skipped_at"), "chore_instances.skipped_at"),
             created_at=_datetime(row.get("created_at"), "chore_instances.created_at"),
@@ -303,7 +306,7 @@ def import_user_export(db: Session, user: User, payload: Mapping[str, Any], *, r
             instructions=_str(row.get("instructions"), "medication_dose_instances.instructions"),
             scheduled_date=_date(row.get("scheduled_date"), "medication_dose_instances.scheduled_date"),
             scheduled_at=_datetime(row.get("scheduled_at"), "medication_dose_instances.scheduled_at"),
-            status=MedicationDoseStatus(_str(row.get("status"), "medication_dose_instances.status")),
+            status=_enum(MedicationDoseStatus, row.get("status"), "medication_dose_instances.status"),
             taken_at=_nullable_datetime(row.get("taken_at"), "medication_dose_instances.taken_at"),
             skipped_at=_nullable_datetime(row.get("skipped_at"), "medication_dose_instances.skipped_at"),
             missed_at=_nullable_datetime(row.get("missed_at"), "medication_dose_instances.missed_at"),
@@ -322,7 +325,7 @@ def import_user_export(db: Session, user: User, payload: Mapping[str, Any], *, r
             linked_source=_nullable_str(row.get("linked_source"), "planned_items.linked_source"),
             linked_ref=_nullable_str(row.get("linked_ref"), "planned_items.linked_ref"),
             planned_for=_date(row.get("planned_for"), "planned_items.planned_for"),
-            priority=Priority(_str(row.get("priority", Priority.normal.value), "planned_items.priority")),
+            priority=_enum(Priority, row.get("priority", Priority.normal.value), "planned_items.priority"),
             tags=_list(row.get("tags"), "planned_items.tags"),
             is_done=_bool(row.get("is_done"), "planned_items.is_done"),
             completed_at=_nullable_datetime(row.get("completed_at"), "planned_items.completed_at"),
@@ -331,7 +334,14 @@ def import_user_export(db: Session, user: User, payload: Mapping[str, Any], *, r
         db.add(item)
         counts["planned_items"] += 1
 
-    db.commit()
+    try:
+        db.commit()
+    except IntegrityError as exc:
+        db.rollback()
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=f"Import conflicts with existing data: {exc.orig}",
+        ) from exc
     return counts
 
 
@@ -420,6 +430,15 @@ def _bool(value: Any, field: str) -> bool:
     if not isinstance(value, bool):
         _invalid(f"{field} must be a boolean")
     return value
+
+
+def _enum(cls: type[_E], value: Any, field: str) -> _E:
+    s = _str(value, field)
+    try:
+        return cls(s)  # type: ignore[call-arg]
+    except ValueError:
+        valid = ", ".join(m.value for m in cls)  # type: ignore[attr-defined]
+        _invalid(f"{field} has invalid value '{s}'; expected one of: {valid}")
 
 
 def _list(value: Any, field: str) -> list[Any]:

--- a/backend/tests/test_analytics_api.py
+++ b/backend/tests/test_analytics_api.py
@@ -4,13 +4,15 @@ from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
 
 from app.api.dependencies.auth import get_current_user
-from app.core.enums import ChoreStatus, MedicationDoseStatus
+from app.core.enums import ChoreStatus, MedicationDoseStatus, TaskStatus
 from app.main import app
 from app.models.chore_instance import ChoreInstance
 from app.models.chore_template import ChoreTemplate
 from app.models.medication_dose_instance import MedicationDoseInstance
 from app.models.medication_plan import MedicationPlan
 from app.models.planned_item import PlannedItem
+from app.models.routine_template import RoutineTemplate
+from app.models.task_instance import TaskInstance
 from app.models.user import User
 
 
@@ -231,3 +233,107 @@ def test_analytics_streaks_use_bounded_recent_history(client: TestClient, db_ses
     assert response.json()["chores"]["streaks"] == [
         {"chore_id": chore_template.id, "name": "Dishes", "current_streak": 3, "longest_streak": 3}
     ]
+
+
+def _add_task(
+    db_session: Session,
+    user: User,
+    template: RoutineTemplate,
+    scheduled_date: date,
+    status: TaskStatus,
+) -> None:
+    db_session.add(
+        TaskInstance(
+            user_id=user.id,
+            routine_template_id=template.id,
+            title=template.name,
+            scheduled_date=scheduled_date,
+            status=status,
+            completed_at=datetime.now(timezone.utc) if status == TaskStatus.completed else None,
+        )
+    )
+
+
+def test_analytics_includes_routine_streaks(client: TestClient, db_session: Session) -> None:
+    user = _create_user(db_session, email="analytics-routine-streaks@example.com")
+    today = date.today()
+
+    routine = RoutineTemplate(
+        user_id=user.id,
+        name="Morning stretches",
+        description=None,
+        start_date=today - timedelta(days=6),
+        every_n_days=1,
+        is_active=True,
+    )
+    db_session.add(routine)
+    db_session.commit()
+    db_session.refresh(routine)
+
+    # completed 3 days ago; skipped 2 days ago; completed yesterday and today → current streak = 2, longest = 2
+    _add_task(db_session, user, routine, today - timedelta(days=3), TaskStatus.completed)
+    _add_task(db_session, user, routine, today - timedelta(days=2), TaskStatus.skipped)
+    _add_task(db_session, user, routine, today - timedelta(days=1), TaskStatus.completed)
+    _add_task(db_session, user, routine, today, TaskStatus.completed)
+    db_session.commit()
+
+    _auth_as(user)
+    try:
+        response = client.get("/api/v1/analytics/summary?period=week")
+    finally:
+        _clear_auth()
+
+    assert response.status_code == 200
+    routines = response.json()["routines"]
+    assert routines["total_completed"] == 3
+    assert routines["total_scheduled"] == 4
+    assert routines["completion_rate"] == 0.75
+    assert len(routines["daily_completions"]) == 7
+    assert routines["streaks"] == [
+        {"routine_id": routine.id, "name": "Morning stretches", "current_streak": 2, "longest_streak": 2}
+    ]
+
+
+def test_analytics_routine_streaks_do_not_leak_across_users(client: TestClient, db_session: Session) -> None:
+    owner = _create_user(db_session, email="analytics-routine-owner@example.com")
+    other = _create_user(db_session, email="analytics-routine-other@example.com")
+    today = date.today()
+
+    routine = RoutineTemplate(
+        user_id=owner.id,
+        name="Owner routine",
+        description=None,
+        start_date=today,
+        every_n_days=1,
+        is_active=True,
+    )
+    db_session.add(routine)
+    db_session.commit()
+    db_session.refresh(routine)
+    _add_task(db_session, owner, routine, today, TaskStatus.completed)
+    db_session.commit()
+
+    _auth_as(other)
+    try:
+        response = client.get("/api/v1/analytics/summary?period=week")
+    finally:
+        _clear_auth()
+
+    assert response.status_code == 200
+    assert response.json()["routines"]["streaks"] == []
+    assert response.json()["routines"]["total_completed"] == 0
+
+
+def test_analytics_summary_response_includes_routines_key(client: TestClient, db_session: Session) -> None:
+    user = _create_user(db_session, email="analytics-routines-key@example.com")
+    _auth_as(user)
+    try:
+        response = client.get("/api/v1/analytics/summary")
+    finally:
+        _clear_auth()
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert "routines" in payload
+    assert "streaks" in payload["routines"]
+    assert "daily_completions" in payload["routines"]

--- a/backend/tests/test_search.py
+++ b/backend/tests/test_search.py
@@ -1,0 +1,209 @@
+from datetime import date, time
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+from app.api.dependencies.auth import get_current_user
+from app.core.enums import Priority
+from app.main import app
+from app.models.chore_template import ChoreTemplate
+from app.models.medication_plan import MedicationPlan
+from app.models.planned_item import PlannedItem
+from app.models.routine_template import RoutineTemplate
+from app.models.user import User
+
+
+def _create_user(db: Session, email: str) -> User:
+    user = User(email=email, full_name="Search User", is_active=True)
+    db.add(user)
+    db.commit()
+    db.refresh(user)
+    return user
+
+
+def _auth_as(user: User) -> None:
+    async def _dep() -> User:
+        return user
+
+    app.dependency_overrides[get_current_user] = _dep
+
+
+def _clear_auth() -> None:
+    app.dependency_overrides.pop(get_current_user, None)
+
+
+def _seed(db: Session, user: User) -> None:
+    db.add_all(
+        [
+            RoutineTemplate(
+                user_id=user.id,
+                name="Morning stretches",
+                description="Light yoga flow",
+                start_date=date(2026, 1, 1),
+                every_n_days=1,
+                is_active=True,
+            ),
+            RoutineTemplate(
+                user_id=user.id,
+                name="Evening reading",
+                description=None,
+                start_date=date(2026, 1, 1),
+                every_n_days=1,
+                is_active=True,
+            ),
+            ChoreTemplate(
+                user_id=user.id,
+                name="Vacuum living room",
+                description="Including under sofa",
+                start_date=date(2026, 1, 1),
+                every_n_days=7,
+                priority=Priority.normal,
+                tags=["home"],
+                is_active=True,
+            ),
+            ChoreTemplate(
+                user_id=user.id,
+                name="Laundry",
+                description=None,
+                start_date=date(2026, 1, 1),
+                every_n_days=7,
+                priority=Priority.high,
+                tags=[],
+                is_active=True,
+            ),
+            MedicationPlan(
+                user_id=user.id,
+                name="Vitamin D",
+                instructions="Take with breakfast",
+                start_date=date(2026, 1, 1),
+                schedule_time=time(9, 0),
+                every_n_days=1,
+                is_active=True,
+            ),
+            PlannedItem(
+                user_id=user.id,
+                title="Meal prep Sunday",
+                notes="Batch cook rice and veggies",
+                planned_for=date(2026, 5, 5),
+                priority=Priority.normal,
+                tags=[],
+                is_done=False,
+            ),
+            PlannedItem(
+                user_id=user.id,
+                title="Buy groceries",
+                notes=None,
+                planned_for=date(2026, 5, 6),
+                priority=Priority.normal,
+                tags=[],
+                is_done=False,
+            ),
+        ]
+    )
+    db.commit()
+
+
+@pytest.fixture(autouse=True)
+def _cleanup():
+    yield
+    _clear_auth()
+
+
+def test_search_returns_grouped_results(client: TestClient, db_session: Session) -> None:
+    user = _create_user(db_session, "search1@example.com")
+    _seed(db_session, user)
+    _auth_as(user)
+
+    response = client.get("/api/v1/search?q=vitamin")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["query"] == "vitamin"
+    assert len(data["medication_plans"]) == 1
+    assert data["medication_plans"][0]["name"] == "Vitamin D"
+    assert data["routine_templates"] == []
+    assert data["chore_templates"] == []
+    assert data["planned_items"] == []
+
+
+def test_search_matches_description_field(client: TestClient, db_session: Session) -> None:
+    user = _create_user(db_session, "search2@example.com")
+    _seed(db_session, user)
+    _auth_as(user)
+
+    response = client.get("/api/v1/search?q=yoga")
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data["routine_templates"]) == 1
+    assert data["routine_templates"][0]["name"] == "Morning stretches"
+
+
+def test_search_is_case_insensitive(client: TestClient, db_session: Session) -> None:
+    user = _create_user(db_session, "search3@example.com")
+    _seed(db_session, user)
+    _auth_as(user)
+
+    response = client.get("/api/v1/search?q=MEAL")
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data["planned_items"]) == 1
+    assert data["planned_items"][0]["title"] == "Meal prep Sunday"
+
+
+def test_search_matches_planned_item_notes(client: TestClient, db_session: Session) -> None:
+    user = _create_user(db_session, "search4@example.com")
+    _seed(db_session, user)
+    _auth_as(user)
+
+    response = client.get("/api/v1/search?q=batch+cook")
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data["planned_items"]) == 1
+    assert data["planned_items"][0]["title"] == "Meal prep Sunday"
+
+
+def test_search_does_not_leak_other_users_data(client: TestClient, db_session: Session) -> None:
+    owner = _create_user(db_session, "search-owner@example.com")
+    other = _create_user(db_session, "search-other@example.com")
+    _seed(db_session, owner)
+    _auth_as(other)
+
+    response = client.get("/api/v1/search?q=vitamin")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["medication_plans"] == []
+
+
+def test_search_rejects_query_shorter_than_two_chars(client: TestClient, db_session: Session) -> None:
+    user = _create_user(db_session, "search5@example.com")
+    _auth_as(user)
+
+    response = client.get("/api/v1/search?q=a")
+    assert response.status_code == 422
+
+
+def test_search_requires_authentication(client: TestClient) -> None:
+    response = client.get("/api/v1/search?q=vitamin")
+    assert response.status_code == 401
+
+
+def test_search_limit_caps_results(client: TestClient, db_session: Session) -> None:
+    user = _create_user(db_session, "search6@example.com")
+    for i in range(5):
+        db_session.add(
+            PlannedItem(
+                user_id=user.id,
+                title=f"Shopping item {i}",
+                notes=None,
+                planned_for=date(2026, 5, i + 1),
+                priority=Priority.normal,
+                tags=[],
+                is_done=False,
+            )
+        )
+    db_session.commit()
+    _auth_as(user)
+
+    response = client.get("/api/v1/search?q=shopping&limit=3")
+    assert response.status_code == 200
+    assert len(response.json()["planned_items"]) == 3


### PR DESCRIPTION
## Summary

- Adds `GET /api/v1/search?q=` returning results grouped by type: routine templates, chore templates, medication plans, and planned items
- Case-insensitive match across name/title and description/notes/instructions fields
- Per-type `limit` param (default 20, max 100); query enforces min 2 chars
- Results are scoped to the authenticated user — no cross-user leakage

> Backend portion of #282. Frontend (header search input, Ctrl+K, grouped results UI) remains open.

## Test plan

- [ ] Returns grouped results matching on name field
- [ ] Matches description/notes fields
- [ ] Case-insensitive matching
- [ ] Does not return other users' data
- [ ] Rejects queries shorter than 2 chars (422)
- [ ] Returns 401 without authentication
- [ ] `limit` param caps results per type

Stacked on #296