### PR TITLE
ci: add changelog and version preflight gates to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,8 +9,108 @@ permissions:
   contents: read
 
 jobs:
+  preflight:
+    name: Release preflight
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Validate SemVer tag
+        run: |
+          if [[ ! "${GITHUB_REF_NAME}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::Tag '${GITHUB_REF_NAME}' is not a strict SemVer release tag (expected format: v1.2.3)"
+            exit 1
+          fi
+          echo "VERSION=${GITHUB_REF_NAME#v}" >> "$GITHUB_ENV"
+
+      - name: Check python-daynest/pyproject.toml
+        run: |
+          FILE_VERSION=$(python3 -c "
+          import tomllib
+          with open('python-daynest/pyproject.toml', 'rb') as f:
+              d = tomllib.load(f)
+          print(d['project']['version'])
+          ")
+          if [[ "${FILE_VERSION}" != "${VERSION}" ]]; then
+            echo "::error::python-daynest/pyproject.toml version '${FILE_VERSION}' does not match tag '${VERSION}'"
+            exit 1
+          fi
+          echo "✓ python-daynest/pyproject.toml: ${FILE_VERSION}"
+
+      - name: Check custom_components/daynest/manifest.json version
+        run: |
+          FILE_VERSION=$(python3 -c "import json; d=json.load(open('custom_components/daynest/manifest.json')); print(d['version'])")
+          if [[ "${FILE_VERSION}" != "${VERSION}" ]]; then
+            echo "::error::custom_components/daynest/manifest.json version '${FILE_VERSION}' does not match tag '${VERSION}'"
+            exit 1
+          fi
+          echo "✓ custom_components/daynest/manifest.json: ${FILE_VERSION}"
+
+      - name: Check manifest.json python-daynest requirements pin
+        run: |
+          FILE_VERSION=$(python3 -c "
+          import json, re
+          d = json.load(open('custom_components/daynest/manifest.json'))
+          reqs = d.get('requirements', [])
+          m = next((re.match(r'python-daynest==(.+)', r) for r in reqs), None)
+          print(m.group(1) if m else '')
+          ")
+          if [[ "${FILE_VERSION}" != "${VERSION}" ]]; then
+            echo "::error::manifest.json python-daynest requirement pin '${FILE_VERSION}' does not match tag '${VERSION}'"
+            exit 1
+          fi
+          echo "✓ manifest.json requirements pin: python-daynest==${FILE_VERSION}"
+
+      - name: Check android/app/build.gradle.kts versionName
+        run: |
+          FILE_VERSION=$(grep -oP 'versionName\s*=\s*"\K[^"]+' android/app/build.gradle.kts)
+          if [[ "${FILE_VERSION}" != "${VERSION}" ]]; then
+            echo "::error::android/app/build.gradle.kts versionName '${FILE_VERSION}' does not match tag '${VERSION}'"
+            exit 1
+          fi
+          echo "✓ android/app/build.gradle.kts versionName: ${FILE_VERSION}"
+
+      - name: Check android/app/build.gradle.kts versionCode
+        run: |
+          IFS='.' read -r MAJOR MINOR PATCH <<< "${VERSION}"
+          EXPECTED_CODE=$(( MAJOR * 10000 + MINOR * 100 + PATCH ))
+          ACTUAL_CODE=$(grep -oP 'versionCode\s*=\s*\K[0-9]+' android/app/build.gradle.kts)
+          if [[ "${ACTUAL_CODE}" != "${EXPECTED_CODE}" ]]; then
+            echo "::error::android versionCode '${ACTUAL_CODE}' does not match expected ${EXPECTED_CODE} (MAJOR×10000 + MINOR×100 + PATCH for v${VERSION})"
+            exit 1
+          fi
+          echo "✓ android/app/build.gradle.kts versionCode: ${ACTUAL_CODE}"
+
+      - name: Check frontend/package.json
+        run: |
+          FILE_VERSION=$(python3 -c "import json; d=json.load(open('frontend/package.json')); print(d['version'])")
+          if [[ "${FILE_VERSION}" != "${VERSION}" ]]; then
+            echo "::error::frontend/package.json version '${FILE_VERSION}' does not match tag '${VERSION}'"
+            exit 1
+          fi
+          echo "✓ frontend/package.json: ${FILE_VERSION}"
+
+      - name: Check dashboard/package.json
+        run: |
+          FILE_VERSION=$(python3 -c "import json; d=json.load(open('dashboard/package.json')); print(d['version'])")
+          if [[ "${FILE_VERSION}" != "${VERSION}" ]]; then
+            echo "::error::dashboard/package.json version '${FILE_VERSION}' does not match tag '${VERSION}'"
+            exit 1
+          fi
+          echo "✓ dashboard/package.json: ${FILE_VERSION}"
+
+      - name: Check CHANGELOG.md entry
+        run: |
+          if ! grep -qF "## [${VERSION}]" CHANGELOG.md; then
+            echo "::error::CHANGELOG.md has no '## [${VERSION}]' section. Add a changelog entry before tagging."
+            exit 1
+          fi
+          echo "✓ CHANGELOG.md: entry for [${VERSION}] found"
+
   lib:
     name: Publish python-daynest to PyPI
+    needs: [preflight]
     runs-on: ubuntu-latest
     environment: pypi
     permissions:
@@ -44,9 +144,6 @@ jobs:
       - name: Test
         run: uv run pytest -q
 
-      - name: Set version from tag
-        run: sed -i "s/^version = .*/version = \"${GITHUB_REF_NAME#v}\"/" pyproject.toml
-
       - name: Build
         run: uv build
 
@@ -55,7 +152,7 @@ jobs:
 
   hacs:
     name: Build HACS package
-    needs: lib
+    needs: [preflight, lib]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -78,14 +175,6 @@ jobs:
         working-directory: dashboard
         run: npm run build
 
-      - name: Stamp version into manifest.json
-        run: |
-          VERSION="${GITHUB_REF_NAME#v}"
-          jq --arg v "$VERSION" \
-            '.version = $v | .requirements = ["python-daynest==\($v)"]' \
-            custom_components/daynest/manifest.json > /tmp/manifest.json
-          mv /tmp/manifest.json custom_components/daynest/manifest.json
-
       - name: Create HACS release archive
         working-directory: custom_components/daynest
         run: zip -r ../../daynest.zip .
@@ -99,6 +188,7 @@ jobs:
 
   android:
     name: Build Android release APK
+    needs: [preflight]
     runs-on: ubuntu-latest
     outputs:
       apk_available: ${{ steps.keystore.outputs.signing_available || 'false' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,10 +78,10 @@ jobs:
         run: |
           set -euo pipefail
           IFS='.' read -r MAJOR MINOR PATCH <<< "${VERSION}"
-          EXPECTED_CODE=$(( MAJOR * 10000 + MINOR * 100 + PATCH ))
+          EXPECTED_CODE=$(( MAJOR * 1000000 + MINOR * 1000 + PATCH ))
           ACTUAL_CODE=$(grep -oP 'versionCode\s*=\s*\K[0-9]+' android/app/build.gradle.kts)
           if [[ "${ACTUAL_CODE}" != "${EXPECTED_CODE}" ]]; then
-            echo "::error::android versionCode '${ACTUAL_CODE}' does not match expected ${EXPECTED_CODE} (MAJOR×10000 + MINOR×100 + PATCH for v${VERSION})"
+            echo "::error::android versionCode '${ACTUAL_CODE}' does not match expected ${EXPECTED_CODE} (MAJOR×1000000 + MINOR×1000 + PATCH for v${VERSION})"
             exit 1
           fi
           echo "✓ android/app/build.gradle.kts versionCode: ${ACTUAL_CODE}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,7 @@ jobs:
 
       - name: Validate SemVer tag
         run: |
+          set -euo pipefail
           if [[ ! "${GITHUB_REF_NAME}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
             echo "::error::Tag '${GITHUB_REF_NAME}' is not a strict SemVer release tag (expected format: v1.2.3)"
             exit 1
@@ -26,12 +27,8 @@ jobs:
 
       - name: Check python-daynest/pyproject.toml
         run: |
-          FILE_VERSION=$(python3 -c "
-          import tomllib
-          with open('python-daynest/pyproject.toml', 'rb') as f:
-              d = tomllib.load(f)
-          print(d['project']['version'])
-          ")
+          set -euo pipefail
+          FILE_VERSION=$(grep -oP '^version\s*=\s*"\K[^"]+' python-daynest/pyproject.toml)
           if [[ "${FILE_VERSION}" != "${VERSION}" ]]; then
             echo "::error::python-daynest/pyproject.toml version '${FILE_VERSION}' does not match tag '${VERSION}'"
             exit 1
@@ -40,6 +37,7 @@ jobs:
 
       - name: Check custom_components/daynest/manifest.json version
         run: |
+          set -euo pipefail
           FILE_VERSION=$(python3 -c "import json; d=json.load(open('custom_components/daynest/manifest.json')); print(d['version'])")
           if [[ "${FILE_VERSION}" != "${VERSION}" ]]; then
             echo "::error::custom_components/daynest/manifest.json version '${FILE_VERSION}' does not match tag '${VERSION}'"
@@ -49,12 +47,16 @@ jobs:
 
       - name: Check manifest.json python-daynest requirements pin
         run: |
+          set -euo pipefail
           FILE_VERSION=$(python3 -c "
-          import json, re
+          import json, re, sys
           d = json.load(open('custom_components/daynest/manifest.json'))
           reqs = d.get('requirements', [])
           m = next((re.match(r'python-daynest==(.+)', r) for r in reqs), None)
-          print(m.group(1) if m else '')
+          if not m:
+              print('::error::manifest.json requirements list has no python-daynest== pin')
+              sys.exit(1)
+          print(m.group(1))
           ")
           if [[ "${FILE_VERSION}" != "${VERSION}" ]]; then
             echo "::error::manifest.json python-daynest requirement pin '${FILE_VERSION}' does not match tag '${VERSION}'"
@@ -64,6 +66,7 @@ jobs:
 
       - name: Check android/app/build.gradle.kts versionName
         run: |
+          set -euo pipefail
           FILE_VERSION=$(grep -oP 'versionName\s*=\s*"\K[^"]+' android/app/build.gradle.kts)
           if [[ "${FILE_VERSION}" != "${VERSION}" ]]; then
             echo "::error::android/app/build.gradle.kts versionName '${FILE_VERSION}' does not match tag '${VERSION}'"
@@ -73,6 +76,7 @@ jobs:
 
       - name: Check android/app/build.gradle.kts versionCode
         run: |
+          set -euo pipefail
           IFS='.' read -r MAJOR MINOR PATCH <<< "${VERSION}"
           EXPECTED_CODE=$(( MAJOR * 10000 + MINOR * 100 + PATCH ))
           ACTUAL_CODE=$(grep -oP 'versionCode\s*=\s*\K[0-9]+' android/app/build.gradle.kts)
@@ -84,6 +88,7 @@ jobs:
 
       - name: Check frontend/package.json
         run: |
+          set -euo pipefail
           FILE_VERSION=$(python3 -c "import json; d=json.load(open('frontend/package.json')); print(d['version'])")
           if [[ "${FILE_VERSION}" != "${VERSION}" ]]; then
             echo "::error::frontend/package.json version '${FILE_VERSION}' does not match tag '${VERSION}'"
@@ -93,6 +98,7 @@ jobs:
 
       - name: Check dashboard/package.json
         run: |
+          set -euo pipefail
           FILE_VERSION=$(python3 -c "import json; d=json.load(open('dashboard/package.json')); print(d['version'])")
           if [[ "${FILE_VERSION}" != "${VERSION}" ]]; then
             echo "::error::dashboard/package.json version '${FILE_VERSION}' does not match tag '${VERSION}'"
@@ -102,8 +108,10 @@ jobs:
 
       - name: Check CHANGELOG.md entry
         run: |
-          if ! grep -qF "## [${VERSION}]" CHANGELOG.md; then
-            echo "::error::CHANGELOG.md has no '## [${VERSION}]' section. Add a changelog entry before tagging."
+          set -euo pipefail
+          ESCAPED_VERSION="$(printf '%s' "${VERSION}" | sed 's/\./\\./g')"
+          if ! grep -qE "^## \[${ESCAPED_VERSION}\] - [0-9]{4}-[0-9]{2}-[0-9]{2}$" CHANGELOG.md; then
+            echo "::error::CHANGELOG.md has no '## [${VERSION}] - YYYY-MM-DD' section. Add a dated changelog entry before tagging."
             exit 1
           fi
           echo "✓ CHANGELOG.md: entry for [${VERSION}] found"
@@ -152,7 +160,7 @@ jobs:
 
   hacs:
     name: Build HACS package
-    needs: [preflight, lib]
+    needs: [lib]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,8 +18,8 @@ Before tagging a release, update **all** of the following to match the new versi
 | `dashboard/package.json` | `version` |
 | `CHANGELOG.md` | new `## [x.y.z]` section |
 
-**Android `versionCode` convention:** `MAJOR × 10000 + MINOR × 100 + PATCH`
-Examples: `v0.1.0` → `100`, `v1.0.0` → `10000`, `v1.2.3` → `10203`
+**Android `versionCode` convention:** `MAJOR × 1000000 + MINOR × 1000 + PATCH`
+Examples: `v0.1.0` → `1000`, `v1.0.0` → `1000000`, `v1.2.3` → `1002003`
 
 The release preflight job enforces all of the above and fails the workflow before any
 artifact is built or published if any check fails.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,42 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## Maintainer notes
+
+Before tagging a release, update **all** of the following to match the new version:
+
+| File | Field |
+|---|---|
+| `python-daynest/pyproject.toml` | `version` |
+| `custom_components/daynest/manifest.json` | `version`, `requirements` pin |
+| `android/app/build.gradle.kts` | `versionName`, `versionCode` |
+| `frontend/package.json` | `version` |
+| `dashboard/package.json` | `version` |
+| `CHANGELOG.md` | new `## [x.y.z]` section |
+
+**Android `versionCode` convention:** `MAJOR × 10000 + MINOR × 100 + PATCH`
+Examples: `v0.1.0` → `100`, `v1.0.0` → `10000`, `v1.2.3` → `10203`
+
+The release preflight job enforces all of the above and fails the workflow before any
+artifact is built or published if any check fails.
+
+---
+
+## [Unreleased]
+
+## [0.1.0] - 2026-04-25
+
+### Added
+
+- Initial scaffold: frontend (React/Vite), backend (FastAPI), Docker
+- Python client library (`python-daynest`) for the Daynest API
+- Home Assistant custom integration with HACS packaging
+- Android app with release APK workflow
+- Tag-driven draft GitHub Release workflow
+
+[Unreleased]: https://github.com/tjorim/daynest/compare/v0.1.0...HEAD
+[0.1.0]: https://github.com/tjorim/daynest/releases/tag/v0.1.0

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -102,7 +102,8 @@ extensions.configure<ApplicationExtension> {
         applicationId = "com.daynest.android"
         minSdk = 26
         targetSdk = 37
-        versionCode = 1
+        // versionCode = MAJOR * 10000 + MINOR * 100 + PATCH (e.g. v1.2.3 → 10203)
+        versionCode = 100
         versionName = "0.1.0"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -102,8 +102,8 @@ extensions.configure<ApplicationExtension> {
         applicationId = "com.daynest.android"
         minSdk = 26
         targetSdk = 37
-        // versionCode = MAJOR * 10000 + MINOR * 100 + PATCH (e.g. v1.2.3 → 10203)
-        versionCode = 100
+        // versionCode = MAJOR * 1000000 + MINOR * 1000 + PATCH (e.g. v1.2.3 → 1002003)
+        versionCode = 1000
         versionName = "0.1.0"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "daynest-card",
-  "version": "1.0.0",
+  "version": "0.1.0",
   "type": "module",
   "scripts": {
     "build": "rollup -c rollup.config.mjs",


### PR DESCRIPTION
Closes #360.

## Summary

- **New `preflight` job** in `release.yml` runs before any artifact is built and validates 9 conditions: strict SemVer tag format, 7 version-file consistency checks, and a `CHANGELOG.md` entry for the release.
- **Stamp steps removed** from `lib` and `hacs` — version metadata is now committed before tagging; the preflight enforces it rather than silently overwriting it.
- **`CHANGELOG.md` bootstrapped** at repo root (Keep-a-Changelog format) with `[Unreleased]` and `[0.1.0]` sections plus a maintainer reference table.
- **`dashboard/package.json`** version corrected from `1.0.0` → `0.1.0` to align with all other version files.
- **Android `versionCode`** updated `1` → `100` per the new documented convention (`MAJOR×10000 + MINOR×100 + PATCH`).

## New release workflow DAG

```
push v1.2.3 tag
  └── preflight  (9 validation checks)
        ├── lib        (PyPI publish)
        │     └── hacs (HACS archive, needs lib for PyPI ordering)
        └── android    (release APK)
                    └── release (draft GitHub Release)
```

A tag like `v1.2.3-rc1`, `v1.2`, or a tag pushed without a matching `CHANGELOG.md` entry will fail preflight before anything is built or published.

## Test plan

- [ ] Push a tag matching `v*` but not strict SemVer (e.g. `v0.1.0-test`) — preflight should fail at the SemVer check.
- [ ] Push `v0.1.0` with all version files and `CHANGELOG.md` at `0.1.0` — preflight should pass all 9 checks and the full pipeline should run.
- [ ] Push a tag with one version file deliberately bumped ahead (e.g. `pyproject.toml` at `0.2.0`) — preflight should fail at that specific check with a clear error message.
- [ ] Verify the draft GitHub Release is still created and contains `daynest.zip` and the APK (if secrets are set).