### PR TITLE
feat: harden and document Today SSE event stream

### DIFF
--- a/backend/app/api/routes/today.py
+++ b/backend/app/api/routes/today.py
@@ -42,6 +42,30 @@ async def stream_today_updates(
     event_bus: EventBus = Depends(get_event_bus),
     current_user: User = Depends(get_current_user_from_query_token),
 ) -> EventSourceResponse:
+    """Today SSE event stream contract.
+
+    **URL**: GET /api/v1/today/stream?token=<access_token>
+
+    Auth uses a query-param token (not a header) because EventSource cannot send
+    custom headers.  Pass the OIDC access token as ``?token=``.
+
+    **Events emitted**:
+    - ``today_updated`` — data: ``{}``  (invalidation hint; refetch /today)
+    - ``ping``          — data: ``{}``  (keepalive every 30 s of inactivity)
+
+    Clients must treat events as invalidation signals and refetch /today; event
+    payloads are intentionally empty and carry no authoritative data.
+
+    **Reconnect**: EventSource reconnects automatically on disconnect.  Missed
+    events are not replayed; clients must refetch after reconnect.
+
+    **Proxy buffering**: Cache-Control: no-cache and X-Accel-Buffering: no are
+    set so that nginx/Caddy do not buffer the stream.
+
+    **Scaling**: EventBus is process-local.  A single-worker deployment (the
+    default) is the only supported mode.  Multi-worker setups require a shared
+    pub/sub layer that is not currently implemented.
+    """
     queue = event_bus.subscribe(current_user.id)
 
     async def _event_generator():

--- a/backend/tests/test_sse.py
+++ b/backend/tests/test_sse.py
@@ -1,16 +1,27 @@
 import asyncio
 from collections.abc import Coroutine
-from datetime import datetime, timezone
+from datetime import date, datetime, timezone
 from typing import Any
+from unittest.mock import MagicMock
 
 import pytest
+from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
 
+from app.api.dependencies.auth import get_current_user, get_current_user_from_query_token
 from app.api.dependencies.events import get_event_bus
 from app.api.routes.today import stream_today_updates
-from app.main import _publish_today_rollovers
+from app.main import _publish_today_rollovers, app
 from app.models.user import User
 from app.services.event_bus import EventBus
+
+
+def _create_user(db: Session, email: str) -> User:
+    user = User(email=email, is_active=True, timezone="UTC")
+    db.add(user)
+    db.commit()
+    db.refresh(user)
+    return user
 
 
 class _FakeRequest:
@@ -79,3 +90,55 @@ async def test_today_rollover_publishes_today_updated_for_subscribed_user(db_ses
     )
     event = await asyncio.wait_for(queue.get(), timeout=1)
     assert event == {"type": "today_updated"}
+
+
+def test_today_stream_rejects_unauthenticated_request(client: TestClient) -> None:
+    response = client.get("/api/v1/today/stream")
+    assert response.status_code == 401
+
+
+@pytest.mark.anyio
+async def test_today_stream_per_user_event_isolation() -> None:
+    bus = EventBus()
+    queue_a = bus.subscribe(101)
+    queue_b = bus.subscribe(102)
+
+    bus.publish(101, {"type": "today_updated"})
+    await asyncio.sleep(0)
+
+    assert not queue_a.empty()
+    assert queue_b.empty()
+
+    bus.unsubscribe(101, queue_a)
+    bus.unsubscribe(102, queue_b)
+
+
+@pytest.mark.anyio
+async def test_today_stream_response_headers() -> None:
+    user = User(id=2001, email="sse-headers@example.com", is_active=True, timezone="UTC")
+    request = _FakeRequest()
+    event_bus = get_event_bus()
+    response = await stream_today_updates(request=request, event_bus=event_bus, current_user=user)
+    assert "text/event-stream" in response.headers.get("content-type", "")
+    assert response.headers.get("cache-control") in ("no-cache", "no-store")
+    assert response.headers.get("x-accel-buffering") == "no"
+    await response.body_iterator.aclose()
+
+
+def test_today_mutation_publishes_today_updated(client: TestClient, db_session: Session) -> None:
+    user = _create_user(db_session, "sse-mutation@example.com")
+
+    async def _auth_dep() -> User:
+        return user
+
+    mock_bus = MagicMock(spec=EventBus)
+    app.dependency_overrides[get_current_user] = _auth_dep
+    app.dependency_overrides[get_event_bus] = lambda: mock_bus
+    try:
+        payload = {"title": "Test item", "planned_for": str(date.today()), "priority": "normal"}
+        response = client.post("/api/v1/planned-items", json=payload)
+        assert response.status_code == 200
+        mock_bus.publish.assert_called_once_with(user.id, {"type": "today_updated"})
+    finally:
+        app.dependency_overrides.pop(get_current_user, None)
+        app.dependency_overrides.pop(get_event_bus, None)

--- a/backend/tests/test_sse.py
+++ b/backend/tests/test_sse.py
@@ -8,7 +8,7 @@ import pytest
 from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
 
-from app.api.dependencies.auth import get_current_user, get_current_user_from_query_token
+from app.api.dependencies.auth import get_current_user
 from app.api.dependencies.events import get_event_bus
 from app.api.routes.today import stream_today_updates
 from app.main import _publish_today_rollovers, app

--- a/frontend/pnpm-workspace.yaml
+++ b/frontend/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+allowBuilds:
+  '0': msw

--- a/frontend/src/features/today/TodayPage.tsx
+++ b/frontend/src/features/today/TodayPage.tsx
@@ -20,9 +20,11 @@ import {
   type TodaySection,
 } from "@/features/today/TodaySections";
 import { useTodayActions } from "@/features/today/useTodayActions";
+import { useTodayLiveUpdates } from "@/features/today/useTodayLiveUpdates";
 import { useTodayQuery } from "@/features/today/useTodayQuery";
 
 export function TodayPage() {
+  useTodayLiveUpdates();
   const todayQuery = useTodayQuery();
   const today = todayQuery.data ?? null;
   const isLoading = todayQuery.isLoading;

--- a/frontend/src/features/today/useTodayLiveUpdates.ts
+++ b/frontend/src/features/today/useTodayLiveUpdates.ts
@@ -6,10 +6,10 @@ import { queryKeys } from "@/lib/query/queryKeys";
 
 export function useTodayLiveUpdates(): void {
   const queryClient = useQueryClient();
+  const token = getOidcAccessToken();
 
   useEffect(() => {
     if (typeof EventSource === "undefined") return;
-    const token = getOidcAccessToken();
     if (!token) return;
 
     const url = buildApiUrl(`/api/v1/today/stream?token=${encodeURIComponent(token)}`);
@@ -31,5 +31,5 @@ export function useTodayLiveUpdates(): void {
     return () => {
       es.close();
     };
-  }, [queryClient]);
+  }, [queryClient, token]);
 }

--- a/frontend/src/features/today/useTodayLiveUpdates.ts
+++ b/frontend/src/features/today/useTodayLiveUpdates.ts
@@ -1,0 +1,35 @@
+import { useEffect } from "react";
+import { useQueryClient } from "@tanstack/react-query";
+import { buildApiUrl } from "@/lib/api/serverConfig";
+import { getOidcAccessToken } from "@/lib/auth/session";
+import { queryKeys } from "@/lib/query/queryKeys";
+
+export function useTodayLiveUpdates(): void {
+  const queryClient = useQueryClient();
+
+  useEffect(() => {
+    if (typeof EventSource === "undefined") return;
+    const token = getOidcAccessToken();
+    if (!token) return;
+
+    const url = buildApiUrl(`/api/v1/today/stream?token=${encodeURIComponent(token)}`);
+    const es = new EventSource(url);
+    let connected = false;
+
+    es.addEventListener("open", () => {
+      if (connected) {
+        // Reconnect after a drop — missed events won't be replayed, so refetch.
+        void queryClient.invalidateQueries({ queryKey: queryKeys.today.read() });
+      }
+      connected = true;
+    });
+
+    es.addEventListener("today_updated", () => {
+      void queryClient.invalidateQueries({ queryKey: queryKeys.today.read() });
+    });
+
+    return () => {
+      es.close();
+    };
+  }, [queryClient]);
+}

--- a/frontend/src/mocks/handlers/today.ts
+++ b/frontend/src/mocks/handlers/today.ts
@@ -4,6 +4,21 @@ import { auth401, forbidden403, serverError500 } from "./errors";
 import { MOCK_TODAY } from "../data/constants";
 
 export const todayHandlers = [
+  http.get("/api/v1/today/stream", () => {
+    const stream = new ReadableStream({
+      start() {
+        // Intentionally empty — keeps the stream alive without emitting events.
+        // Override this handler in individual tests to inject specific events.
+      },
+    });
+    return new Response(stream, {
+      headers: {
+        "Content-Type": "text/event-stream",
+        "Cache-Control": "no-cache",
+      },
+    });
+  }),
+
   http.get("/api/v1/today", () => {
     const { scenario } = getMockState();
     if (scenario === "signed-out" || scenario === "expired-session") return auth401();

--- a/frontend/tests/features/today/useTodayLiveUpdates.test.ts
+++ b/frontend/tests/features/today/useTodayLiveUpdates.test.ts
@@ -1,0 +1,155 @@
+import { act, renderHook } from "@testing-library/react";
+import { QueryClientProvider } from "@tanstack/react-query";
+import { createElement } from "react";
+import type { ReactNode } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { useTodayLiveUpdates } from "@/features/today/useTodayLiveUpdates";
+import { queryKeys } from "@/lib/query/queryKeys";
+import * as session from "@/lib/auth/session";
+import { createQueryTestClient } from "../../utils/queryTestProvider";
+
+type EventHandler = (event: MessageEvent) => void;
+
+class MockEventSource {
+  private readonly handlers: Record<string, EventHandler[]> = {};
+  public closed = false;
+
+  constructor(public readonly url: string) {}
+
+  addEventListener(type: string, handler: EventHandler): void {
+    this.handlers[type] ??= [];
+    this.handlers[type].push(handler);
+  }
+
+  emit(type: string, data: string): void {
+    for (const handler of this.handlers[type] ?? []) {
+      handler(new MessageEvent(type, { data }));
+    }
+  }
+
+  close(): void {
+    this.closed = true;
+  }
+}
+
+function wrapper({ children }: { children: ReactNode }) {
+  return createElement(QueryClientProvider, { client: createQueryTestClient() }, children);
+}
+
+describe("useTodayLiveUpdates", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it("invalidates the today query when today_updated event fires", async () => {
+    let capturedEs: MockEventSource | undefined;
+    vi.stubGlobal(
+      "EventSource",
+      class extends MockEventSource {
+        constructor(url: string) {
+          super(url);
+          capturedEs = this;
+        }
+      },
+    );
+    vi.spyOn(session, "getOidcAccessToken").mockReturnValue("test-token");
+
+    const queryClient = createQueryTestClient();
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+
+    renderHook(() => useTodayLiveUpdates(), {
+      wrapper: ({ children }) => createElement(QueryClientProvider, { client: queryClient }, children),
+    });
+
+    expect(capturedEs).toBeDefined();
+
+    await act(async () => {
+      capturedEs!.emit("today_updated", "{}");
+    });
+
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: queryKeys.today.read() });
+  });
+
+  it("does not open EventSource when there is no access token", () => {
+    const constructorSpy = vi.fn();
+    vi.stubGlobal("EventSource", constructorSpy);
+    vi.spyOn(session, "getOidcAccessToken").mockReturnValue(undefined);
+
+    renderHook(() => useTodayLiveUpdates(), { wrapper });
+
+    expect(constructorSpy).not.toHaveBeenCalled();
+  });
+
+  it("closes EventSource on unmount", () => {
+    let capturedEs: MockEventSource | undefined;
+    vi.stubGlobal(
+      "EventSource",
+      class extends MockEventSource {
+        constructor(url: string) {
+          super(url);
+          capturedEs = this;
+        }
+      },
+    );
+    vi.spyOn(session, "getOidcAccessToken").mockReturnValue("test-token");
+
+    const { unmount } = renderHook(() => useTodayLiveUpdates(), { wrapper });
+
+    unmount();
+
+    expect(capturedEs?.closed).toBe(true);
+  });
+
+  it("invalidates the today query on reconnect but not on initial connect", async () => {
+    let capturedEs: MockEventSource | undefined;
+    vi.stubGlobal(
+      "EventSource",
+      class extends MockEventSource {
+        constructor(url: string) {
+          super(url);
+          capturedEs = this;
+        }
+      },
+    );
+    vi.spyOn(session, "getOidcAccessToken").mockReturnValue("test-token");
+
+    const queryClient = createQueryTestClient();
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+
+    renderHook(() => useTodayLiveUpdates(), {
+      wrapper: ({ children }) => createElement(QueryClientProvider, { client: queryClient }, children),
+    });
+
+    // Initial connect — should NOT invalidate.
+    await act(async () => {
+      capturedEs!.emit("open", "");
+    });
+    expect(invalidateSpy).not.toHaveBeenCalled();
+
+    // Reconnect — should invalidate to recover missed events.
+    await act(async () => {
+      capturedEs!.emit("open", "");
+    });
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: queryKeys.today.read() });
+  });
+
+  it("opens EventSource with the token in the URL", () => {
+    let capturedEs: MockEventSource | undefined;
+    vi.stubGlobal(
+      "EventSource",
+      class extends MockEventSource {
+        constructor(url: string) {
+          super(url);
+          capturedEs = this;
+        }
+      },
+    );
+    vi.spyOn(session, "getOidcAccessToken").mockReturnValue("my-token");
+
+    renderHook(() => useTodayLiveUpdates(), { wrapper });
+
+    expect(capturedEs?.url).toContain("/api/v1/today/stream");
+    expect(capturedEs?.url).toContain("token=my-token");
+  });
+});

--- a/frontend/tests/features/today/useTodayLiveUpdates.test.ts
+++ b/frontend/tests/features/today/useTodayLiveUpdates.test.ts
@@ -134,6 +134,31 @@ describe("useTodayLiveUpdates", () => {
     expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: queryKeys.today.read() });
   });
 
+  it("closes the old connection and opens a new one when the token changes", () => {
+    const instances: MockEventSource[] = [];
+    vi.stubGlobal(
+      "EventSource",
+      class extends MockEventSource {
+        constructor(url: string) {
+          super(url);
+          instances.push(this);
+        }
+      },
+    );
+    const tokenSpy = vi.spyOn(session, "getOidcAccessToken").mockReturnValue("token-a");
+
+    const { rerender } = renderHook(() => useTodayLiveUpdates(), { wrapper });
+    expect(instances).toHaveLength(1);
+    expect(instances[0].url).toContain("token=token-a");
+
+    tokenSpy.mockReturnValue("token-b");
+    rerender();
+
+    expect(instances[0].closed).toBe(true);
+    expect(instances).toHaveLength(2);
+    expect(instances[1].url).toContain("token=token-b");
+  });
+
   it("opens EventSource with the token in the URL", () => {
     let capturedEs: MockEventSource | undefined;
     vi.stubGlobal(

--- a/frontend/tests/features/today/useTodayLiveUpdates.test.ts
+++ b/frontend/tests/features/today/useTodayLiveUpdates.test.ts
@@ -149,14 +149,15 @@ describe("useTodayLiveUpdates", () => {
 
     const { rerender } = renderHook(() => useTodayLiveUpdates(), { wrapper });
     expect(instances).toHaveLength(1);
-    expect(instances[0].url).toContain("token=token-a");
+    const first = instances[0]!;
+    expect(first.url).toContain("token=token-a");
 
     tokenSpy.mockReturnValue("token-b");
     rerender();
 
-    expect(instances[0].closed).toBe(true);
+    expect(first.closed).toBe(true);
     expect(instances).toHaveLength(2);
-    expect(instances[1].url).toContain("token=token-b");
+    expect(instances[1]!.url).toContain("token=token-b");
   });
 
   it("opens EventSource with the token in the URL", () => {


### PR DESCRIPTION
Closes #361

## Summary

- **Backend**: document the `GET /api/v1/today/stream` contract via a docstring (URL, query-param auth, event names, invalidation semantics, reconnect, proxy headers, single-worker constraint); add 4 new tests covering unauthenticated rejection, per-user isolation, response headers, and mutation-triggered broadcasts
- **Frontend**: add `useTodayLiveUpdates` hook that opens an `EventSource`, invalidates the TanStack Query today cache on `today_updated` events, and refetches on reconnect to recover missed updates; wire into `TodayPage`; add MSW handler for the stream endpoint; add 5 hook unit tests
- **Infra**: add `frontend/pnpm-workspace.yaml` with `allowBuilds: [msw]` — the pnpm v10 canonical way to approve MSW's postinstall script

## Test plan

- [ ] `uv run pytest backend/tests/test_sse.py -v` — 7 tests pass
- [ ] `npm run test -- --project=dom "useTodayLiveUpdates"` — 5 tests pass
- [ ] `npm run test -- --project=msw` — 6 tests pass (existing MSW page tests unaffected)
- [ ] Manual: open Today page while backend is running, make a mutation (complete a chore), confirm page refreshes without clicking the refresh button