### PR TITLE
feat: adopt Bootstrap Icons as the standard frontend icon set

### DIFF
--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -79,6 +79,7 @@
   "today_no_items": "No items.",
   "today_overdue_since": "Overdue since {date}",
   "today_scheduled_on": "Scheduled {date}",
+  "today_recurring": "Recurring",
   "today_instructions": "Instructions: {text}",
   "today_planned_done_for": "Done for {date}",
   "today_planned_for": "Planned for {date}",

--- a/frontend/messages/nl.json
+++ b/frontend/messages/nl.json
@@ -79,6 +79,7 @@
   "today_no_items": "Geen items.",
   "today_overdue_since": "Achterstallig sinds {date}",
   "today_scheduled_on": "Ingepland op {date}",
+  "today_recurring": "Terugkerend",
   "today_instructions": "Instructies: {text}",
   "today_planned_done_for": "Klaar voor {date}",
   "today_planned_for": "Gepland voor {date}",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -20,6 +20,7 @@
     "@tanstack/react-router": "^1.170.8",
     "@tanstack/react-table": "^8.21.3",
     "bootstrap": "^5.3.3",
+    "bootstrap-icons": "^1.13.1",
     "canvas-confetti": "^1.9.4",
     "dayjs": "^1.11.13",
     "oidc-client-ts": "^3.5.0",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -26,6 +26,9 @@ importers:
       bootstrap:
         specifier: ^5.3.3
         version: 5.3.8(@popperjs/core@2.11.8)
+      bootstrap-icons:
+        specifier: ^1.13.1
+        version: 1.13.1
       canvas-confetti:
         specifier: ^1.9.4
         version: 1.9.4
@@ -918,6 +921,9 @@ packages:
 
   bidi-js@1.0.3:
     resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
+
+  bootstrap-icons@1.13.1:
+    resolution: {integrity: sha512-ijombt4v6bv5CLeXvRWKy7CuM3TRTuPEuGaGKvTV5cz65rQSY8RQ2JcHt6b90cBBAC7s8fsf2EkQDldzCoXUjw==}
 
   bootstrap@5.3.8:
     resolution: {integrity: sha512-HP1SZDqaLDPwsNiqRqi5NcP0SSXciX2s9E+RyqJIIqGo+vJeN5AJVM98CXmW/Wux0nQ5L7jeWUdplCEf0Ee+tg==}
@@ -2356,6 +2362,8 @@ snapshots:
   bidi-js@1.0.3:
     dependencies:
       require-from-string: 2.0.2
+
+  bootstrap-icons@1.13.1: {}
 
   bootstrap@5.3.8(@popperjs/core@2.11.8):
     dependencies:

--- a/frontend/src/app/layout/AppLayout.tsx
+++ b/frontend/src/app/layout/AppLayout.tsx
@@ -97,7 +97,7 @@ export function AppLayout() {
                 title={m.app_search_shortcut()}
                 onClick={() => setSearchOpen(true)}
               >
-                🔍
+                <i className="bi bi-search" aria-hidden="true" />
               </button>
             ) : null}
             <button
@@ -107,7 +107,10 @@ export function AppLayout() {
               title={themeTitle}
               onClick={toggleTheme}
             >
-              {theme === "auto" ? "🌓" : theme === "light" ? "🌙" : "☀️"}
+              <i
+                className={`bi ${theme === "auto" ? "bi-circle-half" : theme === "light" ? "bi-moon-stars-fill" : "bi-sun-fill"}`}
+                aria-hidden="true"
+              />
             </button>
             {isAuthenticated && user ? (
               <div className="d-flex flex-column flex-sm-row align-items-start align-items-sm-center gap-2">

--- a/frontend/src/features/search/SearchOverlay.tsx
+++ b/frontend/src/features/search/SearchOverlay.tsx
@@ -125,7 +125,9 @@ export function SearchOverlay({ onClose }: { onClose: () => void }) {
       >
         <div className="card-header p-2">
           <div className="input-group">
-            <span className="input-group-text border-0 bg-transparent">🔍</span>
+            <span className="input-group-text border-0 bg-transparent">
+              <i className="bi bi-search" aria-hidden="true" />
+            </span>
             <input
               ref={inputRef}
               type="search"
@@ -142,7 +144,7 @@ export function SearchOverlay({ onClose }: { onClose: () => void }) {
               </span>
             ) : null}
             <button type="button" className="btn btn-link border-0" onClick={onClose} aria-label="Close search">
-              ✕
+              <i className="bi bi-x-lg" aria-hidden="true" />
             </button>
           </div>
           {query.length > 0 && query.length < MIN_QUERY_LEN ? (

--- a/frontend/src/features/today/TodaySections.tsx
+++ b/frontend/src/features/today/TodaySections.tsx
@@ -173,8 +173,9 @@ export function buildPlannedItems(items: PlannedTodayItem[]): SectionItem[] {
     .map((item) => ({
     id: `planned-${item.id}`,
     title: item.time_of_day
-      ? `${item.time_of_day.slice(0, 5)} · ${item.rrule || item.recurrence_series_id ? "🔁 " : ""}${item.title}`
-      : `${item.rrule || item.recurrence_series_id ? "🔁 " : ""}${item.title}`,
+      ? `${item.time_of_day.slice(0, 5)} · ${item.title}`
+      : item.title,
+    isRecurring: Boolean(item.rrule || item.recurrence_series_id),
     subtitle: formatSubtitle(
       item.is_done
         ? m.today_planned_done_for({ date: formatDate(item.planned_for) })
@@ -712,7 +713,12 @@ export function SectionCard({
                   />
                 ) : null}
                 <div>
-                  <div className="fw-medium">{item.title}</div>
+                  <div className="fw-medium d-flex align-items-center gap-1">
+                    {item.isRecurring ? (
+                      <i className="bi bi-arrow-repeat text-muted" aria-label="Recurring" />
+                    ) : null}
+                    {item.title}
+                  </div>
                   {item.instructions ? (
                     <small className="d-block">{m.today_instructions({ text: item.instructions })}</small>
                   ) : null}

--- a/frontend/src/features/today/TodaySections.tsx
+++ b/frontend/src/features/today/TodaySections.tsx
@@ -715,7 +715,7 @@ export function SectionCard({
                 <div>
                   <div className="fw-medium d-flex align-items-center gap-1">
                     {item.isRecurring ? (
-                      <i className="bi bi-arrow-repeat text-muted" aria-label="Recurring" />
+                      <i className="bi bi-arrow-repeat text-muted" role="img" aria-label={m.today_recurring()} />
                     ) : null}
                     {item.title}
                   </div>

--- a/frontend/src/lib/api/today.ts
+++ b/frontend/src/lib/api/today.ts
@@ -103,6 +103,7 @@ export type StatusTone = "primary" | "secondary" | "warning" | "success" | "info
 export interface SectionItem {
   id: string;
   title: string;
+  isRecurring?: boolean;
   subtitle?: string;
   instructions?: string;
   statusLabel?: string;

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -3,6 +3,7 @@ import ReactDOM from "react-dom/client";
 import { RouterProvider } from "@tanstack/react-router";
 import { AuthProvider as OidcProvider } from "react-oidc-context";
 import "bootstrap/dist/css/bootstrap.min.css";
+import "bootstrap-icons/font/bootstrap-icons.min.css";
 import "./app.css";
 
 import * as m from "@/paraglide/messages";

--- a/frontend/tests/features/today/TodaySections.test.tsx
+++ b/frontend/tests/features/today/TodaySections.test.tsx
@@ -396,7 +396,7 @@ describe("build item helpers", () => {
     expect(item).toMatchObject({ statusLabel: "Done", statusTone: "success" });
   });
 
-  it("buildPlannedItems adds repeat indicator prefix for recurring items", () => {
+  it("buildPlannedItems marks recurring items with isRecurring", () => {
     const [item] = buildPlannedItems([
       {
         id: 9,
@@ -407,7 +407,8 @@ describe("build item helpers", () => {
         rrule: "FREQ=DAILY",
       },
     ]);
-    expect(item?.title).toContain("🔁");
+    expect(item?.isRecurring).toBe(true);
+    expect(item?.title).toBe("Read");
   });
 
   it("buildMedicationItems maps medication fields", () => {


### PR DESCRIPTION
Closes #363

## Summary

- Adds `bootstrap-icons` as a frontend dependency and imports the CSS globally in `main.tsx`
- Replaces all emoji icon placeholders with Bootstrap Icons (`<i className="bi bi-…">`) across three components:
  - **AppLayout**: search button (`bi-search`), theme toggle (`bi-circle-half` / `bi-moon-stars-fill` / `bi-sun-fill`)
  - **SearchOverlay**: search input prefix (`bi-search`), close button (`bi-x-lg`)
  - **TodaySections**: recurrence indicator (`bi-arrow-repeat`) — moved from an embedded emoji in the title string to a proper icon via a new `isRecurring` field on `SectionItem`, rendered in `SectionCard`
- All decorative icons carry `aria-hidden="true"`; the recurring icon uses `aria-label="Recurring"`
- Updates the affected Vitest test to assert `isRecurring: true` instead of checking for `🔁` in the title string

## Test plan

- [x] `pnpm build` passes with no type errors
- [x] `pnpm test` — 103/103 tests pass
- [ ] Verify search button, theme toggle, and search overlay icons render correctly in the browser
- [ ] Verify recurring planned items show the `↺` icon in the Today page

🤖 Generated with [Claude Code](https://claude.com/claude-code)