### PR TITLE
feat(observability): extend contract to integration surfaces

### DIFF
--- a/backend/app/api/dependencies/auth.py
+++ b/backend/app/api/dependencies/auth.py
@@ -12,6 +12,7 @@ bearer_scheme = HTTPBearer(auto_error=False)
 def _set_request_auth_state(request: Request, user: User, claims: dict[str, object]) -> None:
     request.state.user_id = user.id
     request.state.roles = _extract_roles(claims)
+    request.state.auth_type = "oidc"
 
 
 def _resolve_user_from_claims(request: Request, db: Session, claims: dict[str, object]) -> User:

--- a/backend/app/api/dependencies/integration_auth.py
+++ b/backend/app/api/dependencies/integration_auth.py
@@ -82,11 +82,11 @@ def require_integration_auth() -> Callable:
                     )
                     if int_client is None or not int_client.is_active:
                         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Integration client not found or inactive")
-                    enforce_integration_rate_limit(int_client)
                     if int_client.user is None:
                         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Integration owner not found")
                     request.state.user_id = int_client.user.id
                     request.state.auth_type = "integration_jwt"
+                    enforce_integration_rate_limit(int_client)
                     return int_client.user
                 except jwt.ExpiredSignatureError as exc:
                     raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Integration token has expired") from exc
@@ -128,10 +128,9 @@ def require_integration_auth() -> Callable:
         if client.user is None:
             raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Integration owner not found")
 
-        enforce_integration_rate_limit(client)
-
         request.state.user_id = client.user.id
         request.state.auth_type = "integration_key"
+        enforce_integration_rate_limit(client)
         return client.user
 
     return dependency

--- a/backend/app/api/dependencies/integration_auth.py
+++ b/backend/app/api/dependencies/integration_auth.py
@@ -6,7 +6,7 @@ from hmac import digest
 
 import jwt
 from anyio import from_thread
-from fastapi import Depends, Header, HTTPException, status
+from fastapi import Depends, Header, HTTPException, Request, status
 from sqlalchemy import select
 from sqlalchemy.orm import Session, joinedload
 
@@ -55,6 +55,7 @@ def enforce_integration_rate_limit(client: IntegrationClient) -> None:
 
 def require_integration_auth() -> Callable:
     def dependency(
+        request: Request,
         authorization: str | None = Header(default=None, alias="Authorization"),
         x_integration_key: str | None = Header(default=None, alias="X-Integration-Key"),
         db: Session = Depends(get_db),
@@ -84,6 +85,8 @@ def require_integration_auth() -> Callable:
                     enforce_integration_rate_limit(int_client)
                     if int_client.user is None:
                         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Integration owner not found")
+                    request.state.user_id = int_client.user.id
+                    request.state.auth_type = "integration_jwt"
                     return int_client.user
                 except jwt.ExpiredSignatureError as exc:
                     raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Integration token has expired") from exc
@@ -103,6 +106,8 @@ def require_integration_auth() -> Callable:
                 user = get_or_create_local_user(subject, claims, db)
                 if not user.is_active:
                     raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="User account is inactive")
+                request.state.user_id = user.id
+                request.state.auth_type = "oidc"
                 return user
 
         # Integration key path
@@ -125,6 +130,8 @@ def require_integration_auth() -> Callable:
 
         enforce_integration_rate_limit(client)
 
+        request.state.user_id = client.user.id
+        request.state.auth_type = "integration_key"
         return client.user
 
     return dependency

--- a/backend/app/api/dependencies/integration_auth.py
+++ b/backend/app/api/dependencies/integration_auth.py
@@ -11,7 +11,7 @@ from sqlalchemy import select
 from sqlalchemy.orm import Session, joinedload
 
 from app.core.config import settings
-from app.core.oidc import OIDCTokenError, decode_oidc_token, get_or_create_local_user
+from app.core.oidc import OIDCTokenError, _extract_roles, decode_oidc_token, get_or_create_local_user
 from app.db.session import get_db
 from app.models.integration_client import IntegrationClient
 from app.models.user import User
@@ -107,6 +107,7 @@ def require_integration_auth() -> Callable:
                 if not user.is_active:
                     raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="User account is inactive")
                 request.state.user_id = user.id
+                request.state.roles = _extract_roles(claims)
                 request.state.auth_type = "oidc"
                 return user
 

--- a/backend/app/core/observability.py
+++ b/backend/app/core/observability.py
@@ -96,6 +96,7 @@ def configure_error_tracking() -> None:
         environment=settings.environment,
         traces_sample_rate=settings.sentry_traces_sample_rate,
         integrations=[FastApiIntegration()],
+        send_default_pii=False,
     )
 
 
@@ -121,10 +122,12 @@ async def observability_middleware(request: Request, call_next):
 
     if logger.isEnabledFor(logging.INFO):
         user_id = getattr(request.state, "user_id", None)
+        auth_type = getattr(request.state, "auth_type", None)
         log_payload = {
             "event": "http_request",
             "request_id": request_id,
             "user_id": user_id,
+            "auth_type": auth_type,
             "method": request.method,
             "route": request.url.path,
             "status_code": status_code,

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -183,6 +183,7 @@ if settings.cors_allow_origins:
         allow_credentials=not wildcard,
         allow_methods=["*"],
         allow_headers=["*"],
+        expose_headers=["X-Request-ID"],
     )
 
 app.include_router(system_router, prefix=settings.api_prefix)

--- a/backend/docs/OBSERVABILITY.md
+++ b/backend/docs/OBSERVABILITY.md
@@ -1,0 +1,125 @@
+# Observability Contract
+
+This document describes the observability guarantees that apply to every HTTP request handled by the Daynest backend. **Any new route must be added through the standard FastAPI router so it automatically inherits this contract.**
+
+---
+
+## X-Request-ID
+
+| Behaviour | Detail |
+|---|---|
+| **Generation** | If the incoming request carries no `X-Request-ID` header, the middleware generates a UUID4 and assigns it. |
+| **Propagation** | If the incoming request supplies `X-Request-ID`, that value is used unchanged. |
+| **Echo** | Every response carries `X-Request-ID` in its headers regardless of status code. |
+| **Scope** | The ID is stored in `request.state.request_id` and is available to all downstream handlers and dependencies. |
+
+Clients that want end-to-end tracing across their own systems should supply `X-Request-ID` on every outbound request.
+
+---
+
+## Structured Request Log
+
+Every request emits one JSON log line via the `app.observability` logger after the response is sent. The log level reflects the outcome:
+
+- `INFO` — 1xx / 2xx / 3xx
+- `WARNING` — 4xx
+- `ERROR` — 5xx (also captures the exception in Sentry when configured)
+
+### Log payload fields
+
+| Field | Type | Notes |
+|---|---|---|
+| `event` | `"http_request"` | Constant — use this to filter in log aggregators. |
+| `request_id` | `string` | UUID4 (generated or propagated). |
+| `user_id` | `int \| null` | Local user ID. `null` for unauthenticated and system routes. |
+| `auth_type` | `"oidc" \| "integration_key" \| "integration_jwt" \| null` | How the caller authenticated. `null` for unauthenticated requests. |
+| `method` | `string` | HTTP verb (`GET`, `POST`, …). |
+| `route` | `string` | URL path only — **query parameters are never logged** to prevent token leakage (relevant for the SSE stream route that accepts a bearer token via `?token=`). |
+| `status_code` | `int` | HTTP response status. |
+| `latency_ms` | `float` | Wall-clock time in milliseconds from first byte received to response headers sent. For SSE connections this is time-to-first-byte, not stream duration. |
+
+Example:
+
+```json
+{"event":"http_request","request_id":"3fa85f64-5717-4562-b3fc-2c963f66afa6","user_id":42,"auth_type":"oidc","method":"POST","route":"/api/v1/today/planned-items","status_code":201,"latency_ms":18.4}
+```
+
+---
+
+## Health Endpoints
+
+| Endpoint | Auth | Behaviour |
+|---|---|---|
+| `GET /api/v1/health/liveness` | None | Returns `{"status": "alive"}` immediately. Use this to tell the process is up. |
+| `GET /api/v1/health/readiness` | None | Runs `SELECT 1` against the database with a 2-second timeout. Returns `{"status": "ready"}` (200) or `{"status": "not_ready"}` (503). |
+| `GET /api/v1/health` | None | Returns liveness status inline and the URL of the readiness endpoint. |
+
+**Deployment note:** Configure your load balancer or orchestrator to use `/api/v1/health/readiness` for traffic routing (not liveness). A failing readiness check means the database is unreachable; the process itself is still alive.
+
+---
+
+## Metrics Endpoint
+
+| Endpoint | Auth |
+|---|---|
+| `GET /api/v1/metrics` | `X-Metrics-Secret` header (HMAC-SHA256 constant-time comparison) |
+
+Returns a JSON snapshot of in-process counters:
+
+| Field | Description |
+|---|---|
+| `uptime_seconds` | Seconds since the process started. |
+| `request_total` | Total requests handled in this process lifetime. |
+| `error_total` | Total 5xx responses. |
+| `request_rate_per_second` | `request_total / uptime_seconds`. |
+| `error_rate` | `error_total / request_total` (0 if no requests). |
+| `latency_avg_ms` | Average request latency. |
+| `latency_max_ms` | Maximum request latency observed. |
+
+**Important limitations:**
+- Metrics are **process-local** and reset on every restart.
+- In a multi-worker deployment (multiple Uvicorn/Gunicorn workers) each process has independent counters — values are **not** aggregated across workers.
+- For production-grade aggregated metrics, export to Prometheus or another time-series system.
+
+The endpoint returns 403 if `METRICS_SECRET` is not set in the environment (fail-closed), or if the supplied secret does not match.
+
+---
+
+## Error Tracking (Sentry)
+
+Sentry is initialised at startup if `SENTRY_DSN` is set. Configuration:
+
+| Setting | Default | Notes |
+|---|---|---|
+| `SENTRY_DSN` | _(unset)_ | Sentry not active when unset. |
+| `ENVIRONMENT` | `"development"` | Sent as the Sentry environment tag. |
+| `SENTRY_TRACES_SAMPLE_RATE` | `0.0` | Set to > 0 to enable performance tracing. |
+| `send_default_pii` | `False` | Hard-coded off — IP addresses, cookies, and request bodies are never sent to Sentry. |
+
+All unhandled exceptions (those not converted to HTTP responses by FastAPI's exception handlers) are captured via `sentry_sdk.capture_exception()` and also emit an `ERROR` log.
+
+---
+
+## Coverage Across Route Types
+
+| Route type | Observability middleware | `user_id` logged | `auth_type` logged |
+|---|---|---|---|
+| Standard OIDC-authenticated routes | ✓ | ✓ | `"oidc"` |
+| Integration-key routes | ✓ | ✓ | `"integration_key"` |
+| Integration-JWT routes | ✓ | ✓ | `"integration_jwt"` |
+| SSE live-update stream (`/api/v1/today/stream`) | ✓ | ✓ | `"oidc"` |
+| MCP routes (`/mcp/*`) | ✓ (path + latency) | ✗ (MCP handles auth internally) | ✗ |
+| Unauthenticated system routes (health, metrics) | ✓ | `null` | `null` |
+
+**MCP note:** The `/mcp` sub-app is mounted on the FastAPI app, so the observability middleware records path, latency, and status for every MCP request. However, user resolution for MCP is handled inside `fastmcp`'s framework (via `get_access_token()`), not via `request.state`, so `user_id` and `auth_type` are `null` in MCP log lines.
+
+---
+
+## Adding a New Route — Checklist
+
+Before merging a new backend route:
+
+- [ ] Route is added via `app.include_router(...)` or inside an existing router — not via `app.mount()` with a sub-application that bypasses middleware.
+- [ ] If the route accepts a bearer token in a query parameter, verify that `request.url.path` (not `request.url`) is what gets logged.
+- [ ] If the route introduces a new auth mechanism, ensure it sets `request.state.user_id` and `request.state.auth_type` so log lines are complete.
+- [ ] System/internal routes that should not be user-accessible use `_require_metrics_access` or equivalent protection.

--- a/backend/tests/test_observability.py
+++ b/backend/tests/test_observability.py
@@ -1,3 +1,7 @@
+import json
+import logging
+import uuid
+
 from fastapi.testclient import TestClient
 
 
@@ -52,10 +56,21 @@ def test_readiness_endpoint_returns_not_ready_with_db_down(client: TestClient, m
     assert readiness_response.json()["status"] == "not_ready"
 
 
-def test_request_id_header_present(client: TestClient) -> None:
+def test_request_id_generated_when_absent(client: TestClient) -> None:
     response = client.get("/api/v1/health/liveness")
     assert response.status_code == 200
-    assert response.headers.get("X-Request-ID")
+    request_id = response.headers.get("X-Request-ID")
+    assert request_id is not None
+    # Generated ID must be a valid UUID4
+    parsed = uuid.UUID(request_id, version=4)
+    assert str(parsed) == request_id
+
+
+def test_request_id_propagated_when_supplied(client: TestClient) -> None:
+    supplied_id = "my-trace-id-abc123"
+    response = client.get("/api/v1/health/liveness", headers={"X-Request-ID": supplied_id})
+    assert response.status_code == 200
+    assert response.headers.get("X-Request-ID") == supplied_id
 
 
 def test_metrics_requires_secret(client: TestClient) -> None:
@@ -68,3 +83,53 @@ def test_metrics_requires_secret(client: TestClient) -> None:
         authed = client.get("/api/v1/metrics", headers={"X-Metrics-Secret": settings.metrics_secret})
         assert authed.status_code == 200
         assert "request_total" in authed.json()
+
+
+def test_metrics_forbidden_with_wrong_secret(client: TestClient, monkeypatch) -> None:
+    from app.core.config import settings
+
+    monkeypatch.setattr(settings, "metrics_secret", "correct-secret")
+
+    response = client.get("/api/v1/metrics", headers={"X-Metrics-Secret": "wrong-secret"})
+    assert response.status_code == 403
+
+    response_no_header = client.get("/api/v1/metrics")
+    assert response_no_header.status_code == 403
+
+    authed = client.get("/api/v1/metrics", headers={"X-Metrics-Secret": "correct-secret"})
+    assert authed.status_code == 200
+
+
+def test_structured_log_payload_shape(client: TestClient, caplog) -> None:
+    with caplog.at_level(logging.INFO, logger="app.observability"):
+        response = client.get("/api/v1/health/liveness")
+
+    assert response.status_code == 200
+
+    log_records = [r for r in caplog.records if r.name == "app.observability"]
+    assert log_records, "Expected at least one structured log record from observability middleware"
+
+    payload = json.loads(log_records[-1].message)
+    assert payload["event"] == "http_request"
+    assert "request_id" in payload
+    assert "user_id" in payload
+    assert "auth_type" in payload
+    assert payload["method"] == "GET"
+    assert payload["route"] == "/api/v1/health/liveness"
+    assert payload["status_code"] == 200
+    assert "latency_ms" in payload
+    assert isinstance(payload["latency_ms"], float)
+
+
+def test_structured_log_does_not_leak_query_params(client: TestClient, caplog) -> None:
+    """Route field must be path-only — query params (e.g. SSE tokens) must not appear."""
+    with caplog.at_level(logging.INFO, logger="app.observability"):
+        response = client.get("/api/v1/health/liveness?sensitive=secret-token")
+
+    assert response.status_code == 200
+
+    log_records = [r for r in caplog.records if r.name == "app.observability"]
+    assert log_records
+    payload = json.loads(log_records[-1].message)
+    assert "sensitive" not in payload["route"]
+    assert "secret-token" not in payload["route"]

--- a/frontend/src/lib/api/today.ts
+++ b/frontend/src/lib/api/today.ts
@@ -371,12 +371,14 @@ export interface ChoreTemplateInput {
 export class ApiError extends Error {
   readonly status: number;
   readonly retryable: boolean;
+  readonly requestId: string | null;
 
-  constructor(message: string, status: number, retryable = false) {
+  constructor(message: string, status: number, retryable = false, requestId: string | null = null) {
     super(message);
     this.name = "ApiError";
     this.status = status;
     this.retryable = retryable;
+    this.requestId = requestId;
   }
 }
 
@@ -458,6 +460,8 @@ async function parseJsonResponse<T>(
   isIdempotent = true,
   schema?: z.ZodType<T>,
 ): Promise<T> {
+  const requestId = response.headers.get("x-request-id");
+
   if (!response.ok) {
     let message = `${fallbackMessage} (${response.status})`;
     try {
@@ -483,10 +487,12 @@ async function parseJsonResponse<T>(
     } catch {
       // keep fallback message
     }
+    const fullMessage = requestId ? `${message} [request-id: ${requestId}]` : message;
     throw new ApiError(
-      message,
+      fullMessage,
       response.status,
       isIdempotent && isRetryableStatus(response.status),
+      requestId,
     );
   }
   const payload = (await response.json()) as unknown;
@@ -503,7 +509,10 @@ async function parseJsonResponse<T>(
         return `${path}: ${issue.message}`;
       })
       .join(", ");
-    throw new ApiError(`Invalid response format: ${details}`, response.status, false);
+    const fullMessage = requestId
+      ? `Invalid response format: ${details} [request-id: ${requestId}]`
+      : `Invalid response format: ${details}`;
+    throw new ApiError(fullMessage, response.status, false, requestId);
   }
 
   return result.data;


### PR DESCRIPTION
Closes #362

## Summary

- **Integration auth**: `require_integration_auth` now sets `request.state.user_id` and `request.state.auth_type` on all three auth paths (`integration_key`, `integration_jwt`, `oidc`) — integration-key requests were logging `user_id: null` before this
- **OIDC auth**: `_set_request_auth_state` sets `request.state.auth_type = "oidc"` for consistency
- **Structured log**: `auth_type` field added to every request log line (`oidc` / `integration_key` / `integration_jwt` / `null` for unauthenticated)
- **CORS**: `expose_headers: ["X-Request-ID"]` added so browsers can read the correlation ID from JS
- **Sentry**: `send_default_pii=False` hardcoded so IP addresses and cookies are never captured if a DSN is ever configured
- **Frontend `ApiError`**: gains a `requestId` field; `parseJsonResponse` appends `[request-id: <id>]` to every error message shown to the user, enabling support correlation without opening devtools
- **Tests**: request ID propagation (echo of supplied ID + UUID4 format validation), wrong-secret metrics 403, structured log payload shape, query-param leak prevention
- **Docs**: `backend/docs/OBSERVABILITY.md` documents the full contract — X-Request-ID behavior, all log fields, health/readiness/metrics endpoints, Sentry config, coverage matrix across route types, and a checklist for adding new routes

## Alignment

Core contract is now consistent with [champagnefestival#463](https://github.com/tjorim/champagnefestival/pull/463) and [worktime#704](https://github.com/tjorim/worktime/pull/704): UUID4 generation/propagation, `request.state.user_id` set by auth deps, `X-Request-ID` in CORS expose headers, request ID surfaced in frontend error messages.

## Test plan

- [ ] `uv run pytest tests/test_observability.py -v` — 9 tests, all green
- [ ] `uv run pytest` — 217 tests, no regressions
- [ ] `npx tsc --noEmit` — no type errors
- [ ] `npx vitest run` — 115 frontend tests, all green