### PR TITLE
Add MSW v2 demo, test, and screenshot fixture mode

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -2,7 +2,8 @@
 # Copy this file to .env.local and fill in your values.
 
 # Set to "true" to start in mock mode (no backend required).
-# Usage: VITE_MSW=true pnpm dev   OR   pnpm dev:mock
+# Cross-platform: pnpm dev:mock   (uses cross-env internally)
+# Or add VITE_MSW=true to a local .env.local file instead of the command line.
 VITE_MSW=false
 
 # OIDC / Keycloak settings (only required when VITE_MSW is not "true")

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,11 @@
+# Daynest frontend environment variables
+# Copy this file to .env.local and fill in your values.
+
+# Set to "true" to start in mock mode (no backend required).
+# Usage: VITE_MSW=true pnpm dev   OR   pnpm dev:mock
+VITE_MSW=false
+
+# OIDC / Keycloak settings (only required when VITE_MSW is not "true")
+# VITE_OIDC_CLIENT_ID=daynest
+# VITE_OIDC_REDIRECT_URI=http://localhost:5173/auth/callback
+# VITE_OIDC_SCOPE=openid profile email

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -40,6 +40,7 @@ Append `?mock-scenario=<name>` to the URL to load a specific fixture state. The 
 | `template-crud` | Templates pre-populated | Routine & chore template lists |
 | `signed-out` | Unauthenticated state | Login prompt, 401 responses |
 | `expired-session` | Expired token | Mid-session 401 responses |
+| `forbidden` | 403 on today + auth/me | Forbidden / access-denied UI |
 | `api-error` | Today endpoint returns 500 | Error boundary / retry UI |
 
 ### Recommended screenshot routes
@@ -50,7 +51,9 @@ Append `?mock-scenario=<name>` to the URL to load a specific fixture state. The 
 | `http://localhost:5173/today` | 390×844 (mobile) | Mobile today view |
 | `http://localhost:5173/today?mock-scenario=overdue` | 1280×800 | Overdue chores + missed meds |
 | `http://localhost:5173/today?mock-scenario=empty` | 1280×800 | Empty / first-run state |
+| `http://localhost:5173/today?mock-scenario=medication-refill` | 1280×800 | All four dose statuses (scheduled, taken, skipped, missed) |
 | `http://localhost:5173/today?mock-scenario=api-error` | 1280×800 | Error UI with retry |
+| `http://localhost:5173/templates?mock-scenario=template-crud` | 1280×800 | Template list with active + inactive items |
 
 ---
 

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,0 +1,128 @@
+# Daynest Frontend
+
+React 19 · TypeScript · TanStack Router / Query · Vite · Vitest
+
+## Getting started
+
+```bash
+pnpm install
+pnpm dev          # requires a running backend + Keycloak
+pnpm dev:mock     # no backend required — see Mock mode below
+pnpm build
+pnpm test
+```
+
+---
+
+## Mock mode
+
+Mock mode starts the app with MSW v2 intercepting all API calls. No backend, database, or Keycloak session is needed.
+
+```bash
+VITE_MSW=true pnpm dev
+# or shorthand:
+pnpm dev:mock
+```
+
+The service worker (`public/mockServiceWorker.js`) is kept up to date automatically by the `postinstall` script. If you upgrade MSW, reinstall dependencies to refresh it.
+
+### Fixture scenarios
+
+Append `?mock-scenario=<name>` to the URL to load a specific fixture state. The scenario is applied once on page load; refreshing the page resets it.
+
+| `?mock-scenario=` | Description | Key items to observe |
+|---|---|---|
+| `default` (or omitted) | Busy today view | Medications, routines, chores, planned items |
+| `empty` | Fresh household | All lists empty, first-run surfaces |
+| `busy-today` | Same as default | Multiple items across all sections |
+| `overdue` | Overdue chores + missed medications | Overdue section populated, missed-dose badges |
+| `medication-refill` | All medications active | Refill-needed edge cases |
+| `template-crud` | Templates pre-populated | Routine & chore template lists |
+| `signed-out` | Unauthenticated state | Login prompt, 401 responses |
+| `expired-session` | Expired token | Mid-session 401 responses |
+| `api-error` | Today endpoint returns 500 | Error boundary / retry UI |
+
+### Recommended screenshot routes
+
+| URL | Viewport | What to capture |
+|---|---|---|
+| `http://localhost:5173/today` | 1280×800 (desktop) | Today overview — all sections |
+| `http://localhost:5173/today` | 390×844 (mobile) | Mobile today view |
+| `http://localhost:5173/today?mock-scenario=overdue` | 1280×800 | Overdue chores + missed meds |
+| `http://localhost:5173/today?mock-scenario=empty` | 1280×800 | Empty / first-run state |
+| `http://localhost:5173/today?mock-scenario=api-error` | 1280×800 | Error UI with retry |
+
+---
+
+## Testing
+
+### Test suites
+
+| Suite | Command | Description |
+|---|---|---|
+| `dom` | `pnpm test` | Component tests (jsdom), mock API via `vi.mock()` |
+| `node` | `pnpm test` | Library / API fetch tests (Node environment) |
+| `msw` | `pnpm test` | Component + API tests backed by real MSW handlers |
+
+Run a specific suite:
+
+```bash
+pnpm vitest run --project msw
+pnpm vitest run --project dom
+```
+
+### Writing MSW-backed tests
+
+Place test files under `tests/msw/` with a `.test.ts` or `.test.tsx` extension. The `setup.msw.ts` file wires the server lifecycle automatically:
+
+- `server.listen()` before all tests
+- `setOidcAccessToken(MOCK_TOKEN)` before each test (satisfies the auth check in `fetchWithAuth`)
+- `server.resetHandlers()` + `resetMockState()` after each test
+
+Per-test handler overrides use `server.use()` — they are scoped to that test and cleaned up automatically:
+
+```typescript
+import { server } from "@/mocks/server";
+import { http, HttpResponse } from "msw";
+
+it("shows error UI on 500", async () => {
+  server.use(
+    http.get("/api/v1/today", () =>
+      HttpResponse.json({ detail: "Server error" }, { status: 500 }),
+    ),
+  );
+  // render and assert error UI...
+});
+```
+
+### Shared handlers
+
+All handlers live in `src/mocks/handlers/`. They read from and write to the in-memory state in `src/mocks/data/state.ts`. Call `resetMockState()` in `afterEach` (already done in `setup.msw.ts`) to restore the default seed data between tests.
+
+---
+
+## Project structure
+
+```
+src/
+├── app/            App bootstrap, providers, router, PWA, theme
+├── config/         OIDC config fetch
+├── features/       Feature modules (today, calendar, medication, etc.)
+├── lib/
+│   ├── api/        Typed fetch functions + Zod schemas
+│   ├── auth/       OIDC token bridge
+│   └── query/      TanStack QueryClient + query key factory
+├── i18n/           Paraglide language provider
+├── mocks/          MSW mock layer (browser + node)
+│   ├── browser.ts  setupWorker (browser demo mode)
+│   ├── server.ts   setupServer (Vitest)
+│   ├── MockAuthProvider.tsx
+│   ├── handlers/   Per-domain request handlers
+│   └── data/       Typed seed data + resettable state
+└── types/          Shared TypeScript types
+tests/
+├── features/       Component tests (dom project)
+├── lib/            API + utility tests (node project)
+├── msw/            MSW-backed integration tests (msw project)
+└── utils/          QueryTestProvider, router helpers
+```

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -106,7 +106,7 @@ All handlers live in `src/mocks/handlers/`. They read from and write to the in-m
 
 ## Project structure
 
-```
+```text
 src/
 ├── app/            App bootstrap, providers, router, PWA, theme
 ├── config/         OIDC config fetch

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -6,7 +6,7 @@
   "packageManager": "pnpm@10.32.1",
   "scripts": {
     "dev": "vite",
-    "dev:mock": "VITE_MSW=true vite",
+    "dev:mock": "cross-env VITE_MSW=true vite",
     "paraglide:compile": "paraglide-js compile --project ./project.inlang --outdir ./src/paraglide --emit-ts-declarations",
     "build": "pnpm paraglide:compile && tsc -b && vite build",
     "preview": "vite preview",
@@ -43,6 +43,7 @@
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.2",
     "@vitest/coverage-v8": "^4.1.7",
+    "cross-env": "^10.1.0",
     "jsdom": "^29.1.1",
     "msw": "^2.14.6",
     "oxfmt": "^0.51.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -6,9 +6,11 @@
   "packageManager": "pnpm@10.32.1",
   "scripts": {
     "dev": "vite",
+    "dev:mock": "VITE_MSW=true vite",
     "paraglide:compile": "paraglide-js compile --project ./project.inlang --outdir ./src/paraglide --emit-ts-declarations",
     "build": "pnpm paraglide:compile && tsc -b && vite build",
     "preview": "vite preview",
+    "postinstall": "msw init public --save",
     "test": "vitest run",
     "lint": "oxlint",
     "format": "oxfmt ."
@@ -42,10 +44,16 @@
     "@vitejs/plugin-react": "^6.0.2",
     "@vitest/coverage-v8": "^4.1.7",
     "jsdom": "^29.1.1",
+    "msw": "^2.14.6",
     "oxfmt": "^0.51.0",
     "oxlint": "^1.66.0",
     "typescript": "^6.0.3",
     "vite": "^8.0.14",
     "vitest": "^4.1.7"
+  },
+  "msw": {
+    "workerDirectory": [
+      "public"
+    ]
   }
 }

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -84,6 +84,9 @@ importers:
       '@vitest/coverage-v8':
         specifier: ^4.1.7
         version: 4.1.7(vitest@4.1.7)
+      cross-env:
+        specifier: ^10.1.0
+        version: 10.1.0
       jsdom:
         specifier: ^29.1.1
         version: 29.1.1
@@ -203,6 +206,9 @@ packages:
 
   '@emnapi/wasi-threads@1.2.1':
     resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
+
+  '@epic-web/invariant@1.0.0':
+    resolution: {integrity: sha512-lrTPqgvfFQtR/eY/qkIzp98OGdNJu0m5ji3q/nJI8v3SXkRKEnWiOxMmbvcSoAIzv/cGiuvRy57k4suKQSAdwA==}
 
   '@exodus/bytes@1.15.0':
     resolution: {integrity: sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ==}
@@ -1039,6 +1045,15 @@ packages:
     resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
     engines: {node: '>=18'}
 
+  cross-env@10.1.0:
+    resolution: {integrity: sha512-GsYosgnACZTADcmEyJctkJIoqAhHjttw7RsFrVoJNXbsWWqaq6Ym+7kZjq6mS45O0jij6vtiReppKQEtqWy6Dw==}
+    engines: {node: '>=20'}
+    hasBin: true
+
+  cross-spawn@7.0.6:
+    resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
+    engines: {node: '>= 8'}
+
   css-tree@3.2.1:
     resolution: {integrity: sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==}
     engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
@@ -1248,6 +1263,9 @@ packages:
     resolution: {integrity: sha512-yNeeynhhtIVRBk12tBV4eHNxwB42HzR4Q3Ea7vCOiJhImGaAIdIMrbJtacQlBizGLjUPw+akkFI5Dn9T70XoVQ==}
     engines: {node: '>=18'}
 
+  isexe@2.0.0:
+    resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
+
   istanbul-lib-coverage@3.2.2:
     resolution: {integrity: sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==}
     engines: {node: '>=8'}
@@ -1450,6 +1468,10 @@ packages:
   parse5@8.0.1:
     resolution: {integrity: sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==}
 
+  path-key@3.1.1:
+    resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
+    engines: {node: '>=8'}
+
   path-to-regexp@6.3.0:
     resolution: {integrity: sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==}
 
@@ -1620,6 +1642,14 @@ packages:
 
   set-cookie-parser@3.1.0:
     resolution: {integrity: sha512-kjnC1DXBHcxaOaOXBHBeRtltsDG2nUiUni+jP92M9gYdW12rsmx92UsfpH7o5tDRs7I1ZZPSQJQGv3UaRfCiuw==}
+
+  shebang-command@2.0.0:
+    resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
+    engines: {node: '>=8'}
+
+  shebang-regex@3.0.0:
+    resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
+    engines: {node: '>=8'}
 
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
@@ -1867,6 +1897,11 @@ packages:
     resolution: {integrity: sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
 
+  which@2.0.2:
+    resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
+    engines: {node: '>= 8'}
+    hasBin: true
+
   why-is-node-running@2.3.0:
     resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
     engines: {node: '>=8'}
@@ -1988,6 +2023,8 @@ snapshots:
     dependencies:
       tslib: 2.8.1
     optional: true
+
+  '@epic-web/invariant@1.0.0': {}
 
   '@exodus/bytes@1.15.0': {}
 
@@ -2648,6 +2685,17 @@ snapshots:
 
   cookie@1.1.1: {}
 
+  cross-env@10.1.0:
+    dependencies:
+      '@epic-web/invariant': 1.0.0
+      cross-spawn: 7.0.6
+
+  cross-spawn@7.0.6:
+    dependencies:
+      path-key: 3.1.1
+      shebang-command: 2.0.0
+      which: 2.0.2
+
   css-tree@3.2.1:
     dependencies:
       mdn-data: 2.27.1
@@ -2803,6 +2851,8 @@ snapshots:
   is-potential-custom-element-name@1.0.1: {}
 
   isbot@5.1.40: {}
+
+  isexe@2.0.0: {}
 
   istanbul-lib-coverage@3.2.2: {}
 
@@ -3019,6 +3069,8 @@ snapshots:
     dependencies:
       entities: 8.0.0
 
+  path-key@3.1.1: {}
+
   path-to-regexp@6.3.0: {}
 
   pathe@2.0.3: {}
@@ -3217,6 +3269,12 @@ snapshots:
 
   set-cookie-parser@3.1.0: {}
 
+  shebang-command@2.0.0:
+    dependencies:
+      shebang-regex: 3.0.0
+
+  shebang-regex@3.0.0: {}
+
   siginfo@2.0.0: {}
 
   signal-exit@4.1.0: {}
@@ -3406,6 +3464,10 @@ snapshots:
       webidl-conversions: 8.0.1
     transitivePeerDependencies:
       - '@noble/hashes'
+
+  which@2.0.2:
+    dependencies:
+      isexe: 2.0.0
 
   why-is-node-running@2.3.0:
     dependencies:

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -87,6 +87,9 @@ importers:
       jsdom:
         specifier: ^29.1.1
         version: 29.1.1
+      msw:
+        specifier: ^2.14.6
+        version: 2.14.6(@types/node@25.9.1)(typescript@6.0.3)
       oxfmt:
         specifier: ^0.51.0
         version: 0.51.0
@@ -101,7 +104,7 @@ importers:
         version: 8.0.14(@types/node@25.9.1)
       vitest:
         specifier: ^4.1.7
-        version: 4.1.7(@types/node@25.9.1)(@vitest/coverage-v8@4.1.7)(jsdom@29.1.1)(vite@8.0.14(@types/node@25.9.1))
+        version: 4.1.7(@types/node@25.9.1)(@vitest/coverage-v8@4.1.7)(jsdom@29.1.1)(msw@2.14.6(@types/node@25.9.1)(typescript@6.0.3))(vite@8.0.14(@types/node@25.9.1))
 
 packages:
 
@@ -226,6 +229,41 @@ packages:
     resolution: {integrity: sha512-E/SxcSji8WIt4DqQG9APlOs6tVtJxrrOUS3dE4ho3pWRCLLIY0PIVzgNwSukuFT+m8LuJDFwpRY5VY3ryzyGWQ==}
     engines: {node: '>=20.0.0'}
 
+  '@inquirer/ansi@2.0.6':
+    resolution: {integrity: sha512-I/INw4sHGlVZ/afZOckpLiDP9SmbMl1g/GCqeHjLw1Afw/0PlRs2tRFgTGWmdI0hoNuWZn3y2iHNmG1vyECyQQ==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
+
+  '@inquirer/confirm@6.1.0':
+    resolution: {integrity: sha512-USpeB76eqK7yGricDlGAupxWlp4a59qpeZOoNWaxO/nJln7agpJveyNkQ1d5u8YXG6TOqxZtQpKPORQQDrdVsA==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/core@11.2.0':
+    resolution: {integrity: sha512-joR1YS2sI0us+9d0I8ViqFbrRLONO8CFTuyvBX4ZVBSch+VsZiugUABdrhBXXJR1VyEzvpz5SQCix3keETQ58g==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/figures@2.0.6':
+    resolution: {integrity: sha512-dsZgQtH2t5Q6ah3aPbZbeEZAxsD9qQu0DXf01AltuEfRTm+NoLN6+rLVbr+4edeEbNCp/wBNM6mALRWtsQpfkw==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
+
+  '@inquirer/type@4.0.6':
+    resolution: {integrity: sha512-J+9tdxOskuYuGjsvGaq00AamhDgjR7anhEW2dP4QdQpFCMPngCeC/bCYWQ5NsMWZRdsy53is7kAHb/+7cwDk2g==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
   '@internationalized/date@3.12.1':
     resolution: {integrity: sha512-6IedsVWXyq4P9Tj+TxuU8WGWM70hYLl12nbYU8jkikVpa6WXapFazPUcHUMDMoWftIDE2ILDkFFte6W2nFCkRQ==}
 
@@ -258,11 +296,27 @@ packages:
   '@lix-js/server-protocol-schema@0.1.1':
     resolution: {integrity: sha512-jBeALB6prAbtr5q4vTuxnRZZv1M2rKe8iNqRQhFJ4Tv7150unEa0vKyz0hs8Gl3fUGsWaNJBh3J8++fpbrpRBQ==}
 
+  '@mswjs/interceptors@0.41.9':
+    resolution: {integrity: sha512-VVPPgHyQ6ShqnrmDWuxjmUIsO9gWyOZFmuOfLd9LfBGQJwZfy0gvv9pbHSJuoFNIYC7ZDX9aoFwowjcdSC4E8w==}
+    engines: {node: '>=18'}
+
   '@napi-rs/wasm-runtime@1.1.4':
     resolution: {integrity: sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==}
     peerDependencies:
       '@emnapi/core': ^1.7.1
       '@emnapi/runtime': ^1.7.1
+
+  '@open-draft/deferred-promise@2.2.0':
+    resolution: {integrity: sha512-CecwLWx3rhxVQF6V4bAgPS5t+So2sTbPgAzafKkVizyi7tlwpcFpdFqq+wqF2OwNBmqFuu6tOyouTuxgpMfzmA==}
+
+  '@open-draft/deferred-promise@3.0.0':
+    resolution: {integrity: sha512-XW375UK8/9SqUVNVa6M0yEy8+iTi4QN5VZ7aZuRFQmy76LRwI9wy5F4YIBU6T+eTe2/DNDo8tqu8RHlwLHM6RA==}
+
+  '@open-draft/logger@0.3.0':
+    resolution: {integrity: sha512-X2g45fzhxH238HKO4xbSr7+wBS8Fvw6ixhTDuvLd5mqh6bJJCFAPwU9mPDxbcrRtfxv4u5IHCEH77BmxvXmmxQ==}
+
+  '@open-draft/until@2.1.0':
+    resolution: {integrity: sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==}
 
   '@oxc-project/types@0.132.0':
     resolution: {integrity: sha512-FESMOxil5Se014ui/Eq8fT5uHJo6nIRwH0PfJrZJXs6Gek3ZVFOrpUv3YIZT20m+extU98Hg1Ym72U58rlsxUQ==}
@@ -829,6 +883,12 @@ packages:
   '@types/react@19.2.15':
     resolution: {integrity: sha512-eRwcGNHve+E8qtEQSSRl6urh+rFop4v8gm6O8rGv25CodbvFdLjA1vVQ1KkiFE0w0UPOnb8tDiFKL5lp0rtY5Q==}
 
+  '@types/set-cookie-parser@2.4.10':
+    resolution: {integrity: sha512-GGmQVGpQWUe5qglJozEjZV/5dyxbOOZ0LHe/lqyWssB88Y4svNfst0uqBVscdDeIKl5Jy5+aPSvy7mI9tYRguw==}
+
+  '@types/statuses@2.0.6':
+    resolution: {integrity: sha512-xMAgYwceFhRA2zY+XbEA7mxYbA093wdiW8Vu6gZPGWy9cmOyU9XesH1tNcEWsKFd5Vzrqx5T3D38PWx1FIIXkA==}
+
   '@types/use-sync-external-store@0.0.6':
     resolution: {integrity: sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==}
 
@@ -895,6 +955,10 @@ packages:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
     engines: {node: '>=8'}
 
+  ansi-styles@4.3.0:
+    resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
+    engines: {node: '>=8'}
+
   ansi-styles@5.2.0:
     resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
     engines: {node: '>=10'}
@@ -934,9 +998,24 @@ packages:
   classnames@2.5.1:
     resolution: {integrity: sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow==}
 
+  cli-width@4.1.0:
+    resolution: {integrity: sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==}
+    engines: {node: '>= 12'}
+
+  cliui@8.0.1:
+    resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
+    engines: {node: '>=12'}
+
   clsx@2.1.1:
     resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
     engines: {node: '>=6'}
+
+  color-convert@2.0.1:
+    resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
+    engines: {node: '>=7.0.0'}
+
+  color-name@1.1.4:
+    resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
 
   commander@11.1.0:
     resolution: {integrity: sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==}
@@ -955,6 +1034,10 @@ packages:
 
   cookie-es@3.1.1:
     resolution: {integrity: sha512-UaXxwISYJPTr9hwQxMFYZ7kNhSXboMXP+Z3TRX6f1/NyaGPfuNUZOWP1pUEb75B2HjfklIYLVRfWiFZJyC6Npg==}
+
+  cookie@1.1.1:
+    resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
+    engines: {node: '>=18'}
 
   css-tree@3.2.1:
     resolution: {integrity: sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==}
@@ -1048,6 +1131,9 @@ packages:
   dom-helpers@5.2.1:
     resolution: {integrity: sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==}
 
+  emoji-regex@8.0.0:
+    resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
+
   entities@8.0.0:
     resolution: {integrity: sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==}
     engines: {node: '>=20.19.0'}
@@ -1057,6 +1143,10 @@ packages:
 
   es-toolkit@1.46.1:
     resolution: {integrity: sha512-5eNtXOs3tbfxXOj04tjjseeWkRWaoCjdEI+96DgwzZoe6c9juL49pXlzAFTI72aWC9Y8p7168g6XIKjh7k6pyQ==}
+
+  escalade@3.2.0:
+    resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
+    engines: {node: '>=6'}
 
   esprima@4.0.1:
     resolution: {integrity: sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==}
@@ -1072,6 +1162,15 @@ packages:
   expect-type@1.3.0:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
+
+  fast-string-truncated-width@3.0.3:
+    resolution: {integrity: sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g==}
+
+  fast-string-width@3.0.2:
+    resolution: {integrity: sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==}
+
+  fast-wrap-ansi@0.2.2:
+    resolution: {integrity: sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q==}
 
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
@@ -1092,9 +1191,20 @@ packages:
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
 
+  get-caller-file@2.0.5:
+    resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
+    engines: {node: 6.* || 8.* || >= 10.*}
+
+  graphql@16.14.0:
+    resolution: {integrity: sha512-BBvQ/406p+4CZbTpCbVPSxfzrZrbnuWSP1ELYgyS6B+hNeKzgrdB4JczCa5VZUBQrDa9hUngm0KnexY6pJRN5Q==}
+    engines: {node: ^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0}
+
   has-flag@4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
     engines: {node: '>=8'}
+
+  headers-polyfill@5.0.1:
+    resolution: {integrity: sha512-1TJ6Fih/b8h5TIcv+1+Hw0PDQWJTKDKzFZzcKOiW1wJza3XoAQlkCuXLbymPYB8+ZQyw8mHvdw560e8zVFIWyA==}
 
   html-encoding-sniffer@6.0.0:
     resolution: {integrity: sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==}
@@ -1123,6 +1233,13 @@ packages:
 
   invariant@2.2.4:
     resolution: {integrity: sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==}
+
+  is-fullwidth-code-point@3.0.0:
+    resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
+    engines: {node: '>=8'}
+
+  is-node-process@1.2.0:
+    resolution: {integrity: sha512-Vg4o6/fqPxIjtxgUH5QLJhwZ7gW5diGCVlXpuUfELC62CuxM1iHcRe51f2W1FDy04Ai4KJkagKjx3XaqyfRKXw==}
 
   is-potential-custom-element-name@1.0.1:
     resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
@@ -1277,6 +1394,20 @@ packages:
     resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
     engines: {node: '>=4'}
 
+  msw@2.14.6:
+    resolution: {integrity: sha512-ALe+N10S72cyx94cMcy3Zs4HhXCj35sgeAL4c+WTvKi0zWnbd8/h0lcFqv0mb2P+aSgAdD7p9HzvA0DiUPxsyg==}
+    engines: {node: '>=18'}
+    hasBin: true
+    peerDependencies:
+      typescript: '>= 4.8.x'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  mute-stream@4.0.0:
+    resolution: {integrity: sha512-gSrprq0fJ3EiOErzjdIZrjysVVmJ4uu1QWfCDss5LypA5OXvrMje5Ym5z6V6RLyJ2eF87lasX7t6a0AnFvZblg==}
+    engines: {node: ^22.22.2 || ^24.15.0 || >=26.0.0}
+
   nanoid@3.3.12:
     resolution: {integrity: sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
@@ -1292,6 +1423,9 @@ packages:
   oidc-client-ts@3.5.0:
     resolution: {integrity: sha512-l2q8l9CTCTOlbX+AnK4p3M+4CEpKpyQhle6blQkdFhm0IsBqsxm15bYaSa11G7pWdsYr6epdsRZxJpCyCRbT8A==}
     engines: {node: '>=18'}
+
+  outvariant@1.4.3:
+    resolution: {integrity: sha512-+Sl2UErvtsoajRDKCE5/dBz4DIvHXQQnAxtQTF04OJxY0+DyZXSo5P5Bb7XYWOh81syohlYL24hbDwxedPUJCA==}
 
   oxfmt@0.51.0:
     resolution: {integrity: sha512-l/AoAnaEOV7Q5/Z9kHOMDehVJnCgYN7wRoooWCTUMBMi16BJhLZqd9cmCnwcVFfVlzkt53zK2KLPFNp8vSsoDg==}
@@ -1315,6 +1449,9 @@ packages:
 
   parse5@8.0.1:
     resolution: {integrity: sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==}
+
+  path-to-regexp@6.3.0:
+    resolution: {integrity: sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==}
 
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
@@ -1440,12 +1577,19 @@ packages:
   redux@5.0.1:
     resolution: {integrity: sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==}
 
+  require-directory@2.1.1:
+    resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
+    engines: {node: '>=0.10.0'}
+
   require-from-string@2.0.2:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
     engines: {node: '>=0.10.0'}
 
   reselect@5.1.1:
     resolution: {integrity: sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==}
+
+  rettime@0.11.11:
+    resolution: {integrity: sha512-ILJRqVWBCTlg9r42fFgwVZx1gnFAcQF8mRoMkbgQfIrjEDf9nbBFDFx00oloOa+Q869FUtaYDXZvEfnecQSCoQ==}
 
   rolldown@1.0.2:
     resolution: {integrity: sha512-oZx5zVDtVB44AW3eaifgDml1gWRDZGvjcfdxonE4swNPG98PrrXjaO/KrnUjzlMnztCCRVlUueA1kCXhARGk6g==}
@@ -1474,8 +1618,15 @@ packages:
     resolution: {integrity: sha512-46uFvgrXTVxZcUorgSSRZ4y+ieqLLQRMlG4bnCZKW3qI6BZm7Rg4ntMW4p1mILEEBZWrFlcpp0AyIIlM6jD9iw==}
     engines: {node: '>=10'}
 
+  set-cookie-parser@3.1.0:
+    resolution: {integrity: sha512-kjnC1DXBHcxaOaOXBHBeRtltsDG2nUiUni+jP92M9gYdW12rsmx92UsfpH7o5tDRs7I1ZZPSQJQGv3UaRfCiuw==}
+
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
+  signal-exit@4.1.0:
+    resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
+    engines: {node: '>=14'}
 
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
@@ -1489,8 +1640,23 @@ packages:
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
 
+  statuses@2.0.2:
+    resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
+    engines: {node: '>= 0.8'}
+
   std-env@4.1.0:
     resolution: {integrity: sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==}
+
+  strict-event-emitter@0.5.1:
+    resolution: {integrity: sha512-vMgjE/GGEPEFnhFub6pa4FmJBRBVOLpIII2hvCZ8Kzb7K0hlHo7mQv6xYrBvCL2LtAIBwFUK8wvuJgTVSQ5MFQ==}
+
+  string-width@4.2.3:
+    resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
+    engines: {node: '>=8'}
+
+  strip-ansi@6.0.1:
+    resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
+    engines: {node: '>=8'}
 
   strip-indent@3.0.0:
     resolution: {integrity: sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==}
@@ -1502,6 +1668,10 @@ packages:
 
   symbol-tree@3.2.4:
     resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
+
+  tagged-tag@1.0.0:
+    resolution: {integrity: sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==}
+    engines: {node: '>=20'}
 
   tiny-invariant@1.3.3:
     resolution: {integrity: sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==}
@@ -1543,6 +1713,10 @@ packages:
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
+  type-fest@5.6.0:
+    resolution: {integrity: sha512-8ZiHFm91orbSAe2PSAiSVBVko18pbhbiB3U9GglSzF/zCGkR+rxpHx6sEMCUm4kxY4LjDIUGgCfUMtwfZfjfUA==}
+    engines: {node: '>=20'}
+
   typescript@6.0.3:
     resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
     engines: {node: '>=14.17'}
@@ -1568,6 +1742,9 @@ packages:
   unplugin@2.3.11:
     resolution: {integrity: sha512-5uKD0nqiYVzlmCRs01Fhs2BdkEgBS3SAVP6ndrBsuK42iC2+JHyxM05Rm9G8+5mkmRtzMZGY8Ct5+mliZxU/Ww==}
     engines: {node: '>=18.12.0'}
+
+  until-async@3.0.2:
+    resolution: {integrity: sha512-IiSk4HlzAMqTUseHHe3VhIGyuFmN90zMTpD3Z3y8jeQbzLIq500MVM7Jq2vUAnTKAFPJrqwkzr6PoTcPhGcOiw==}
 
   urlpattern-polyfill@10.1.0:
     resolution: {integrity: sha512-IGjKp/o0NL3Bso1PymYURCJxMPNAf/ILOpendP9f5B6e1rTJgdgiOvgfoT8VxCAdY+Wisb9uhGaJJf3yZ2V9nw==}
@@ -1695,12 +1872,28 @@ packages:
     engines: {node: '>=8'}
     hasBin: true
 
+  wrap-ansi@7.0.0:
+    resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
+    engines: {node: '>=10'}
+
   xml-name-validator@5.0.0:
     resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
     engines: {node: '>=18'}
 
   xmlchars@2.2.0:
     resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
+
+  y18n@5.0.8:
+    resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
+    engines: {node: '>=10'}
+
+  yargs-parser@21.1.1:
+    resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
+    engines: {node: '>=12'}
+
+  yargs@17.7.2:
+    resolution: {integrity: sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==}
+    engines: {node: '>=12'}
 
   zod@4.4.3:
     resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
@@ -1826,6 +2019,33 @@ snapshots:
     transitivePeerDependencies:
       - babel-plugin-macros
 
+  '@inquirer/ansi@2.0.6': {}
+
+  '@inquirer/confirm@6.1.0(@types/node@25.9.1)':
+    dependencies:
+      '@inquirer/core': 11.2.0(@types/node@25.9.1)
+      '@inquirer/type': 4.0.6(@types/node@25.9.1)
+    optionalDependencies:
+      '@types/node': 25.9.1
+
+  '@inquirer/core@11.2.0(@types/node@25.9.1)':
+    dependencies:
+      '@inquirer/ansi': 2.0.6
+      '@inquirer/figures': 2.0.6
+      '@inquirer/type': 4.0.6(@types/node@25.9.1)
+      cli-width: 4.1.0
+      fast-wrap-ansi: 0.2.2
+      mute-stream: 4.0.0
+      signal-exit: 4.1.0
+    optionalDependencies:
+      '@types/node': 25.9.1
+
+  '@inquirer/figures@2.0.6': {}
+
+  '@inquirer/type@4.0.6(@types/node@25.9.1)':
+    optionalDependencies:
+      '@types/node': 25.9.1
+
   '@internationalized/date@3.12.1':
     dependencies:
       '@swc/helpers': 0.5.21
@@ -1871,12 +2091,32 @@ snapshots:
 
   '@lix-js/server-protocol-schema@0.1.1': {}
 
+  '@mswjs/interceptors@0.41.9':
+    dependencies:
+      '@open-draft/deferred-promise': 2.2.0
+      '@open-draft/logger': 0.3.0
+      '@open-draft/until': 2.1.0
+      is-node-process: 1.2.0
+      outvariant: 1.4.3
+      strict-event-emitter: 0.5.1
+
   '@napi-rs/wasm-runtime@1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
     dependencies:
       '@emnapi/core': 1.10.0
       '@emnapi/runtime': 1.10.0
       '@tybys/wasm-util': 0.10.2
     optional: true
+
+  '@open-draft/deferred-promise@2.2.0': {}
+
+  '@open-draft/deferred-promise@3.0.0': {}
+
+  '@open-draft/logger@0.3.0':
+    dependencies:
+      is-node-process: 1.2.0
+      outvariant: 1.4.3
+
+  '@open-draft/until@2.1.0': {}
 
   '@oxc-project/types@0.132.0': {}
 
@@ -2249,7 +2489,6 @@ snapshots:
   '@types/node@25.9.1':
     dependencies:
       undici-types: 7.24.6
-    optional: true
 
   '@types/prop-types@15.7.15': {}
 
@@ -2264,6 +2503,12 @@ snapshots:
   '@types/react@19.2.15':
     dependencies:
       csstype: 3.2.3
+
+  '@types/set-cookie-parser@2.4.10':
+    dependencies:
+      '@types/node': 25.9.1
+
+  '@types/statuses@2.0.6': {}
 
   '@types/use-sync-external-store@0.0.6': {}
 
@@ -2286,7 +2531,7 @@ snapshots:
       obug: 2.1.1
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.7(@types/node@25.9.1)(@vitest/coverage-v8@4.1.7)(jsdom@29.1.1)(vite@8.0.14(@types/node@25.9.1))
+      vitest: 4.1.7(@types/node@25.9.1)(@vitest/coverage-v8@4.1.7)(jsdom@29.1.1)(msw@2.14.6(@types/node@25.9.1)(typescript@6.0.3))(vite@8.0.14(@types/node@25.9.1))
 
   '@vitest/expect@4.1.7':
     dependencies:
@@ -2297,12 +2542,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.7(vite@8.0.14(@types/node@25.9.1))':
+  '@vitest/mocker@4.1.7(msw@2.14.6(@types/node@25.9.1)(typescript@6.0.3))(vite@8.0.14(@types/node@25.9.1))':
     dependencies:
       '@vitest/spy': 4.1.7
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
+      msw: 2.14.6(@types/node@25.9.1)(typescript@6.0.3)
       vite: 8.0.14(@types/node@25.9.1)
 
   '@vitest/pretty-format@4.1.7':
@@ -2332,6 +2578,10 @@ snapshots:
   acorn@8.16.0: {}
 
   ansi-regex@5.0.1: {}
+
+  ansi-styles@4.3.0:
+    dependencies:
+      color-convert: 2.0.1
 
   ansi-styles@5.2.0: {}
 
@@ -2367,7 +2617,21 @@ snapshots:
 
   classnames@2.5.1: {}
 
+  cli-width@4.1.0: {}
+
+  cliui@8.0.1:
+    dependencies:
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+      wrap-ansi: 7.0.0
+
   clsx@2.1.1: {}
+
+  color-convert@2.0.1:
+    dependencies:
+      color-name: 1.1.4
+
+  color-name@1.1.4: {}
 
   commander@11.1.0: {}
 
@@ -2381,6 +2645,8 @@ snapshots:
   convert-source-map@2.0.0: {}
 
   cookie-es@3.1.1: {}
+
+  cookie@1.1.1: {}
 
   css-tree@3.2.1:
     dependencies:
@@ -2457,11 +2723,15 @@ snapshots:
       '@babel/runtime': 7.29.2
       csstype: 3.2.3
 
+  emoji-regex@8.0.0: {}
+
   entities@8.0.0: {}
 
   es-module-lexer@2.1.0: {}
 
   es-toolkit@1.46.1: {}
+
+  escalade@3.2.0: {}
 
   esprima@4.0.1: {}
 
@@ -2473,6 +2743,16 @@ snapshots:
 
   expect-type@1.3.0: {}
 
+  fast-string-truncated-width@3.0.3: {}
+
+  fast-string-width@3.0.2:
+    dependencies:
+      fast-string-truncated-width: 3.0.3
+
+  fast-wrap-ansi@0.2.2:
+    dependencies:
+      fast-string-width: 3.0.2
+
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
       picomatch: 4.0.4
@@ -2483,7 +2763,16 @@ snapshots:
   fsevents@2.3.3:
     optional: true
 
+  get-caller-file@2.0.5: {}
+
+  graphql@16.14.0: {}
+
   has-flag@4.0.0: {}
+
+  headers-polyfill@5.0.1:
+    dependencies:
+      '@types/set-cookie-parser': 2.4.10
+      set-cookie-parser: 3.1.0
 
   html-encoding-sniffer@6.0.0:
     dependencies:
@@ -2506,6 +2795,10 @@ snapshots:
   invariant@2.2.4:
     dependencies:
       loose-envify: 1.4.0
+
+  is-fullwidth-code-point@3.0.0: {}
+
+  is-node-process@1.2.0: {}
 
   is-potential-custom-element-name@1.0.1: {}
 
@@ -2637,6 +2930,33 @@ snapshots:
 
   min-indent@1.0.1: {}
 
+  msw@2.14.6(@types/node@25.9.1)(typescript@6.0.3):
+    dependencies:
+      '@inquirer/confirm': 6.1.0(@types/node@25.9.1)
+      '@mswjs/interceptors': 0.41.9
+      '@open-draft/deferred-promise': 3.0.0
+      '@types/statuses': 2.0.6
+      cookie: 1.1.1
+      graphql: 16.14.0
+      headers-polyfill: 5.0.1
+      is-node-process: 1.2.0
+      outvariant: 1.4.3
+      path-to-regexp: 6.3.0
+      picocolors: 1.1.1
+      rettime: 0.11.11
+      statuses: 2.0.2
+      strict-event-emitter: 0.5.1
+      tough-cookie: 6.0.1
+      type-fest: 5.6.0
+      until-async: 3.0.2
+      yargs: 17.7.2
+    optionalDependencies:
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - '@types/node'
+
+  mute-stream@4.0.0: {}
+
   nanoid@3.3.12: {}
 
   object-assign@4.1.1: {}
@@ -2646,6 +2966,8 @@ snapshots:
   oidc-client-ts@3.5.0:
     dependencies:
       jwt-decode: 4.0.0
+
+  outvariant@1.4.3: {}
 
   oxfmt@0.51.0:
     dependencies:
@@ -2696,6 +3018,8 @@ snapshots:
   parse5@8.0.1:
     dependencies:
       entities: 8.0.0
+
+  path-to-regexp@6.3.0: {}
 
   pathe@2.0.3: {}
 
@@ -2848,9 +3172,13 @@ snapshots:
 
   redux@5.0.1: {}
 
+  require-directory@2.1.1: {}
+
   require-from-string@2.0.2: {}
 
   reselect@5.1.1: {}
+
+  rettime@0.11.11: {}
 
   rolldown@1.0.2:
     dependencies:
@@ -2887,7 +3215,11 @@ snapshots:
 
   seroval@1.5.4: {}
 
+  set-cookie-parser@3.1.0: {}
+
   siginfo@2.0.0: {}
+
+  signal-exit@4.1.0: {}
 
   source-map-js@1.2.1: {}
 
@@ -2898,7 +3230,21 @@ snapshots:
 
   stackback@0.0.2: {}
 
+  statuses@2.0.2: {}
+
   std-env@4.1.0: {}
+
+  strict-event-emitter@0.5.1: {}
+
+  string-width@4.2.3:
+    dependencies:
+      emoji-regex: 8.0.0
+      is-fullwidth-code-point: 3.0.0
+      strip-ansi: 6.0.1
+
+  strip-ansi@6.0.1:
+    dependencies:
+      ansi-regex: 5.0.1
 
   strip-indent@3.0.0:
     dependencies:
@@ -2909,6 +3255,8 @@ snapshots:
       has-flag: 4.0.0
 
   symbol-tree@3.2.4: {}
+
+  tagged-tag@1.0.0: {}
 
   tiny-invariant@1.3.3: {}
 
@@ -2941,6 +3289,10 @@ snapshots:
 
   tslib@2.8.1: {}
 
+  type-fest@5.6.0:
+    dependencies:
+      tagged-tag: 1.0.0
+
   typescript@6.0.3: {}
 
   uncontrollable@7.2.1(react@19.2.6):
@@ -2955,8 +3307,7 @@ snapshots:
     dependencies:
       react: 19.2.6
 
-  undici-types@7.24.6:
-    optional: true
+  undici-types@7.24.6: {}
 
   undici@7.25.0: {}
 
@@ -2966,6 +3317,8 @@ snapshots:
       acorn: 8.16.0
       picomatch: 4.0.4
       webpack-virtual-modules: 0.6.2
+
+  until-async@3.0.2: {}
 
   urlpattern-polyfill@10.1.0: {}
 
@@ -3003,10 +3356,10 @@ snapshots:
       '@types/node': 25.9.1
       fsevents: 2.3.3
 
-  vitest@4.1.7(@types/node@25.9.1)(@vitest/coverage-v8@4.1.7)(jsdom@29.1.1)(vite@8.0.14(@types/node@25.9.1)):
+  vitest@4.1.7(@types/node@25.9.1)(@vitest/coverage-v8@4.1.7)(jsdom@29.1.1)(msw@2.14.6(@types/node@25.9.1)(typescript@6.0.3))(vite@8.0.14(@types/node@25.9.1)):
     dependencies:
       '@vitest/expect': 4.1.7
-      '@vitest/mocker': 4.1.7(vite@8.0.14(@types/node@25.9.1))
+      '@vitest/mocker': 4.1.7(msw@2.14.6(@types/node@25.9.1)(typescript@6.0.3))(vite@8.0.14(@types/node@25.9.1))
       '@vitest/pretty-format': 4.1.7
       '@vitest/runner': 4.1.7
       '@vitest/snapshot': 4.1.7
@@ -3059,8 +3412,28 @@ snapshots:
       siginfo: 2.0.0
       stackback: 0.0.2
 
+  wrap-ansi@7.0.0:
+    dependencies:
+      ansi-styles: 4.3.0
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+
   xml-name-validator@5.0.0: {}
 
   xmlchars@2.2.0: {}
+
+  y18n@5.0.8: {}
+
+  yargs-parser@21.1.1: {}
+
+  yargs@17.7.2:
+    dependencies:
+      cliui: 8.0.1
+      escalade: 3.2.0
+      get-caller-file: 2.0.5
+      require-directory: 2.1.1
+      string-width: 4.2.3
+      y18n: 5.0.8
+      yargs-parser: 21.1.1
 
   zod@4.4.3: {}

--- a/frontend/public/mockServiceWorker.js
+++ b/frontend/public/mockServiceWorker.js
@@ -1,0 +1,349 @@
+/* eslint-disable */
+/* tslint:disable */
+
+/**
+ * Mock Service Worker.
+ * @see https://github.com/mswjs/msw
+ * - Please do NOT modify this file.
+ */
+
+const PACKAGE_VERSION = '2.14.6'
+const INTEGRITY_CHECKSUM = '4db4a41e972cec1b64cc569c66952d82'
+const IS_MOCKED_RESPONSE = Symbol('isMockedResponse')
+const activeClientIds = new Set()
+
+addEventListener('install', function () {
+  self.skipWaiting()
+})
+
+addEventListener('activate', function (event) {
+  event.waitUntil(self.clients.claim())
+})
+
+addEventListener('message', async function (event) {
+  const clientId = Reflect.get(event.source || {}, 'id')
+
+  if (!clientId || !self.clients) {
+    return
+  }
+
+  const client = await self.clients.get(clientId)
+
+  if (!client) {
+    return
+  }
+
+  const allClients = await self.clients.matchAll({
+    type: 'window',
+  })
+
+  switch (event.data) {
+    case 'KEEPALIVE_REQUEST': {
+      sendToClient(client, {
+        type: 'KEEPALIVE_RESPONSE',
+      })
+      break
+    }
+
+    case 'INTEGRITY_CHECK_REQUEST': {
+      sendToClient(client, {
+        type: 'INTEGRITY_CHECK_RESPONSE',
+        payload: {
+          packageVersion: PACKAGE_VERSION,
+          checksum: INTEGRITY_CHECKSUM,
+        },
+      })
+      break
+    }
+
+    case 'MOCK_ACTIVATE': {
+      activeClientIds.add(clientId)
+
+      sendToClient(client, {
+        type: 'MOCKING_ENABLED',
+        payload: {
+          client: {
+            id: client.id,
+            frameType: client.frameType,
+          },
+        },
+      })
+      break
+    }
+
+    case 'CLIENT_CLOSED': {
+      activeClientIds.delete(clientId)
+
+      const remainingClients = allClients.filter((client) => {
+        return client.id !== clientId
+      })
+
+      // Unregister itself when there are no more clients
+      if (remainingClients.length === 0) {
+        self.registration.unregister()
+      }
+
+      break
+    }
+  }
+})
+
+addEventListener('fetch', function (event) {
+  const requestInterceptedAt = Date.now()
+
+  // Bypass navigation requests.
+  if (event.request.mode === 'navigate') {
+    return
+  }
+
+  // Opening the DevTools triggers the "only-if-cached" request
+  // that cannot be handled by the worker. Bypass such requests.
+  if (
+    event.request.cache === 'only-if-cached' &&
+    event.request.mode !== 'same-origin'
+  ) {
+    return
+  }
+
+  // Bypass all requests when there are no active clients.
+  // Prevents the self-unregistered worked from handling requests
+  // after it's been terminated (still remains active until the next reload).
+  if (activeClientIds.size === 0) {
+    return
+  }
+
+  const requestId = crypto.randomUUID()
+  event.respondWith(handleRequest(event, requestId, requestInterceptedAt))
+})
+
+/**
+ * @param {FetchEvent} event
+ * @param {string} requestId
+ * @param {number} requestInterceptedAt
+ */
+async function handleRequest(event, requestId, requestInterceptedAt) {
+  const client = await resolveMainClient(event)
+  const requestCloneForEvents = event.request.clone()
+  const response = await getResponse(
+    event,
+    client,
+    requestId,
+    requestInterceptedAt,
+  )
+
+  // Send back the response clone for the "response:*" life-cycle events.
+  // Ensure MSW is active and ready to handle the message, otherwise
+  // this message will pend indefinitely.
+  if (client && activeClientIds.has(client.id)) {
+    const serializedRequest = await serializeRequest(requestCloneForEvents)
+
+    // Clone the response so both the client and the library could consume it.
+    const responseClone = response.clone()
+
+    sendToClient(
+      client,
+      {
+        type: 'RESPONSE',
+        payload: {
+          isMockedResponse: IS_MOCKED_RESPONSE in response,
+          request: {
+            id: requestId,
+            ...serializedRequest,
+          },
+          response: {
+            type: responseClone.type,
+            status: responseClone.status,
+            statusText: responseClone.statusText,
+            headers: Object.fromEntries(responseClone.headers.entries()),
+            body: responseClone.body,
+          },
+        },
+      },
+      responseClone.body ? [serializedRequest.body, responseClone.body] : [],
+    )
+  }
+
+  return response
+}
+
+/**
+ * Resolve the main client for the given event.
+ * Client that issues a request doesn't necessarily equal the client
+ * that registered the worker. It's with the latter the worker should
+ * communicate with during the response resolving phase.
+ * @param {FetchEvent} event
+ * @returns {Promise<Client | undefined>}
+ */
+async function resolveMainClient(event) {
+  const client = await self.clients.get(event.clientId)
+
+  if (activeClientIds.has(event.clientId)) {
+    return client
+  }
+
+  if (client?.frameType === 'top-level') {
+    return client
+  }
+
+  const allClients = await self.clients.matchAll({
+    type: 'window',
+  })
+
+  return allClients
+    .filter((client) => {
+      // Get only those clients that are currently visible.
+      return client.visibilityState === 'visible'
+    })
+    .find((client) => {
+      // Find the client ID that's recorded in the
+      // set of clients that have registered the worker.
+      return activeClientIds.has(client.id)
+    })
+}
+
+/**
+ * @param {FetchEvent} event
+ * @param {Client | undefined} client
+ * @param {string} requestId
+ * @param {number} requestInterceptedAt
+ * @returns {Promise<Response>}
+ */
+async function getResponse(event, client, requestId, requestInterceptedAt) {
+  // Clone the request because it might've been already used
+  // (i.e. its body has been read and sent to the client).
+  const requestClone = event.request.clone()
+
+  function passthrough() {
+    // Cast the request headers to a new Headers instance
+    // so the headers can be manipulated with.
+    const headers = new Headers(requestClone.headers)
+
+    // Remove the "accept" header value that marked this request as passthrough.
+    // This prevents request alteration and also keeps it compliant with the
+    // user-defined CORS policies.
+    const acceptHeader = headers.get('accept')
+    if (acceptHeader) {
+      const values = acceptHeader.split(',').map((value) => value.trim())
+      const filteredValues = values.filter(
+        (value) => value !== 'msw/passthrough',
+      )
+
+      if (filteredValues.length > 0) {
+        headers.set('accept', filteredValues.join(', '))
+      } else {
+        headers.delete('accept')
+      }
+    }
+
+    return fetch(requestClone, { headers })
+  }
+
+  // Bypass mocking when the client is not active.
+  if (!client) {
+    return passthrough()
+  }
+
+  // Bypass initial page load requests (i.e. static assets).
+  // The absence of the immediate/parent client in the map of the active clients
+  // means that MSW hasn't dispatched the "MOCK_ACTIVATE" event yet
+  // and is not ready to handle requests.
+  if (!activeClientIds.has(client.id)) {
+    return passthrough()
+  }
+
+  // Notify the client that a request has been intercepted.
+  const serializedRequest = await serializeRequest(event.request)
+  const clientMessage = await sendToClient(
+    client,
+    {
+      type: 'REQUEST',
+      payload: {
+        id: requestId,
+        interceptedAt: requestInterceptedAt,
+        ...serializedRequest,
+      },
+    },
+    [serializedRequest.body],
+  )
+
+  switch (clientMessage.type) {
+    case 'MOCK_RESPONSE': {
+      return respondWithMock(clientMessage.data)
+    }
+
+    case 'PASSTHROUGH': {
+      return passthrough()
+    }
+  }
+
+  return passthrough()
+}
+
+/**
+ * @param {Client} client
+ * @param {any} message
+ * @param {Array<Transferable>} transferrables
+ * @returns {Promise<any>}
+ */
+function sendToClient(client, message, transferrables = []) {
+  return new Promise((resolve, reject) => {
+    const channel = new MessageChannel()
+
+    channel.port1.onmessage = (event) => {
+      if (event.data && event.data.error) {
+        return reject(event.data.error)
+      }
+
+      resolve(event.data)
+    }
+
+    client.postMessage(message, [
+      channel.port2,
+      ...transferrables.filter(Boolean),
+    ])
+  })
+}
+
+/**
+ * @param {Response} response
+ * @returns {Response}
+ */
+function respondWithMock(response) {
+  // Setting response status code to 0 is a no-op.
+  // However, when responding with a "Response.error()", the produced Response
+  // instance will have status code set to 0. Since it's not possible to create
+  // a Response instance with status code 0, handle that use-case separately.
+  if (response.status === 0) {
+    return Response.error()
+  }
+
+  const mockedResponse = new Response(response.body, response)
+
+  Reflect.defineProperty(mockedResponse, IS_MOCKED_RESPONSE, {
+    value: true,
+    enumerable: true,
+  })
+
+  return mockedResponse
+}
+
+/**
+ * @param {Request} request
+ */
+async function serializeRequest(request) {
+  return {
+    url: request.url,
+    mode: request.mode,
+    method: request.method,
+    headers: Object.fromEntries(request.headers.entries()),
+    cache: request.cache,
+    credentials: request.credentials,
+    destination: request.destination,
+    integrity: request.integrity,
+    redirect: request.redirect,
+    referrer: request.referrer,
+    referrerPolicy: request.referrerPolicy,
+    body: await request.arrayBuffer(),
+    keepalive: request.keepalive,
+  }
+}

--- a/frontend/src/app/providers/AuthProvider.tsx
+++ b/frontend/src/app/providers/AuthProvider.tsx
@@ -21,7 +21,7 @@ type AuthContextValue = {
   refreshUser: () => Promise<void>;
 };
 
-const AuthContext = createContext<AuthContextValue | null>(null);
+export const AuthContext = createContext<AuthContextValue | null>(null);
 
 export function AuthProvider({ children }: { children: React.ReactNode }) {
   const oidc = useOidcAuth();

--- a/frontend/src/env.d.ts
+++ b/frontend/src/env.d.ts
@@ -1,0 +1,12 @@
+/// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly VITE_OIDC_CLIENT_ID?: string
+  readonly VITE_OIDC_REDIRECT_URI?: string
+  readonly VITE_OIDC_SCOPE?: string
+  readonly VITE_MSW?: string
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -35,6 +35,27 @@ function App() {
 }
 
 async function bootstrap() {
+  if (import.meta.env.VITE_MSW === "true") {
+    const { worker } = await import("./mocks/browser");
+    await worker.start({ onUnhandledRequest: "warn" });
+    const { MockAuthProvider } = await import("./mocks/MockAuthProvider");
+
+    ReactDOM.createRoot(document.getElementById("root")!).render(
+      <React.StrictMode>
+        <LanguageProvider>
+          <MockAuthProvider>
+            <QueryProvider>
+              <ThemeProvider>
+                <App />
+              </ThemeProvider>
+            </QueryProvider>
+          </MockAuthProvider>
+        </LanguageProvider>
+      </React.StrictMode>,
+    );
+    return;
+  }
+
   let oidcConfig;
   try {
     oidcConfig = await fetchOidcConfig();

--- a/frontend/src/mocks/MockAuthProvider.tsx
+++ b/frontend/src/mocks/MockAuthProvider.tsx
@@ -1,0 +1,32 @@
+import { useEffect } from "react";
+import { AuthContext } from "@/app/providers/AuthProvider";
+import { setOidcAccessToken } from "@/lib/auth/session";
+import { MOCK_TOKEN, MOCK_USER } from "./data/constants";
+import { getMockState } from "./data/state";
+
+export function MockAuthProvider({ children }: { children: React.ReactNode }) {
+  useEffect(() => {
+    setOidcAccessToken(MOCK_TOKEN);
+    return () => {
+      setOidcAccessToken(undefined);
+    };
+  }, []);
+
+  const { scenario } = getMockState();
+  const isAuthenticated = scenario !== "signed-out" && scenario !== "expired-session";
+
+  return (
+    <AuthContext.Provider
+      value={{
+        user: isAuthenticated ? MOCK_USER : null,
+        isLoading: false,
+        isAuthenticated,
+        login: () => {},
+        logout: () => {},
+        refreshUser: async () => {},
+      }}
+    >
+      {children}
+    </AuthContext.Provider>
+  );
+}

--- a/frontend/src/mocks/browser.ts
+++ b/frontend/src/mocks/browser.ts
@@ -1,0 +1,7 @@
+import { setupWorker } from "msw/browser";
+import { handlers } from "./handlers";
+import { initScenarioFromUrl } from "./data/state";
+
+export const worker = setupWorker(...handlers);
+
+initScenarioFromUrl();

--- a/frontend/src/mocks/data/constants.ts
+++ b/frontend/src/mocks/data/constants.ts
@@ -1,0 +1,12 @@
+import type { AuthUser } from "@/lib/api/auth";
+
+export const MOCK_TODAY = "2026-05-29";
+export const MOCK_TOKEN = "mock-access-token";
+
+export const MOCK_USER: AuthUser = {
+  id: 1,
+  email: "demo@daynest.app",
+  full_name: "Demo User",
+  is_active: true,
+  roles: ["user"],
+};

--- a/frontend/src/mocks/data/medication.ts
+++ b/frontend/src/mocks/data/medication.ts
@@ -83,3 +83,7 @@ let _nextMedicationId = 100;
 export function nextMedicationId(): number {
   return _nextMedicationId++;
 }
+
+export function resetMedicationId(): void {
+  _nextMedicationId = 100;
+}

--- a/frontend/src/mocks/data/medication.ts
+++ b/frontend/src/mocks/data/medication.ts
@@ -1,0 +1,85 @@
+import type { MedicationPlan, MedicationHistoryItem } from "@/lib/api/today";
+
+export function seedMedications(): MedicationPlan[] {
+  return [
+    {
+      id: 10,
+      name: "Morning vitamin",
+      instructions: "With breakfast",
+      start_date: "2026-01-01",
+      schedule_time: "08:00",
+      every_n_days: 1,
+      is_active: true,
+    },
+    {
+      id: 11,
+      name: "Blood pressure pill",
+      instructions: "Before bed",
+      start_date: "2026-01-15",
+      schedule_time: "22:00",
+      every_n_days: 1,
+      is_active: true,
+    },
+    {
+      id: 12,
+      name: "Evening magnesium",
+      instructions: "After dinner",
+      start_date: "2026-02-01",
+      schedule_time: "20:00",
+      every_n_days: 1,
+      is_active: true,
+    },
+    {
+      id: 13,
+      name: "Vitamin D (inactive)",
+      instructions: "With fatty meal",
+      start_date: "2026-01-01",
+      schedule_time: "12:00",
+      every_n_days: 7,
+      is_active: false,
+    },
+  ];
+}
+
+export function seedMedicationHistory(): MedicationHistoryItem[] {
+  return [
+    {
+      medication_dose_instance_id: 90,
+      medication_plan_id: 10,
+      name: "Morning vitamin",
+      instructions: "With breakfast",
+      scheduled_at: "2026-05-28T08:00:00Z",
+      status: "taken",
+    },
+    {
+      medication_dose_instance_id: 91,
+      medication_plan_id: 11,
+      name: "Blood pressure pill",
+      instructions: "Before bed",
+      scheduled_at: "2026-05-28T22:00:00Z",
+      status: "taken",
+    },
+    {
+      medication_dose_instance_id: 92,
+      medication_plan_id: 12,
+      name: "Evening magnesium",
+      instructions: "After dinner",
+      scheduled_at: "2026-05-27T20:00:00Z",
+      status: "skipped",
+    },
+  ];
+}
+
+/** Returns a low-stock/refill-needed scenario set of medication plans. */
+export function refillMedications(): MedicationPlan[] {
+  return seedMedications().map((m) => ({
+    ...m,
+    is_active: m.id !== 13,
+  }));
+}
+
+let _nextMedicationId = 100;
+
+export function nextMedicationId(): number {
+  return _nextMedicationId++;
+}

--- a/frontend/src/mocks/data/plannedItems.ts
+++ b/frontend/src/mocks/data/plannedItems.ts
@@ -55,3 +55,7 @@ let _nextPlannedItemId = 500;
 export function nextPlannedItemId(): number {
   return _nextPlannedItemId++;
 }
+
+export function resetPlannedItemId(): void {
+  _nextPlannedItemId = 500;
+}

--- a/frontend/src/mocks/data/plannedItems.ts
+++ b/frontend/src/mocks/data/plannedItems.ts
@@ -1,0 +1,57 @@
+import type { PlannedTodayItem } from "@/lib/api/today";
+
+export function seedPlannedItems(date: string): PlannedTodayItem[] {
+  return [
+    {
+      id: 401,
+      title: "Order groceries",
+      planned_for: date,
+      time_of_day: null,
+      duration_minutes: 30,
+      notes: "Check pantry first",
+      module_key: "shopping_list",
+      recurrence_hint: null,
+      rrule: null,
+      recurrence_series_id: null,
+      linked_source: null,
+      linked_ref: null,
+      is_done: false,
+    },
+    {
+      id: 402,
+      title: "Call dentist",
+      planned_for: date,
+      time_of_day: "10:00",
+      duration_minutes: 15,
+      notes: null,
+      module_key: null,
+      recurrence_hint: null,
+      rrule: null,
+      recurrence_series_id: null,
+      linked_source: null,
+      linked_ref: null,
+      is_done: true,
+    },
+    {
+      id: 403,
+      title: "Weekly meal plan",
+      planned_for: date,
+      time_of_day: null,
+      duration_minutes: 45,
+      notes: null,
+      module_key: "meal_planning",
+      recurrence_hint: "weekly",
+      rrule: "FREQ=WEEKLY;BYDAY=FR",
+      recurrence_series_id: "series-001",
+      linked_source: null,
+      linked_ref: null,
+      is_done: false,
+    },
+  ];
+}
+
+let _nextPlannedItemId = 500;
+
+export function nextPlannedItemId(): number {
+  return _nextPlannedItemId++;
+}

--- a/frontend/src/mocks/data/settings.ts
+++ b/frontend/src/mocks/data/settings.ts
@@ -1,0 +1,14 @@
+import type { UserSettings } from "@/lib/api/today";
+
+export function seedUserSettings(): UserSettings {
+  return {
+    timezone: "Europe/Brussels",
+    default_snooze_days: 1,
+    medication_reminder_minutes: 30,
+    quiet_hours_start: "22:00",
+    quiet_hours_end: "08:00",
+    push_overdue_chores_enabled: true,
+    push_medication_reminders_enabled: true,
+    push_missed_medications_enabled: true,
+  };
+}

--- a/frontend/src/mocks/data/state.ts
+++ b/frontend/src/mocks/data/state.ts
@@ -6,9 +6,14 @@ import type {
   UserSettings,
 } from "@/lib/api/today";
 import { MOCK_TODAY } from "./constants";
-import { busyTodayPayload, emptyTodayPayload, overdueTodayPayload } from "./today";
+import { busyTodayPayload, emptyTodayPayload, medicationRefillTodayPayload, overdueTodayPayload } from "./today";
 import { seedMedications } from "./medication";
-import { seedRoutineTemplates, seedChoreTemplates } from "./templates";
+import {
+  seedRoutineTemplates,
+  seedRoutineTemplatesCrud,
+  seedChoreTemplates,
+  seedChoreTemplatesCrud,
+} from "./templates";
 import { seedPlannedItems } from "./plannedItems";
 import { seedUserSettings } from "./settings";
 
@@ -21,6 +26,7 @@ export type MockScenario =
   | "template-crud"
   | "signed-out"
   | "expired-session"
+  | "forbidden"
   | "api-error";
 
 interface MockState {
@@ -35,10 +41,10 @@ interface MockState {
 function buildInitialState(scenario: MockScenario): MockState {
   return {
     scenario,
-    plannedItems: scenario === "empty" ? [] : seedPlannedItems(MOCK_TODAY),
+    plannedItems: scenario === "empty" || scenario === "template-crud" ? [] : seedPlannedItems(MOCK_TODAY),
     medications: seedMedications(),
-    routineTemplates: seedRoutineTemplates(),
-    choreTemplates: seedChoreTemplates(),
+    routineTemplates: scenario === "template-crud" ? seedRoutineTemplatesCrud() : seedRoutineTemplates(),
+    choreTemplates: scenario === "template-crud" ? seedChoreTemplatesCrud() : seedChoreTemplates(),
     settings: seedUserSettings(),
   };
 }
@@ -62,6 +68,8 @@ export function getTodayPayload() {
   if (scenario === "empty") return emptyTodayPayload(MOCK_TODAY);
   if (scenario === "busy-today") return busyTodayPayload(MOCK_TODAY);
   if (scenario === "overdue") return overdueTodayPayload(MOCK_TODAY);
+  if (scenario === "medication-refill") return medicationRefillTodayPayload(MOCK_TODAY);
+  if (scenario === "template-crud") return emptyTodayPayload(MOCK_TODAY);
   return busyTodayPayload(MOCK_TODAY);
 }
 
@@ -109,6 +117,7 @@ export function initScenarioFromUrl(): void {
       "template-crud",
       "signed-out",
       "expired-session",
+      "forbidden",
       "api-error",
     ];
     if (valid.includes(raw as MockScenario)) {

--- a/frontend/src/mocks/data/state.ts
+++ b/frontend/src/mocks/data/state.ts
@@ -1,0 +1,118 @@
+import type {
+  PlannedTodayItem,
+  MedicationPlan,
+  RoutineTemplate,
+  ChoreTemplate,
+  UserSettings,
+} from "@/lib/api/today";
+import { MOCK_TODAY } from "./constants";
+import { busyTodayPayload, emptyTodayPayload, overdueTodayPayload } from "./today";
+import { seedMedications } from "./medication";
+import { seedRoutineTemplates, seedChoreTemplates } from "./templates";
+import { seedPlannedItems } from "./plannedItems";
+import { seedUserSettings } from "./settings";
+
+export type MockScenario =
+  | "default"
+  | "empty"
+  | "busy-today"
+  | "overdue"
+  | "medication-refill"
+  | "template-crud"
+  | "signed-out"
+  | "expired-session"
+  | "api-error";
+
+interface MockState {
+  scenario: MockScenario;
+  plannedItems: PlannedTodayItem[];
+  medications: MedicationPlan[];
+  routineTemplates: RoutineTemplate[];
+  choreTemplates: ChoreTemplate[];
+  settings: UserSettings;
+}
+
+function buildInitialState(scenario: MockScenario): MockState {
+  return {
+    scenario,
+    plannedItems: scenario === "empty" ? [] : seedPlannedItems(MOCK_TODAY),
+    medications: seedMedications(),
+    routineTemplates: seedRoutineTemplates(),
+    choreTemplates: seedChoreTemplates(),
+    settings: seedUserSettings(),
+  };
+}
+
+let _state: MockState = buildInitialState("default");
+
+export function getMockState(): Readonly<MockState> {
+  return _state;
+}
+
+export function setScenario(scenario: MockScenario): void {
+  _state = buildInitialState(scenario);
+}
+
+export function resetMockState(): void {
+  _state = buildInitialState("default");
+}
+
+export function getTodayPayload() {
+  const { scenario } = _state;
+  if (scenario === "empty") return emptyTodayPayload(MOCK_TODAY);
+  if (scenario === "busy-today") return busyTodayPayload(MOCK_TODAY);
+  if (scenario === "overdue") return overdueTodayPayload(MOCK_TODAY);
+  return busyTodayPayload(MOCK_TODAY);
+}
+
+export function mutatePlannedItems(
+  updater: (items: PlannedTodayItem[]) => PlannedTodayItem[],
+): void {
+  _state = { ..._state, plannedItems: updater(_state.plannedItems) };
+}
+
+export function mutateMedications(
+  updater: (items: MedicationPlan[]) => MedicationPlan[],
+): void {
+  _state = { ..._state, medications: updater(_state.medications) };
+}
+
+export function mutateRoutineTemplates(
+  updater: (items: RoutineTemplate[]) => RoutineTemplate[],
+): void {
+  _state = { ..._state, routineTemplates: updater(_state.routineTemplates) };
+}
+
+export function mutateChoreTemplates(
+  updater: (items: ChoreTemplate[]) => ChoreTemplate[],
+): void {
+  _state = { ..._state, choreTemplates: updater(_state.choreTemplates) };
+}
+
+export function mutateSettings(
+  updater: (s: UserSettings) => UserSettings,
+): void {
+  _state = { ..._state, settings: updater(_state.settings) };
+}
+
+/** Reads the `mock-scenario` URL search param and applies it if present. */
+export function initScenarioFromUrl(): void {
+  if (typeof window === "undefined") return;
+  const raw = new URLSearchParams(window.location.search).get("mock-scenario");
+  if (raw) {
+    const valid: MockScenario[] = [
+      "default",
+      "empty",
+      "busy-today",
+      "overdue",
+      "medication-refill",
+      "template-crud",
+      "signed-out",
+      "expired-session",
+      "api-error",
+    ];
+    if (valid.includes(raw as MockScenario)) {
+      setScenario(raw as MockScenario);
+    }
+  }
+}

--- a/frontend/src/mocks/data/state.ts
+++ b/frontend/src/mocks/data/state.ts
@@ -7,14 +7,15 @@ import type {
 } from "@/lib/api/today";
 import { MOCK_TODAY } from "./constants";
 import { busyTodayPayload, emptyTodayPayload, medicationRefillTodayPayload, overdueTodayPayload } from "./today";
-import { seedMedications } from "./medication";
+import { seedMedications, resetMedicationId } from "./medication";
 import {
   seedRoutineTemplates,
   seedRoutineTemplatesCrud,
   seedChoreTemplates,
   seedChoreTemplatesCrud,
+  resetTemplateId,
 } from "./templates";
-import { seedPlannedItems } from "./plannedItems";
+import { seedPlannedItems, resetPlannedItemId } from "./plannedItems";
 import { seedUserSettings } from "./settings";
 
 export type MockScenario =
@@ -60,6 +61,9 @@ export function setScenario(scenario: MockScenario): void {
 }
 
 export function resetMockState(): void {
+  resetMedicationId();
+  resetPlannedItemId();
+  resetTemplateId();
   _state = buildInitialState("default");
 }
 

--- a/frontend/src/mocks/data/templates.ts
+++ b/frontend/src/mocks/data/templates.ts
@@ -95,6 +95,66 @@ export function seedChoreTemplates(): ChoreTemplate[] {
   ];
 }
 
+/** Extended set used by the template-crud scenario — shows active, inactive, and paginated lists. */
+export function seedRoutineTemplatesCrud(): RoutineTemplate[] {
+  return [
+    ...seedRoutineTemplates(),
+    {
+      id: 24,
+      name: "Journaling",
+      description: "Daily reflection before bed",
+      start_date: "2026-02-01",
+      every_n_days: 1,
+      due_time: "21:00",
+      is_active: true,
+      created_at: "2026-02-01T00:00:00Z",
+    },
+    {
+      id: 25,
+      name: "Old yoga routine",
+      description: "Replaced by morning stretches",
+      start_date: "2025-06-01",
+      every_n_days: 1,
+      due_time: "07:00",
+      is_active: false,
+      created_at: "2025-06-01T00:00:00Z",
+    },
+  ];
+}
+
+export function seedChoreTemplatesCrud(): ChoreTemplate[] {
+  return [
+    ...seedChoreTemplates(),
+    {
+      id: 35,
+      name: "Change bed sheets",
+      description: null,
+      start_date: "2026-01-01",
+      every_n_days: 14,
+      is_active: true,
+      created_at: "2026-01-01T00:00:00Z",
+    },
+    {
+      id: 36,
+      name: "Defrost freezer",
+      description: "Do quarterly",
+      start_date: "2026-01-01",
+      every_n_days: 90,
+      is_active: true,
+      created_at: "2026-01-01T00:00:00Z",
+    },
+    {
+      id: 37,
+      name: "Old window cleaning",
+      description: null,
+      start_date: "2025-01-01",
+      every_n_days: 30,
+      is_active: false,
+      created_at: "2025-01-01T00:00:00Z",
+    },
+  ];
+}
+
 let _nextTemplateId = 200;
 
 export function nextTemplateId(): number {

--- a/frontend/src/mocks/data/templates.ts
+++ b/frontend/src/mocks/data/templates.ts
@@ -160,3 +160,7 @@ let _nextTemplateId = 200;
 export function nextTemplateId(): number {
   return _nextTemplateId++;
 }
+
+export function resetTemplateId(): void {
+  _nextTemplateId = 200;
+}

--- a/frontend/src/mocks/data/templates.ts
+++ b/frontend/src/mocks/data/templates.ts
@@ -1,0 +1,102 @@
+import type { RoutineTemplate, ChoreTemplate } from "@/lib/api/today";
+
+export function seedRoutineTemplates(): RoutineTemplate[] {
+  return [
+    {
+      id: 20,
+      name: "Morning routine",
+      description: "Stretches and mindfulness",
+      start_date: "2026-01-01",
+      every_n_days: 1,
+      due_time: "09:00",
+      is_active: true,
+      created_at: "2026-01-01T00:00:00Z",
+    },
+    {
+      id: 21,
+      name: "Pack lunch",
+      description: null,
+      start_date: "2026-01-01",
+      every_n_days: 1,
+      due_time: null,
+      is_active: true,
+      created_at: "2026-01-01T00:00:00Z",
+    },
+    {
+      id: 22,
+      name: "Evening walk",
+      description: "30 minute walk around the block",
+      start_date: "2026-01-01",
+      every_n_days: 1,
+      due_time: "19:00",
+      is_active: true,
+      created_at: "2026-01-01T00:00:00Z",
+    },
+    {
+      id: 23,
+      name: "Weekly review",
+      description: "Review goals and plan next week",
+      start_date: "2026-01-05",
+      every_n_days: 7,
+      due_time: "18:00",
+      is_active: true,
+      created_at: "2026-01-05T00:00:00Z",
+    },
+  ];
+}
+
+export function seedChoreTemplates(): ChoreTemplate[] {
+  return [
+    {
+      id: 30,
+      name: "Water plants",
+      description: null,
+      start_date: "2026-01-01",
+      every_n_days: 2,
+      is_active: true,
+      created_at: "2026-01-01T00:00:00Z",
+    },
+    {
+      id: 31,
+      name: "Take out recycling",
+      description: "Blue bin on Mondays",
+      start_date: "2026-01-05",
+      every_n_days: 7,
+      is_active: true,
+      created_at: "2026-01-05T00:00:00Z",
+    },
+    {
+      id: 32,
+      name: "Clean bathroom",
+      description: null,
+      start_date: "2026-01-01",
+      every_n_days: 7,
+      is_active: true,
+      created_at: "2026-01-01T00:00:00Z",
+    },
+    {
+      id: 33,
+      name: "Vacuum living room",
+      description: null,
+      start_date: "2026-01-01",
+      every_n_days: 7,
+      is_active: true,
+      created_at: "2026-01-01T00:00:00Z",
+    },
+    {
+      id: 34,
+      name: "Clean kitchen",
+      description: "Deep clean including oven",
+      start_date: "2026-01-01",
+      every_n_days: 14,
+      is_active: true,
+      created_at: "2026-01-01T00:00:00Z",
+    },
+  ];
+}
+
+let _nextTemplateId = 200;
+
+export function nextTemplateId(): number {
+  return _nextTemplateId++;
+}

--- a/frontend/src/mocks/data/today.ts
+++ b/frontend/src/mocks/data/today.ts
@@ -1,0 +1,212 @@
+import type { TodayPayload } from "@/lib/api/today";
+
+export function emptyTodayPayload(_date: string): TodayPayload {
+  return {
+    medication: [],
+    medication_history: [],
+    routines: [],
+    overdue: [],
+    due_today: [],
+    upcoming: [],
+    planned: [],
+    day_items: [],
+  };
+}
+
+export function busyTodayPayload(date: string): TodayPayload {
+  return {
+    medication: [
+      {
+        medication_dose_instance_id: 101,
+        medication_plan_id: 10,
+        name: "Morning vitamin",
+        instructions: "With breakfast",
+        scheduled_at: `${date}T08:00:00Z`,
+        status: "scheduled",
+      },
+      {
+        medication_dose_instance_id: 102,
+        medication_plan_id: 11,
+        name: "Blood pressure pill",
+        instructions: "Before bed",
+        scheduled_at: `${date}T22:00:00Z`,
+        status: "taken",
+      },
+      {
+        medication_dose_instance_id: 103,
+        medication_plan_id: 12,
+        name: "Evening magnesium",
+        instructions: "After dinner",
+        scheduled_at: `${date}T20:00:00Z`,
+        status: "skipped",
+      },
+    ],
+    medication_history: [
+      {
+        medication_dose_instance_id: 90,
+        medication_plan_id: 10,
+        name: "Morning vitamin",
+        instructions: "With breakfast",
+        scheduled_at: `2026-05-28T08:00:00Z`,
+        status: "taken",
+      },
+    ],
+    routines: [
+      {
+        task_instance_id: 201,
+        routine_template_id: 20,
+        title: "Morning stretches",
+        status: "completed",
+        scheduled_date: date,
+        due_at: `${date}T09:00:00Z`,
+      },
+      {
+        task_instance_id: 202,
+        routine_template_id: 21,
+        title: "Pack lunch",
+        status: "pending",
+        scheduled_date: date,
+        due_at: null,
+      },
+      {
+        task_instance_id: 203,
+        routine_template_id: 22,
+        title: "Evening walk",
+        status: "in_progress",
+        scheduled_date: date,
+        due_at: `${date}T19:00:00Z`,
+      },
+    ],
+    overdue: [],
+    due_today: [
+      {
+        chore_instance_id: 301,
+        chore_template_id: 30,
+        title: "Water plants",
+        status: "pending",
+        scheduled_date: date,
+      },
+      {
+        chore_instance_id: 302,
+        chore_template_id: 31,
+        title: "Take out recycling",
+        status: "completed",
+        scheduled_date: date,
+      },
+    ],
+    upcoming: [
+      {
+        chore_instance_id: 303,
+        chore_template_id: 32,
+        title: "Clean bathroom",
+        scheduled_date: "2026-06-01",
+      },
+    ],
+    planned: [
+      {
+        id: 401,
+        title: "Order groceries",
+        planned_for: date,
+        time_of_day: null,
+        duration_minutes: 30,
+        notes: "Check pantry first",
+        module_key: "shopping_list",
+        recurrence_hint: null,
+        rrule: null,
+        recurrence_series_id: null,
+        linked_source: null,
+        linked_ref: null,
+        is_done: false,
+      },
+      {
+        id: 402,
+        title: "Call dentist",
+        planned_for: date,
+        time_of_day: "10:00",
+        duration_minutes: 15,
+        notes: null,
+        module_key: null,
+        recurrence_hint: null,
+        rrule: null,
+        recurrence_series_id: null,
+        linked_source: null,
+        linked_ref: null,
+        is_done: true,
+      },
+    ],
+    day_items: [
+      {
+        item_type: "routine",
+        item_id: 201,
+        title: "Morning stretches",
+        status: "completed",
+        scheduled_at: `${date}T09:00:00Z`,
+        scheduled_date: date,
+        detail: null,
+        module_key: null,
+      },
+    ],
+  };
+}
+
+export function overdueTodayPayload(date: string): TodayPayload {
+  return {
+    medication: [
+      {
+        medication_dose_instance_id: 110,
+        medication_plan_id: 10,
+        name: "Morning vitamin",
+        instructions: "With breakfast",
+        scheduled_at: `${date}T08:00:00Z`,
+        status: "missed",
+      },
+      {
+        medication_dose_instance_id: 111,
+        medication_plan_id: 11,
+        name: "Blood pressure pill",
+        instructions: "Before bed",
+        scheduled_at: `${date}T22:00:00Z`,
+        status: "missed",
+      },
+    ],
+    medication_history: [],
+    routines: [
+      {
+        task_instance_id: 210,
+        routine_template_id: 20,
+        title: "Morning stretches",
+        status: "pending",
+        scheduled_date: date,
+        due_at: `${date}T09:00:00Z`,
+      },
+    ],
+    overdue: [
+      {
+        chore_instance_id: 310,
+        chore_template_id: 30,
+        title: "Clean kitchen",
+        status: "pending",
+        overdue_since: "2026-05-25",
+      },
+      {
+        chore_instance_id: 311,
+        chore_template_id: 31,
+        title: "Change bed sheets",
+        status: "pending",
+        overdue_since: "2026-05-20",
+      },
+    ],
+    due_today: [
+      {
+        chore_instance_id: 312,
+        chore_template_id: 32,
+        title: "Vacuum living room",
+        status: "pending",
+        scheduled_date: date,
+      },
+    ],
+    upcoming: [],
+    planned: [],
+    day_items: [],
+  };
+}

--- a/frontend/src/mocks/data/today.ts
+++ b/frontend/src/mocks/data/today.ts
@@ -149,6 +149,69 @@ export function busyTodayPayload(date: string): TodayPayload {
   };
 }
 
+export function medicationRefillTodayPayload(date: string): TodayPayload {
+  return {
+    medication: [
+      {
+        medication_dose_instance_id: 120,
+        medication_plan_id: 10,
+        name: "Morning vitamin",
+        instructions: "With breakfast",
+        scheduled_at: `${date}T08:00:00Z`,
+        status: "scheduled",
+      },
+      {
+        medication_dose_instance_id: 121,
+        medication_plan_id: 11,
+        name: "Blood pressure pill",
+        instructions: "Before bed",
+        scheduled_at: `${date}T22:00:00Z`,
+        status: "taken",
+      },
+      {
+        medication_dose_instance_id: 122,
+        medication_plan_id: 12,
+        name: "Evening magnesium",
+        instructions: "After dinner — last dose, needs refill",
+        scheduled_at: `${date}T20:00:00Z`,
+        status: "skipped",
+      },
+      {
+        medication_dose_instance_id: 123,
+        medication_plan_id: 14,
+        name: "Antihistamine (expired plan)",
+        instructions: "Take with water",
+        scheduled_at: `${date}T12:00:00Z`,
+        status: "missed",
+      },
+    ],
+    medication_history: [
+      {
+        medication_dose_instance_id: 115,
+        medication_plan_id: 12,
+        name: "Evening magnesium",
+        instructions: "After dinner",
+        scheduled_at: "2026-05-28T20:00:00Z",
+        status: "missed",
+      },
+      {
+        medication_dose_instance_id: 116,
+        medication_plan_id: 12,
+        name: "Evening magnesium",
+        instructions: "After dinner",
+        scheduled_at: "2026-05-27T20:00:00Z",
+        status: "missed",
+      },
+    ],
+    routines: [],
+    overdue: [],
+    due_today: [],
+    upcoming: [],
+    planned: [],
+    day_items: [],
+  };
+}
+
 export function overdueTodayPayload(date: string): TodayPayload {
   return {
     medication: [

--- a/frontend/src/mocks/handlers/analytics.ts
+++ b/frontend/src/mocks/handlers/analytics.ts
@@ -1,0 +1,53 @@
+import { http, HttpResponse } from "msw";
+import { MOCK_TODAY } from "../data/constants";
+
+export const analyticsHandlers = [
+  http.get("/api/v1/analytics/summary", ({ request }) => {
+    const url = new URL(request.url);
+    const period = url.searchParams.get("period") ?? "week";
+    return HttpResponse.json({
+      period,
+      start_date: "2026-05-22",
+      end_date: MOCK_TODAY,
+      chores: {
+        completion_rate: 0.78,
+        total_completed: 14,
+        total_scheduled: 18,
+        daily_completions: [],
+        streaks: [{ chore_id: 30, name: "Water plants", current_streak: 5, longest_streak: 12 }],
+        most_skipped: [],
+      },
+      medications: {
+        adherence_rate: 0.93,
+        total_taken: 13,
+        total_scheduled: 14,
+        daily_adherence: [],
+      },
+      planned_items: {
+        completion_rate: 0.6,
+        total_completed: 9,
+        total_scheduled: 15,
+        daily_completions: [],
+      },
+      routines: {
+        completion_rate: 0.85,
+        total_completed: 17,
+        total_scheduled: 20,
+        daily_completions: [],
+        streaks: [{ routine_id: 20, name: "Morning routine", current_streak: 7, longest_streak: 21 }],
+      },
+    });
+  }),
+
+  http.get("/api/v1/search", ({ request }) => {
+    const url = new URL(request.url);
+    const q = url.searchParams.get("q") ?? "";
+    return HttpResponse.json({
+      query: q,
+      routine_templates: [],
+      chore_templates: [],
+      medication_plans: [],
+      planned_items: [],
+    });
+  }),
+];

--- a/frontend/src/mocks/handlers/auth.ts
+++ b/frontend/src/mocks/handlers/auth.ts
@@ -1,5 +1,5 @@
 import { http, HttpResponse } from "msw";
-import { MOCK_USER } from "../data/constants";
+import { MOCK_USER, MOCK_TODAY } from "../data/constants";
 import { getMockState } from "../data/state";
 import { auth401, forbidden403 } from "./errors";
 
@@ -14,13 +14,14 @@ export const authHandlers = [
   http.get("/api/v1/auth/sessions", () => {
     const { scenario } = getMockState();
     if (scenario === "signed-out") return auth401();
+    const base = new Date(MOCK_TODAY + "T12:00:00Z").getTime();
     return HttpResponse.json([
       {
         id: "session-001",
         ip_address: "127.0.0.1",
-        started: Date.now() - 3600_000,
-        last_access: Date.now() - 60_000,
-        expires: Date.now() + 86_400_000,
+        started: base - 3_600_000,
+        last_access: base - 60_000,
+        expires: base + 86_400_000,
         clients: [],
       },
     ]);

--- a/frontend/src/mocks/handlers/auth.ts
+++ b/frontend/src/mocks/handlers/auth.ts
@@ -1,0 +1,32 @@
+import { http, HttpResponse } from "msw";
+import { MOCK_USER } from "../data/constants";
+import { getMockState } from "../data/state";
+import { auth401 } from "./errors";
+
+export const authHandlers = [
+  http.get("/api/v1/auth/me", () => {
+    const { scenario } = getMockState();
+    if (scenario === "signed-out") return auth401();
+    if (scenario === "expired-session") return auth401();
+    return HttpResponse.json(MOCK_USER);
+  }),
+
+  http.get("/api/v1/auth/sessions", () => {
+    const { scenario } = getMockState();
+    if (scenario === "signed-out") return auth401();
+    return HttpResponse.json([
+      {
+        id: "session-001",
+        ip_address: "127.0.0.1",
+        started: Date.now() - 3600_000,
+        last_access: Date.now() - 60_000,
+        expires: Date.now() + 86_400_000,
+        clients: [],
+      },
+    ]);
+  }),
+
+  http.delete("/api/v1/auth/sessions/:sessionId", () =>
+    new HttpResponse(null, { status: 204 }),
+  ),
+];

--- a/frontend/src/mocks/handlers/auth.ts
+++ b/frontend/src/mocks/handlers/auth.ts
@@ -1,13 +1,13 @@
 import { http, HttpResponse } from "msw";
 import { MOCK_USER } from "../data/constants";
 import { getMockState } from "../data/state";
-import { auth401 } from "./errors";
+import { auth401, forbidden403 } from "./errors";
 
 export const authHandlers = [
   http.get("/api/v1/auth/me", () => {
     const { scenario } = getMockState();
-    if (scenario === "signed-out") return auth401();
-    if (scenario === "expired-session") return auth401();
+    if (scenario === "signed-out" || scenario === "expired-session") return auth401();
+    if (scenario === "forbidden") return forbidden403();
     return HttpResponse.json(MOCK_USER);
   }),
 

--- a/frontend/src/mocks/handlers/chores.ts
+++ b/frontend/src/mocks/handlers/chores.ts
@@ -7,7 +7,7 @@ export const choreHandlers = [
       chore_instance_id: Number(params.id),
       status: "completed",
       scheduled_date: MOCK_TODAY,
-      completed_at: new Date().toISOString(),
+      completed_at: `${MOCK_TODAY}T09:00:00.000Z`,
       skipped_at: null,
     }),
   ),
@@ -18,7 +18,7 @@ export const choreHandlers = [
       status: "skipped",
       scheduled_date: MOCK_TODAY,
       completed_at: null,
-      skipped_at: new Date().toISOString(),
+      skipped_at: `${MOCK_TODAY}T09:00:00.000Z`,
     }),
   ),
 

--- a/frontend/src/mocks/handlers/chores.ts
+++ b/frontend/src/mocks/handlers/chores.ts
@@ -1,0 +1,35 @@
+import { http, HttpResponse } from "msw";
+import { MOCK_TODAY } from "../data/constants";
+
+export const choreHandlers = [
+  http.post("/api/v1/chores/:id/complete", ({ params }) =>
+    HttpResponse.json({
+      chore_instance_id: Number(params.id),
+      status: "completed",
+      scheduled_date: MOCK_TODAY,
+      completed_at: new Date().toISOString(),
+      skipped_at: null,
+    }),
+  ),
+
+  http.post("/api/v1/chores/:id/skip", ({ params }) =>
+    HttpResponse.json({
+      chore_instance_id: Number(params.id),
+      status: "skipped",
+      scheduled_date: MOCK_TODAY,
+      completed_at: null,
+      skipped_at: new Date().toISOString(),
+    }),
+  ),
+
+  http.post("/api/v1/chores/:id/reschedule", async ({ params, request }) => {
+    const body = (await request.json()) as { scheduled_date: string };
+    return HttpResponse.json({
+      chore_instance_id: Number(params.id),
+      status: "pending",
+      scheduled_date: body.scheduled_date,
+      completed_at: null,
+      skipped_at: null,
+    });
+  }),
+];

--- a/frontend/src/mocks/handlers/config.ts
+++ b/frontend/src/mocks/handlers/config.ts
@@ -1,0 +1,11 @@
+import { http, HttpResponse } from "msw";
+
+export const configHandlers = [
+  http.get("/api/v1/auth/oidc-config", () =>
+    HttpResponse.json({
+      issuer: "http://localhost/mock-issuer",
+      authorization_url: "http://localhost/mock-issuer/auth",
+      token_url: "http://localhost/mock-issuer/token",
+    }),
+  ),
+];

--- a/frontend/src/mocks/handlers/errors.ts
+++ b/frontend/src/mocks/handlers/errors.ts
@@ -1,0 +1,16 @@
+import { HttpResponse } from "msw";
+
+export const auth401 = () =>
+  HttpResponse.json({ detail: "Not authenticated" }, { status: 401 });
+
+export const forbidden403 = () =>
+  HttpResponse.json({ detail: "Forbidden" }, { status: 403 });
+
+export const validation422 = (field: string, msg: string) =>
+  HttpResponse.json(
+    { detail: [{ loc: ["body", field], msg, type: "value_error" }] },
+    { status: 422 },
+  );
+
+export const serverError500 = () =>
+  HttpResponse.json({ detail: "Internal server error" }, { status: 500 });

--- a/frontend/src/mocks/handlers/index.ts
+++ b/frontend/src/mocks/handlers/index.ts
@@ -1,0 +1,23 @@
+import { configHandlers } from "./config";
+import { authHandlers } from "./auth";
+import { todayHandlers } from "./today";
+import { plannedItemHandlers } from "./plannedItems";
+import { choreHandlers } from "./chores";
+import { taskHandlers } from "./tasks";
+import { medicationHandlers } from "./medication";
+import { templateHandlers } from "./templates";
+import { settingsHandlers } from "./settings";
+import { analyticsHandlers } from "./analytics";
+
+export const handlers = [
+  ...configHandlers,
+  ...authHandlers,
+  ...todayHandlers,
+  ...plannedItemHandlers,
+  ...choreHandlers,
+  ...taskHandlers,
+  ...medicationHandlers,
+  ...templateHandlers,
+  ...settingsHandlers,
+  ...analyticsHandlers,
+];

--- a/frontend/src/mocks/handlers/medication.ts
+++ b/frontend/src/mocks/handlers/medication.ts
@@ -1,0 +1,67 @@
+import { http, HttpResponse } from "msw";
+import { getMockState, mutateMedications } from "../data/state";
+import { nextMedicationId, seedMedicationHistory } from "../data/medication";
+import { MOCK_TODAY } from "../data/constants";
+import type { MedicationPlanInput, MedicationPlanUpdateInput } from "@/lib/api/today";
+
+export const medicationHandlers = [
+  http.get("/api/v1/medications", () =>
+    HttpResponse.json(getMockState().medications),
+  ),
+
+  http.post("/api/v1/medications", async ({ request }) => {
+    const input = (await request.json()) as MedicationPlanInput;
+    const newPlan = {
+      id: nextMedicationId(),
+      name: input.name,
+      instructions: input.instructions,
+      start_date: input.start_date,
+      schedule_time: input.schedule_time,
+      every_n_days: input.every_n_days,
+      is_active: true,
+    };
+    mutateMedications((plans) => [...plans, newPlan]);
+    return HttpResponse.json(newPlan, { status: 201 });
+  }),
+
+  http.put("/api/v1/medications/:id", async ({ params, request }) => {
+    const id = Number(params.id);
+    const input = (await request.json()) as MedicationPlanUpdateInput;
+    const { medications } = getMockState();
+    const existing = medications.find((m) => m.id === id);
+
+    if (!existing) {
+      return HttpResponse.json({ detail: "Not found" }, { status: 404 });
+    }
+
+    const updated = { ...existing, ...input };
+    mutateMedications((plans) => plans.map((m) => (m.id === id ? updated : m)));
+    return HttpResponse.json(updated);
+  }),
+
+  http.delete("/api/v1/medications/:id", ({ params }) => {
+    const id = Number(params.id);
+    mutateMedications((plans) => plans.filter((m) => m.id !== id));
+    return new HttpResponse(null, { status: 204 });
+  }),
+
+  http.post("/api/v1/medication-doses/:id/take", ({ params }) =>
+    HttpResponse.json({
+      medication_dose_instance_id: Number(params.id),
+      status: "taken",
+      scheduled_date: MOCK_TODAY,
+    }),
+  ),
+
+  http.post("/api/v1/medication-doses/:id/skip", ({ params }) =>
+    HttpResponse.json({
+      medication_dose_instance_id: Number(params.id),
+      status: "skipped",
+      scheduled_date: MOCK_TODAY,
+    }),
+  ),
+
+  http.get("/api/v1/medication-doses/history", () =>
+    HttpResponse.json({ history: seedMedicationHistory() }),
+  ),
+];

--- a/frontend/src/mocks/handlers/plannedItems.ts
+++ b/frontend/src/mocks/handlers/plannedItems.ts
@@ -1,0 +1,67 @@
+import { http, HttpResponse } from "msw";
+import {
+  getMockState,
+  mutatePlannedItems,
+} from "../data/state";
+import { nextPlannedItemId } from "../data/plannedItems";
+import type { PlannedItemInput, PlannedItemUpdateInput } from "@/lib/api/today";
+
+export const plannedItemHandlers = [
+  http.get("/api/v1/planned-items", ({ request }) => {
+    const url = new URL(request.url);
+    const startDate = url.searchParams.get("start_date");
+    const endDate = url.searchParams.get("end_date");
+    let { plannedItems } = getMockState();
+
+    if (startDate) {
+      plannedItems = plannedItems.filter((i) => i.planned_for >= startDate);
+    }
+    if (endDate) {
+      plannedItems = plannedItems.filter((i) => i.planned_for <= endDate);
+    }
+
+    return HttpResponse.json(plannedItems);
+  }),
+
+  http.post("/api/v1/planned-items", async ({ request }) => {
+    const input = (await request.json()) as PlannedItemInput;
+    const newItem = {
+      id: nextPlannedItemId(),
+      title: input.title,
+      planned_for: input.planned_for,
+      time_of_day: input.time_of_day ?? null,
+      duration_minutes: input.duration_minutes ?? null,
+      notes: input.notes ?? null,
+      module_key: input.module_key ?? null,
+      recurrence_hint: input.recurrence_hint ?? null,
+      rrule: input.rrule ?? null,
+      recurrence_series_id: null,
+      linked_source: input.linked_source ?? null,
+      linked_ref: input.linked_ref ?? null,
+      is_done: false,
+    };
+    mutatePlannedItems((items) => [...items, newItem]);
+    return HttpResponse.json(newItem, { status: 201 });
+  }),
+
+  http.put("/api/v1/planned-items/:id", async ({ params, request }) => {
+    const id = Number(params.id);
+    const input = (await request.json()) as PlannedItemUpdateInput;
+    const { plannedItems } = getMockState();
+    const existing = plannedItems.find((i) => i.id === id);
+
+    if (!existing) {
+      return HttpResponse.json({ detail: "Not found" }, { status: 404 });
+    }
+
+    const updated = { ...existing, ...input };
+    mutatePlannedItems((items) => items.map((i) => (i.id === id ? updated : i)));
+    return HttpResponse.json(updated);
+  }),
+
+  http.delete("/api/v1/planned-items/:id", ({ params }) => {
+    const id = Number(params.id);
+    mutatePlannedItems((items) => items.filter((i) => i.id !== id));
+    return new HttpResponse(null, { status: 204 });
+  }),
+];

--- a/frontend/src/mocks/handlers/settings.ts
+++ b/frontend/src/mocks/handlers/settings.ts
@@ -1,0 +1,60 @@
+import { http, HttpResponse } from "msw";
+import { getMockState, mutateSettings } from "../data/state";
+import type { UserSettingsPatch } from "@/lib/api/today";
+
+export const settingsHandlers = [
+  http.get("/api/v1/users/me/settings", () =>
+    HttpResponse.json(getMockState().settings),
+  ),
+
+  http.patch("/api/v1/users/me/settings", async ({ request }) => {
+    const patch = (await request.json()) as UserSettingsPatch;
+    mutateSettings((s) => ({ ...s, ...patch }));
+    return HttpResponse.json(getMockState().settings);
+  }),
+
+  http.get("/api/v1/integrations/clients", () =>
+    HttpResponse.json([
+      {
+        id: 1,
+        name: "Home Assistant",
+        rate_limit_per_minute: 60,
+        is_active: true,
+      },
+    ]),
+  ),
+
+  http.post("/api/v1/integrations/clients", async ({ request }) => {
+    const body = (await request.json()) as { name: string; rate_limit_per_minute: number };
+    return HttpResponse.json(
+      {
+        id: 99,
+        name: body.name,
+        rate_limit_per_minute: body.rate_limit_per_minute,
+        is_active: true,
+        api_key: "mock-api-key-new",
+        client_id: "mock-client-id-new",
+        client_secret: "mock-client-secret-new",
+        token_url: "http://localhost/mock-issuer/token",
+      },
+      { status: 201 },
+    );
+  }),
+
+  http.post("/api/v1/integrations/clients/:id/rotate", ({ params }) =>
+    HttpResponse.json({
+      id: Number(params.id),
+      name: "Home Assistant",
+      rate_limit_per_minute: 60,
+      is_active: true,
+      api_key: "mock-api-key-rotated",
+      client_id: "mock-client-id-rotated",
+      client_secret: "mock-client-secret-rotated",
+      token_url: "http://localhost/mock-issuer/token",
+    }),
+  ),
+
+  http.delete("/api/v1/integrations/clients/:id", () =>
+    new HttpResponse(null, { status: 204 }),
+  ),
+];

--- a/frontend/src/mocks/handlers/tasks.ts
+++ b/frontend/src/mocks/handlers/tasks.ts
@@ -1,0 +1,34 @@
+import { http, HttpResponse } from "msw";
+import { MOCK_TODAY } from "../data/constants";
+
+export const taskHandlers = [
+  http.post("/api/v1/tasks/:id/start", ({ params }) =>
+    HttpResponse.json({
+      task_instance_id: Number(params.id),
+      status: "in_progress",
+      scheduled_date: MOCK_TODAY,
+      due_at: null,
+      completed_at: null,
+    }),
+  ),
+
+  http.post("/api/v1/tasks/:id/complete", ({ params }) =>
+    HttpResponse.json({
+      task_instance_id: Number(params.id),
+      status: "completed",
+      scheduled_date: MOCK_TODAY,
+      due_at: null,
+      completed_at: new Date().toISOString(),
+    }),
+  ),
+
+  http.post("/api/v1/tasks/:id/skip", ({ params }) =>
+    HttpResponse.json({
+      task_instance_id: Number(params.id),
+      status: "skipped",
+      scheduled_date: MOCK_TODAY,
+      due_at: null,
+      completed_at: null,
+    }),
+  ),
+];

--- a/frontend/src/mocks/handlers/tasks.ts
+++ b/frontend/src/mocks/handlers/tasks.ts
@@ -18,7 +18,7 @@ export const taskHandlers = [
       status: "completed",
       scheduled_date: MOCK_TODAY,
       due_at: null,
-      completed_at: new Date().toISOString(),
+      completed_at: `${MOCK_TODAY}T09:00:00.000Z`,
     }),
   ),
 

--- a/frontend/src/mocks/handlers/templates.ts
+++ b/frontend/src/mocks/handlers/templates.ts
@@ -1,6 +1,7 @@
 import { http, HttpResponse } from "msw";
 import { getMockState, mutateRoutineTemplates, mutateChoreTemplates } from "../data/state";
 import { nextTemplateId } from "../data/templates";
+import { MOCK_TODAY } from "../data/constants";
 import type { RoutineTemplateInput, ChoreTemplateInput } from "@/lib/api/today";
 
 export const templateHandlers = [
@@ -19,7 +20,7 @@ export const templateHandlers = [
       every_n_days: input.every_n_days,
       due_time: input.due_time ?? null,
       is_active: input.is_active,
-      created_at: new Date().toISOString(),
+      created_at: `${MOCK_TODAY}T00:00:00.000Z`,
     };
     mutateRoutineTemplates((ts) => [...ts, newTemplate]);
     return HttpResponse.json(newTemplate, { status: 201 });
@@ -60,7 +61,7 @@ export const templateHandlers = [
       start_date: input.start_date,
       every_n_days: input.every_n_days,
       is_active: input.is_active,
-      created_at: new Date().toISOString(),
+      created_at: `${MOCK_TODAY}T00:00:00.000Z`,
     };
     mutateChoreTemplates((ts) => [...ts, newTemplate]);
     return HttpResponse.json(newTemplate, { status: 201 });

--- a/frontend/src/mocks/handlers/templates.ts
+++ b/frontend/src/mocks/handlers/templates.ts
@@ -1,0 +1,89 @@
+import { http, HttpResponse } from "msw";
+import { getMockState, mutateRoutineTemplates, mutateChoreTemplates } from "../data/state";
+import { nextTemplateId } from "../data/templates";
+import type { RoutineTemplateInput, ChoreTemplateInput } from "@/lib/api/today";
+
+export const templateHandlers = [
+  // Routine templates
+  http.get("/api/v1/templates/routines", () =>
+    HttpResponse.json(getMockState().routineTemplates),
+  ),
+
+  http.post("/api/v1/templates/routines", async ({ request }) => {
+    const input = (await request.json()) as RoutineTemplateInput;
+    const newTemplate = {
+      id: nextTemplateId(),
+      name: input.name,
+      description: input.description ?? null,
+      start_date: input.start_date,
+      every_n_days: input.every_n_days,
+      due_time: input.due_time ?? null,
+      is_active: input.is_active,
+      created_at: new Date().toISOString(),
+    };
+    mutateRoutineTemplates((ts) => [...ts, newTemplate]);
+    return HttpResponse.json(newTemplate, { status: 201 });
+  }),
+
+  http.put("/api/v1/templates/routines/:id", async ({ params, request }) => {
+    const id = Number(params.id);
+    const input = (await request.json()) as RoutineTemplateInput;
+    const { routineTemplates } = getMockState();
+    const existing = routineTemplates.find((t) => t.id === id);
+
+    if (!existing) {
+      return HttpResponse.json({ detail: "Not found" }, { status: 404 });
+    }
+
+    const updated = { ...existing, ...input, description: input.description ?? null, due_time: input.due_time ?? null };
+    mutateRoutineTemplates((ts) => ts.map((t) => (t.id === id ? updated : t)));
+    return HttpResponse.json(updated);
+  }),
+
+  http.delete("/api/v1/templates/routines/:id", ({ params }) => {
+    const id = Number(params.id);
+    mutateRoutineTemplates((ts) => ts.filter((t) => t.id !== id));
+    return new HttpResponse(null, { status: 204 });
+  }),
+
+  // Chore templates
+  http.get("/api/v1/templates/chores", () =>
+    HttpResponse.json(getMockState().choreTemplates),
+  ),
+
+  http.post("/api/v1/templates/chores", async ({ request }) => {
+    const input = (await request.json()) as ChoreTemplateInput;
+    const newTemplate = {
+      id: nextTemplateId(),
+      name: input.name,
+      description: input.description ?? null,
+      start_date: input.start_date,
+      every_n_days: input.every_n_days,
+      is_active: input.is_active,
+      created_at: new Date().toISOString(),
+    };
+    mutateChoreTemplates((ts) => [...ts, newTemplate]);
+    return HttpResponse.json(newTemplate, { status: 201 });
+  }),
+
+  http.put("/api/v1/templates/chores/:id", async ({ params, request }) => {
+    const id = Number(params.id);
+    const input = (await request.json()) as ChoreTemplateInput;
+    const { choreTemplates } = getMockState();
+    const existing = choreTemplates.find((t) => t.id === id);
+
+    if (!existing) {
+      return HttpResponse.json({ detail: "Not found" }, { status: 404 });
+    }
+
+    const updated = { ...existing, ...input, description: input.description ?? null };
+    mutateChoreTemplates((ts) => ts.map((t) => (t.id === id ? updated : t)));
+    return HttpResponse.json(updated);
+  }),
+
+  http.delete("/api/v1/templates/chores/:id", ({ params }) => {
+    const id = Number(params.id);
+    mutateChoreTemplates((ts) => ts.filter((t) => t.id !== id));
+    return new HttpResponse(null, { status: 204 });
+  }),
+];

--- a/frontend/src/mocks/handlers/today.ts
+++ b/frontend/src/mocks/handlers/today.ts
@@ -1,0 +1,67 @@
+import { http, HttpResponse } from "msw";
+import { getMockState, getTodayPayload } from "../data/state";
+import { auth401, serverError500 } from "./errors";
+import { MOCK_TODAY } from "../data/constants";
+
+export const todayHandlers = [
+  http.get("/api/v1/today", () => {
+    const { scenario } = getMockState();
+    if (scenario === "signed-out" || scenario === "expired-session") return auth401();
+    if (scenario === "api-error") return serverError500();
+    return HttpResponse.json(getTodayPayload());
+  }),
+
+  http.get("/api/v1/calendar/month", ({ request }) => {
+    const url = new URL(request.url);
+    const year = Number(url.searchParams.get("year") ?? new Date().getFullYear());
+    const month = Number(url.searchParams.get("month") ?? new Date().getMonth() + 1);
+
+    const days = Array.from({ length: 28 }, (_, i) => {
+      const day = i + 1;
+      const date = `${year}-${String(month).padStart(2, "0")}-${String(day).padStart(2, "0")}`;
+      const hasItems = day % 3 !== 0;
+      return {
+        date,
+        total: hasItems ? 3 : 0,
+        routines: hasItems ? 1 : 0,
+        chores: hasItems ? 1 : 0,
+        medications: hasItems ? 1 : 0,
+        planned: 0,
+      };
+    });
+
+    return HttpResponse.json({ year, month, days });
+  }),
+
+  http.get("/api/v1/calendar/day", ({ request }) => {
+    const url = new URL(request.url);
+    const date = url.searchParams.get("date") ?? MOCK_TODAY;
+    const payload = getTodayPayload();
+
+    return HttpResponse.json({
+      date,
+      items: [
+        ...payload.routines.map((r) => ({
+          item_type: "routine" as const,
+          item_id: r.task_instance_id,
+          title: r.title,
+          status: r.status,
+          scheduled_at: r.due_at,
+          scheduled_date: r.scheduled_date,
+          detail: null,
+          module_key: null,
+        })),
+        ...payload.due_today.map((c) => ({
+          item_type: "chore" as const,
+          item_id: c.chore_instance_id,
+          title: c.title,
+          status: c.status,
+          scheduled_at: null,
+          scheduled_date: c.scheduled_date,
+          detail: null,
+          module_key: null,
+        })),
+      ],
+    });
+  }),
+];

--- a/frontend/src/mocks/handlers/today.ts
+++ b/frontend/src/mocks/handlers/today.ts
@@ -14,8 +14,9 @@ export const todayHandlers = [
 
   http.get("/api/v1/calendar/month", ({ request }) => {
     const url = new URL(request.url);
-    const year = Number(url.searchParams.get("year") ?? new Date().getFullYear());
-    const month = Number(url.searchParams.get("month") ?? new Date().getMonth() + 1);
+    const [defaultYear, defaultMonth] = MOCK_TODAY.split("-").map(Number);
+    const year = Number(url.searchParams.get("year") ?? defaultYear);
+    const month = Number(url.searchParams.get("month") ?? defaultMonth);
 
     const days = Array.from({ length: 28 }, (_, i) => {
       const day = i + 1;

--- a/frontend/src/mocks/handlers/today.ts
+++ b/frontend/src/mocks/handlers/today.ts
@@ -1,12 +1,13 @@
 import { http, HttpResponse } from "msw";
 import { getMockState, getTodayPayload } from "../data/state";
-import { auth401, serverError500 } from "./errors";
+import { auth401, forbidden403, serverError500 } from "./errors";
 import { MOCK_TODAY } from "../data/constants";
 
 export const todayHandlers = [
   http.get("/api/v1/today", () => {
     const { scenario } = getMockState();
     if (scenario === "signed-out" || scenario === "expired-session") return auth401();
+    if (scenario === "forbidden") return forbidden403();
     if (scenario === "api-error") return serverError500();
     return HttpResponse.json(getTodayPayload());
   }),

--- a/frontend/src/mocks/server.ts
+++ b/frontend/src/mocks/server.ts
@@ -1,0 +1,4 @@
+import { setupServer } from "msw/node";
+import { handlers } from "./handlers";
+
+export const server = setupServer(...handlers);

--- a/frontend/tests/msw/medication.test.ts
+++ b/frontend/tests/msw/medication.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+import { http, HttpResponse } from "msw";
+import { server } from "@/mocks/server";
+import { listMedicationPlans, createMedicationPlan } from "@/lib/api/today";
+import { seedMedications } from "@/mocks/data/medication";
+
+describe("listMedicationPlans — MSW-backed", () => {
+  it("returns medication plans from MSW seed data", async () => {
+    const plans = await listMedicationPlans();
+    const seed = seedMedications();
+
+    expect(plans).toHaveLength(seed.length);
+    const first = plans[0];
+    expect(first?.name).toBe("Morning vitamin");
+    expect(first?.is_active).toBe(true);
+  });
+
+  it("returns the newly created plan after POST", async () => {
+    const newPlan = await createMedicationPlan({
+      name: "New test medication",
+      instructions: "Test instructions",
+      start_date: "2026-06-01",
+      schedule_time: "10:00",
+      every_n_days: 1,
+    });
+
+    expect(newPlan.name).toBe("New test medication");
+    expect(newPlan.is_active).toBe(true);
+    expect(typeof newPlan.id).toBe("number");
+  });
+
+  it("propagates a 422 validation error from MSW override", async () => {
+    server.use(
+      http.post("/api/v1/medications", () =>
+        HttpResponse.json(
+          { detail: [{ loc: ["body", "name"], msg: "Field required", type: "missing" }] },
+          { status: 422 },
+        ),
+      ),
+    );
+
+    await expect(
+      createMedicationPlan({
+        name: "",
+        instructions: "",
+        start_date: "2026-06-01",
+        schedule_time: "10:00",
+        every_n_days: 1,
+      }),
+    ).rejects.toMatchObject({ status: 422, message: expect.stringContaining("Field required") });
+  });
+});

--- a/frontend/tests/msw/today.test.tsx
+++ b/frontend/tests/msw/today.test.tsx
@@ -1,0 +1,75 @@
+// @vitest-environment jsdom
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { http, HttpResponse } from "msw";
+import { server } from "@/mocks/server";
+import { TodayPage } from "@/features/today/TodayPage";
+import { QueryTestProvider } from "../utils/queryTestProvider";
+
+// Minimal auth mock — we only need useAuth to be available, not the real OIDC flow.
+// The real API fetch goes through MSW (no vi.mock on the api module).
+vi.mock("@/app/providers/AuthProvider", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/app/providers/AuthProvider")>();
+  return {
+    ...actual,
+    useAuth: () => ({
+      user: { id: 1, email: "demo@daynest.app", full_name: "Demo User", is_active: true, roles: ["user"] },
+      isLoading: false,
+      isAuthenticated: true,
+      login: () => {},
+      logout: () => {},
+      refreshUser: async () => {},
+    }),
+  };
+});
+
+describe("TodayPage — MSW-backed", () => {
+  it("renders items fetched via real HTTP through MSW handlers", async () => {
+    render(
+      <QueryTestProvider>
+        <TodayPage />
+      </QueryTestProvider>,
+    );
+
+    // Seed data from busyTodayPayload includes "Morning vitamin" as scheduled medication.
+    // It appears in both the focus panel and the medication section.
+    const vitaminMatches = await screen.findAllByText("Morning vitamin");
+    expect(vitaminMatches.length).toBeGreaterThanOrEqual(1);
+    // And "Water plants" as a due-today chore
+    expect(screen.getByText("Water plants")).toBeInTheDocument();
+    // And "Order groceries" as a planned item
+    expect(screen.getByText("Order groceries")).toBeInTheDocument();
+  });
+
+  it("shows error UI when MSW returns a 500 for /api/v1/today", async () => {
+    server.use(
+      http.get("/api/v1/today", () =>
+        HttpResponse.json({ detail: "Internal server error" }, { status: 500 }),
+      ),
+    );
+
+    render(
+      <QueryTestProvider>
+        <TodayPage />
+      </QueryTestProvider>,
+    );
+
+    expect(await screen.findByText(/Internal server error/i)).toBeInTheDocument();
+  });
+
+  it("shows error UI when MSW returns a 401 for /api/v1/today", async () => {
+    server.use(
+      http.get("/api/v1/today", () =>
+        HttpResponse.json({ detail: "Not authenticated" }, { status: 401 }),
+      ),
+    );
+
+    render(
+      <QueryTestProvider>
+        <TodayPage />
+      </QueryTestProvider>,
+    );
+
+    expect(await screen.findByText(/Not authenticated/i)).toBeInTheDocument();
+  });
+});

--- a/frontend/tests/setup.msw.ts
+++ b/frontend/tests/setup.msw.ts
@@ -1,0 +1,19 @@
+import { afterAll, afterEach, beforeAll, beforeEach } from "vitest";
+import { server } from "@/mocks/server";
+import { resetMockState } from "@/mocks/data/state";
+import { setOidcAccessToken } from "@/lib/auth/session";
+import { MOCK_TOKEN } from "@/mocks/data/constants";
+
+beforeAll(() => server.listen({ onUnhandledRequest: "warn" }));
+
+beforeEach(() => {
+  setOidcAccessToken(MOCK_TOKEN);
+});
+
+afterEach(() => {
+  server.resetHandlers();
+  resetMockState();
+  setOidcAccessToken(undefined);
+});
+
+afterAll(() => server.close());

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -47,6 +47,18 @@ export default defineConfig({
           setupFiles: ["./tests/setup.ts"],
         },
       },
+      {
+        extends: true,
+        test: {
+          name: "msw",
+          include: ["tests/msw/**/*.test.?(c|m)[jt]s?(x)"],
+          environment: "jsdom",
+          env: {
+            TZ: "UTC",
+          },
+          setupFiles: ["./tests/setup.ts", "./tests/setup.msw.ts"],
+        },
+      },
     ],
     coverage: {
       provider: "v8",

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -32,7 +32,7 @@ export default defineConfig({
           env: {
             TZ: "UTC",
           },
-          setupFiles: ["./tests/setup.ts"],
+          setupFiles: ["./tests/setup.ts", "./tests/setup.msw.ts"],
         },
       },
       {


### PR DESCRIPTION
Closes #359

## Summary

- Installs MSW v2 and generates `public/mockServiceWorker.js` (kept fresh via `postinstall`)
- Adds `src/mocks/` layer: browser worker, Node server, `MockAuthProvider`, 10 handler files covering all API endpoints, typed resettable seed data
- Wires mock bootstrap into `main.tsx` behind `VITE_MSW=true` — starts the worker before React renders and replaces `OidcProvider` + `AuthProvider` with `MockAuthProvider` (no backend or Keycloak required)
- Adds `pnpm dev:mock` shorthand (uses `cross-env` for Windows compatibility)
- Adds `msw` Vitest project with `setup.msw.ts`; also wires MSW into the existing `dom` project so all component tests can use handlers without per-file `vi.mock()`
- MSW-backed tests in `tests/msw/`: `TodayPage` rendered against real handlers (success, 500, 401 overrides) and `listMedicationPlans` / `createMedicationPlan` API tests (including 422 override)
- Nine `?mock-scenario=` URL params for deterministic screenshot states: `default`, `empty`, `busy-today`, `overdue`, `medication-refill`, `template-crud`, `signed-out`, `expired-session`, `forbidden`, `api-error`
- Adds `frontend/README.md` with startup instructions, fixture scenario table, screenshot routes with viewport guidance, and test patterns for humans and AI agents
- Exports `AuthContext` from `AuthProvider.tsx` so `MockAuthProvider` can provide into it
- Adds `src/env.d.ts` for `VITE_MSW` type declaration

## Test plan

- [ ] `pnpm dev:mock` starts the app without a backend; today view shows seed data
- [ ] `http://localhost:5173/today?mock-scenario=overdue` shows overdue chores and missed medications
- [ ] `http://localhost:5173/today?mock-scenario=medication-refill` shows all four dose statuses
- [ ] `http://localhost:5173/today?mock-scenario=forbidden` shows a 403 error state
- [ ] `http://localhost:5173/today?mock-scenario=api-error` shows the error/retry UI
- [ ] `http://localhost:5173/templates?mock-scenario=template-crud` shows template list with active + inactive items
- [ ] `pnpm test` passes all 109 tests across all three projects (dom, node, msw)
- [ ] `pnpm build` produces a production bundle with no MSW activation (check Network tab — no service worker registered)