### PR TITLE
feat: routine streaks in analytics summary (#287)

### DIFF
--- a/backend/app/api/routes/analytics.py
+++ b/backend/app/api/routes/analytics.py
@@ -7,7 +7,7 @@ from sqlalchemy.orm import Session
 from app.api.dependencies.auth import get_current_user
 from app.db.session import get_db
 from app.models.user import User
-from app.repositories.analytics_repository import get_chore_stats, get_medication_stats, get_planned_item_stats
+from app.repositories.analytics_repository import get_chore_stats, get_medication_stats, get_planned_item_stats, get_routine_stats
 from app.schemas.analytics import AnalyticsSummaryResponse
 
 router = APIRouter(prefix="/analytics", tags=["analytics"])
@@ -38,4 +38,5 @@ def get_analytics_summary(
         chores=get_chore_stats(db, current_user.id, start_date, end_date),
         medications=get_medication_stats(db, current_user.id, start_date, end_date),
         planned_items=get_planned_item_stats(db, current_user.id, start_date, end_date),
+        routines=get_routine_stats(db, current_user.id, start_date, end_date),
     )

--- a/backend/app/api/routes/search.py
+++ b/backend/app/api/routes/search.py
@@ -4,6 +4,7 @@ from datetime import date, datetime
 
 from fastapi import APIRouter, Depends, Query
 from pydantic import BaseModel
+from sqlalchemy import select
 from sqlalchemy.orm import Session
 
 from app.api.dependencies.auth import get_current_user
@@ -17,6 +18,12 @@ from app.models.user import User
 router = APIRouter(prefix="/search", tags=["search"])
 
 _DEFAULT_LIMIT = 20
+_ESCAPE_CHAR = "\\"
+
+
+def _like_pattern(q: str) -> str:
+    escaped = q.replace(_ESCAPE_CHAR, _ESCAPE_CHAR * 2).replace("%", f"{_ESCAPE_CHAR}%").replace("_", f"{_ESCAPE_CHAR}_")
+    return f"%{escaped}%"
 
 
 class RoutineSearchResult(BaseModel):
@@ -71,52 +78,52 @@ def search(
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ) -> SearchResponse:
-    pattern = f"%{q}%"
+    pattern = _like_pattern(q)
     uid = current_user.id
 
-    routines = (
-        db.query(RoutineTemplate)
-        .filter(
+    routines = db.scalars(
+        select(RoutineTemplate)
+        .where(
             RoutineTemplate.user_id == uid,
-            (RoutineTemplate.name.ilike(pattern)) | (RoutineTemplate.description.ilike(pattern)),
+            (RoutineTemplate.name.ilike(pattern, escape=_ESCAPE_CHAR))
+            | (RoutineTemplate.description.ilike(pattern, escape=_ESCAPE_CHAR)),
         )
         .order_by(RoutineTemplate.name)
         .limit(limit)
-        .all()
-    )
+    ).all()
 
-    chores = (
-        db.query(ChoreTemplate)
-        .filter(
+    chores = db.scalars(
+        select(ChoreTemplate)
+        .where(
             ChoreTemplate.user_id == uid,
-            (ChoreTemplate.name.ilike(pattern)) | (ChoreTemplate.description.ilike(pattern)),
+            (ChoreTemplate.name.ilike(pattern, escape=_ESCAPE_CHAR))
+            | (ChoreTemplate.description.ilike(pattern, escape=_ESCAPE_CHAR)),
         )
         .order_by(ChoreTemplate.name)
         .limit(limit)
-        .all()
-    )
+    ).all()
 
-    medications = (
-        db.query(MedicationPlan)
-        .filter(
+    medications = db.scalars(
+        select(MedicationPlan)
+        .where(
             MedicationPlan.user_id == uid,
-            (MedicationPlan.name.ilike(pattern)) | (MedicationPlan.instructions.ilike(pattern)),
+            (MedicationPlan.name.ilike(pattern, escape=_ESCAPE_CHAR))
+            | (MedicationPlan.instructions.ilike(pattern, escape=_ESCAPE_CHAR)),
         )
         .order_by(MedicationPlan.name)
         .limit(limit)
-        .all()
-    )
+    ).all()
 
-    planned = (
-        db.query(PlannedItem)
-        .filter(
+    planned = db.scalars(
+        select(PlannedItem)
+        .where(
             PlannedItem.user_id == uid,
-            (PlannedItem.title.ilike(pattern)) | (PlannedItem.notes.ilike(pattern)),
+            (PlannedItem.title.ilike(pattern, escape=_ESCAPE_CHAR))
+            | (PlannedItem.notes.ilike(pattern, escape=_ESCAPE_CHAR)),
         )
         .order_by(PlannedItem.planned_for.desc(), PlannedItem.title)
         .limit(limit)
-        .all()
-    )
+    ).all()
 
     return SearchResponse(
         query=q,
@@ -135,7 +142,7 @@ def search(
                 id=c.id,
                 name=c.name,
                 description=c.description,
-                priority=c.priority.value if hasattr(c.priority, "value") else c.priority,
+                priority=c.priority,
                 tags=c.tags or [],
                 is_active=c.is_active,
                 created_at=c.created_at,
@@ -158,7 +165,7 @@ def search(
                 title=p.title,
                 notes=p.notes,
                 planned_for=p.planned_for,
-                priority=p.priority.value if hasattr(p.priority, "value") else p.priority,
+                priority=p.priority,
                 tags=p.tags or [],
                 is_done=p.is_done,
                 created_at=p.created_at,

--- a/backend/app/repositories/analytics_repository.py
+++ b/backend/app/repositories/analytics_repository.py
@@ -248,7 +248,7 @@ def get_routine_stats(db: Session, user_id: int, start_date: date, end_date: dat
         .where(TaskInstance.user_id == user_id)
         .where(TaskInstance.scheduled_date >= streak_start_date)
         .where(TaskInstance.scheduled_date <= end_date)
-        .where(TaskInstance.status != TaskStatus.pending)
+        .where(TaskInstance.status.notin_([TaskStatus.pending, TaskStatus.in_progress]))
         .order_by(TaskInstance.routine_template_id, TaskInstance.scheduled_date)
     ).all()
 

--- a/backend/app/repositories/analytics_repository.py
+++ b/backend/app/repositories/analytics_repository.py
@@ -4,11 +4,13 @@ from datetime import date, timedelta
 from sqlalchemy import case, func, select
 from sqlalchemy.orm import Session
 
-from app.core.enums import ChoreStatus, MedicationDoseStatus
+from app.core.enums import ChoreStatus, MedicationDoseStatus, TaskStatus
 from app.models.chore_instance import ChoreInstance
 from app.models.chore_template import ChoreTemplate
 from app.models.medication_dose_instance import MedicationDoseInstance
 from app.models.planned_item import PlannedItem
+from app.models.routine_template import RoutineTemplate
+from app.models.task_instance import TaskInstance
 from app.schemas.analytics import (
     ChoreStats,
     ChoreStreak,
@@ -16,6 +18,8 @@ from app.schemas.analytics import (
     DailyCount,
     MedicationStats,
     PlannedItemStats,
+    RoutineStats,
+    RoutineStreak,
     SkippedChore,
 )
 
@@ -204,4 +208,86 @@ def get_planned_item_stats(db: Session, user_id: int, start_date: date, end_date
         total_completed=total_completed,
         total_scheduled=total_scheduled,
         daily_completions=daily_completions,
+    )
+
+
+def get_routine_stats(db: Session, user_id: int, start_date: date, end_date: date) -> RoutineStats:
+    daily_rows = db.execute(
+        select(
+            TaskInstance.scheduled_date,
+            func.count(TaskInstance.id),
+            func.sum(case((TaskInstance.status == TaskStatus.completed, 1), else_=0)),
+        )
+        .where(TaskInstance.user_id == user_id)
+        .where(TaskInstance.scheduled_date >= start_date)
+        .where(TaskInstance.scheduled_date <= end_date)
+        .group_by(TaskInstance.scheduled_date)
+    ).all()
+
+    by_date = {row[0]: {"total": int(row[1]), "completed": int(row[2] or 0)} for row in daily_rows}
+
+    dates = _date_range(start_date, end_date)
+    daily_completions = []
+    for d in dates:
+        total = by_date.get(d, {}).get("total", 0)
+        completed = by_date.get(d, {}).get("completed", 0)
+        daily_completions.append(DailyCount(date=d, completed=completed, total=total, completion_rate=_rate(completed, total)))
+
+    total_completed = sum(day["completed"] for day in by_date.values())
+    total_scheduled = sum(day["total"] for day in by_date.values())
+    completion_rate = _rate(total_completed, total_scheduled)
+
+    streak_start_date = _streak_lookback_start(start_date, end_date)
+    templates = {
+        t.id: t.name
+        for t in db.scalars(select(RoutineTemplate).where(RoutineTemplate.user_id == user_id)).all()
+    }
+
+    all_resolved = db.scalars(
+        select(TaskInstance)
+        .where(TaskInstance.user_id == user_id)
+        .where(TaskInstance.scheduled_date >= streak_start_date)
+        .where(TaskInstance.scheduled_date <= end_date)
+        .where(TaskInstance.status != TaskStatus.pending)
+        .order_by(TaskInstance.routine_template_id, TaskInstance.scheduled_date)
+    ).all()
+
+    by_template: dict[int, list[TaskInstance]] = defaultdict(list)
+    for inst in all_resolved:
+        by_template[inst.routine_template_id].append(inst)
+
+    streaks: list[RoutineStreak] = []
+    for template_id, insts in by_template.items():
+        name = templates.get(template_id, f"Routine #{template_id}")
+
+        current = 0
+        for inst in reversed(insts):
+            if inst.status == TaskStatus.completed:
+                current += 1
+            else:
+                break
+
+        longest, run = 0, 0
+        for inst in insts:
+            if inst.status == TaskStatus.completed:
+                run += 1
+                longest = max(longest, run)
+            else:
+                run = 0
+
+        streaks.append(RoutineStreak(
+            routine_id=template_id,
+            name=name,
+            current_streak=current,
+            longest_streak=longest,
+        ))
+
+    streaks.sort(key=lambda x: x.current_streak, reverse=True)
+
+    return RoutineStats(
+        completion_rate=round(completion_rate, 4),
+        total_completed=total_completed,
+        total_scheduled=total_scheduled,
+        daily_completions=daily_completions,
+        streaks=streaks,
     )

--- a/backend/app/schemas/analytics.py
+++ b/backend/app/schemas/analytics.py
@@ -54,6 +54,21 @@ class PlannedItemStats(BaseModel):
     daily_completions: list[DailyCount]
 
 
+class RoutineStreak(BaseModel):
+    routine_id: int
+    name: str
+    current_streak: int
+    longest_streak: int
+
+
+class RoutineStats(BaseModel):
+    completion_rate: float
+    total_completed: int
+    total_scheduled: int
+    daily_completions: list[DailyCount]
+    streaks: list[RoutineStreak]
+
+
 class AnalyticsSummaryResponse(BaseModel):
     period: Literal["week", "month", "year"]
     start_date: date
@@ -61,3 +76,4 @@ class AnalyticsSummaryResponse(BaseModel):
     chores: ChoreStats
     medications: MedicationStats
     planned_items: PlannedItemStats
+    routines: RoutineStats

--- a/backend/app/services/export_import_service.py
+++ b/backend/app/services/export_import_service.py
@@ -5,11 +5,14 @@ import json
 from collections.abc import Iterable, Mapping
 from datetime import date, datetime, time, timezone
 from io import StringIO
-from typing import Any, NoReturn
+from typing import Any, NoReturn, TypeVar
 
 from fastapi import HTTPException, status
 from sqlalchemy import delete
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
+
+_E = TypeVar("_E")
 
 from app.core.enums import ChoreStatus, MedicationDoseStatus, Priority, TaskStatus
 from app.models.chore_instance import ChoreInstance
@@ -236,7 +239,7 @@ def import_user_export(db: Session, user: User, payload: Mapping[str, Any], *, r
             start_date=_date(row.get("start_date"), "chore_templates.start_date"),
             every_n_days=_int(row.get("every_n_days"), "chore_templates.every_n_days"),
             rrule=_nullable_str(row.get("rrule"), "chore_templates.rrule"),
-            priority=Priority(_str(row.get("priority", Priority.normal.value), "chore_templates.priority")),
+            priority=_enum(Priority, row.get("priority", Priority.normal.value), "chore_templates.priority"),
             tags=_list(row.get("tags"), "chore_templates.tags"),
             is_active=_bool(row.get("is_active"), "chore_templates.is_active"),
             created_at=_datetime(row.get("created_at"), "chore_templates.created_at"),
@@ -270,7 +273,7 @@ def import_user_export(db: Session, user: User, payload: Mapping[str, Any], *, r
             title=_str(row.get("title"), "task_instances.title"),
             scheduled_date=_date(row.get("scheduled_date"), "task_instances.scheduled_date"),
             due_at=_nullable_datetime(row.get("due_at"), "task_instances.due_at"),
-            status=TaskStatus(_str(row.get("status"), "task_instances.status")),
+            status=_enum(TaskStatus, row.get("status"), "task_instances.status"),
             completed_at=_nullable_datetime(row.get("completed_at"), "task_instances.completed_at"),
             created_at=_datetime(row.get("created_at"), "task_instances.created_at"),
         )
@@ -283,7 +286,7 @@ def import_user_export(db: Session, user: User, payload: Mapping[str, Any], *, r
             chore_template_id=_mapped_id(chore_id_map, row.get("chore_template_id"), "chore_instances.chore_template_id"),
             title=_str(row.get("title"), "chore_instances.title"),
             scheduled_date=_date(row.get("scheduled_date"), "chore_instances.scheduled_date"),
-            status=ChoreStatus(_str(row.get("status"), "chore_instances.status")),
+            status=_enum(ChoreStatus, row.get("status"), "chore_instances.status"),
             completed_at=_nullable_datetime(row.get("completed_at"), "chore_instances.completed_at"),
             skipped_at=_nullable_datetime(row.get("skipped_at"), "chore_instances.skipped_at"),
             created_at=_datetime(row.get("created_at"), "chore_instances.created_at"),
@@ -303,7 +306,7 @@ def import_user_export(db: Session, user: User, payload: Mapping[str, Any], *, r
             instructions=_str(row.get("instructions"), "medication_dose_instances.instructions"),
             scheduled_date=_date(row.get("scheduled_date"), "medication_dose_instances.scheduled_date"),
             scheduled_at=_datetime(row.get("scheduled_at"), "medication_dose_instances.scheduled_at"),
-            status=MedicationDoseStatus(_str(row.get("status"), "medication_dose_instances.status")),
+            status=_enum(MedicationDoseStatus, row.get("status"), "medication_dose_instances.status"),
             taken_at=_nullable_datetime(row.get("taken_at"), "medication_dose_instances.taken_at"),
             skipped_at=_nullable_datetime(row.get("skipped_at"), "medication_dose_instances.skipped_at"),
             missed_at=_nullable_datetime(row.get("missed_at"), "medication_dose_instances.missed_at"),
@@ -322,7 +325,7 @@ def import_user_export(db: Session, user: User, payload: Mapping[str, Any], *, r
             linked_source=_nullable_str(row.get("linked_source"), "planned_items.linked_source"),
             linked_ref=_nullable_str(row.get("linked_ref"), "planned_items.linked_ref"),
             planned_for=_date(row.get("planned_for"), "planned_items.planned_for"),
-            priority=Priority(_str(row.get("priority", Priority.normal.value), "planned_items.priority")),
+            priority=_enum(Priority, row.get("priority", Priority.normal.value), "planned_items.priority"),
             tags=_list(row.get("tags"), "planned_items.tags"),
             is_done=_bool(row.get("is_done"), "planned_items.is_done"),
             completed_at=_nullable_datetime(row.get("completed_at"), "planned_items.completed_at"),
@@ -331,7 +334,14 @@ def import_user_export(db: Session, user: User, payload: Mapping[str, Any], *, r
         db.add(item)
         counts["planned_items"] += 1
 
-    db.commit()
+    try:
+        db.commit()
+    except IntegrityError as exc:
+        db.rollback()
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=f"Import conflicts with existing data: {exc.orig}",
+        ) from exc
     return counts
 
 
@@ -420,6 +430,15 @@ def _bool(value: Any, field: str) -> bool:
     if not isinstance(value, bool):
         _invalid(f"{field} must be a boolean")
     return value
+
+
+def _enum(cls: type[_E], value: Any, field: str) -> _E:
+    s = _str(value, field)
+    try:
+        return cls(s)  # type: ignore[call-arg]
+    except ValueError:
+        valid = ", ".join(m.value for m in cls)  # type: ignore[attr-defined]
+        _invalid(f"{field} has invalid value '{s}'; expected one of: {valid}")
 
 
 def _list(value: Any, field: str) -> list[Any]:

--- a/backend/tests/test_analytics_api.py
+++ b/backend/tests/test_analytics_api.py
@@ -270,7 +270,7 @@ def test_analytics_includes_routine_streaks(client: TestClient, db_session: Sess
     db_session.commit()
     db_session.refresh(routine)
 
-    # completed 3 days ago and yesterday; skipped 2 days ago; completed today → current streak = 1, longest = 2
+    # completed 3 days ago; skipped 2 days ago; completed yesterday and today → current streak = 2, longest = 2
     _add_task(db_session, user, routine, today - timedelta(days=3), TaskStatus.completed)
     _add_task(db_session, user, routine, today - timedelta(days=2), TaskStatus.skipped)
     _add_task(db_session, user, routine, today - timedelta(days=1), TaskStatus.completed)

--- a/backend/tests/test_analytics_api.py
+++ b/backend/tests/test_analytics_api.py
@@ -4,13 +4,15 @@ from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
 
 from app.api.dependencies.auth import get_current_user
-from app.core.enums import ChoreStatus, MedicationDoseStatus
+from app.core.enums import ChoreStatus, MedicationDoseStatus, TaskStatus
 from app.main import app
 from app.models.chore_instance import ChoreInstance
 from app.models.chore_template import ChoreTemplate
 from app.models.medication_dose_instance import MedicationDoseInstance
 from app.models.medication_plan import MedicationPlan
 from app.models.planned_item import PlannedItem
+from app.models.routine_template import RoutineTemplate
+from app.models.task_instance import TaskInstance
 from app.models.user import User
 
 
@@ -231,3 +233,107 @@ def test_analytics_streaks_use_bounded_recent_history(client: TestClient, db_ses
     assert response.json()["chores"]["streaks"] == [
         {"chore_id": chore_template.id, "name": "Dishes", "current_streak": 3, "longest_streak": 3}
     ]
+
+
+def _add_task(
+    db_session: Session,
+    user: User,
+    template: RoutineTemplate,
+    scheduled_date: date,
+    status: TaskStatus,
+) -> None:
+    db_session.add(
+        TaskInstance(
+            user_id=user.id,
+            routine_template_id=template.id,
+            title=template.name,
+            scheduled_date=scheduled_date,
+            status=status,
+            completed_at=datetime.now(timezone.utc) if status == TaskStatus.completed else None,
+        )
+    )
+
+
+def test_analytics_includes_routine_streaks(client: TestClient, db_session: Session) -> None:
+    user = _create_user(db_session, email="analytics-routine-streaks@example.com")
+    today = date.today()
+
+    routine = RoutineTemplate(
+        user_id=user.id,
+        name="Morning stretches",
+        description=None,
+        start_date=today - timedelta(days=6),
+        every_n_days=1,
+        is_active=True,
+    )
+    db_session.add(routine)
+    db_session.commit()
+    db_session.refresh(routine)
+
+    # completed 3 days ago and yesterday; skipped 2 days ago; completed today → current streak = 1, longest = 2
+    _add_task(db_session, user, routine, today - timedelta(days=3), TaskStatus.completed)
+    _add_task(db_session, user, routine, today - timedelta(days=2), TaskStatus.skipped)
+    _add_task(db_session, user, routine, today - timedelta(days=1), TaskStatus.completed)
+    _add_task(db_session, user, routine, today, TaskStatus.completed)
+    db_session.commit()
+
+    _auth_as(user)
+    try:
+        response = client.get("/api/v1/analytics/summary?period=week")
+    finally:
+        _clear_auth()
+
+    assert response.status_code == 200
+    routines = response.json()["routines"]
+    assert routines["total_completed"] == 3
+    assert routines["total_scheduled"] == 4
+    assert routines["completion_rate"] == 0.75
+    assert len(routines["daily_completions"]) == 7
+    assert routines["streaks"] == [
+        {"routine_id": routine.id, "name": "Morning stretches", "current_streak": 2, "longest_streak": 2}
+    ]
+
+
+def test_analytics_routine_streaks_do_not_leak_across_users(client: TestClient, db_session: Session) -> None:
+    owner = _create_user(db_session, email="analytics-routine-owner@example.com")
+    other = _create_user(db_session, email="analytics-routine-other@example.com")
+    today = date.today()
+
+    routine = RoutineTemplate(
+        user_id=owner.id,
+        name="Owner routine",
+        description=None,
+        start_date=today,
+        every_n_days=1,
+        is_active=True,
+    )
+    db_session.add(routine)
+    db_session.commit()
+    db_session.refresh(routine)
+    _add_task(db_session, owner, routine, today, TaskStatus.completed)
+    db_session.commit()
+
+    _auth_as(other)
+    try:
+        response = client.get("/api/v1/analytics/summary?period=week")
+    finally:
+        _clear_auth()
+
+    assert response.status_code == 200
+    assert response.json()["routines"]["streaks"] == []
+    assert response.json()["routines"]["total_completed"] == 0
+
+
+def test_analytics_summary_response_includes_routines_key(client: TestClient, db_session: Session) -> None:
+    user = _create_user(db_session, email="analytics-routines-key@example.com")
+    _auth_as(user)
+    try:
+        response = client.get("/api/v1/analytics/summary")
+    finally:
+        _clear_auth()
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert "routines" in payload
+    assert "streaks" in payload["routines"]
+    assert "daily_completions" in payload["routines"]


### PR DESCRIPTION
## Summary

- Adds `routines` section to `GET /api/v1/analytics/summary` with completion rate, daily completions, and current/longest streak per routine template
- Mirrors the existing chore streak logic (same bounded lookback window)
- Chore streaks were already present; this closes the routine gap called out in #287

> Backend portion of #287. Frontend streak badges, confetti animation, and Android push notifications remain open.

## Test plan

- [ ] `routines` key present in summary response
- [ ] `current_streak` and `longest_streak` computed correctly across completions and skips
- [ ] Routine data does not leak to other users
- [ ] Existing chore/medication/planned-item tests unaffected (129 passing)

Stacked on #297 → #296