### PR TITLE
feat(dashboard): embed Schedule-X agenda in Daynest card

### DIFF
--- a/dashboard/package-lock.json
+++ b/dashboard/package-lock.json
@@ -1,12 +1,16 @@
 {
   "name": "daynest-card",
-  "version": "1.0.0",
+  "version": "0.1.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "daynest-card",
-      "version": "1.0.0",
+      "version": "0.1.9",
+      "dependencies": {
+        "@schedule-x/calendar": "^2.36.0",
+        "@schedule-x/theme-default": "^2.36.0"
+      },
       "devDependencies": {
         "@rollup/plugin-node-resolve": "^16.0.3",
         "@rollup/plugin-terser": "^1.0.0",
@@ -14,6 +18,7 @@
         "custom-card-helpers": "^2.0.0",
         "lit": "^3.0.0",
         "rollup": "^4.0.0",
+        "rollup-plugin-import-css": "^4.2.1",
         "tslib": "^2.0.0",
         "typescript": "^6.0.3"
       }
@@ -118,6 +123,34 @@
       "license": "BSD-3-Clause",
       "dependencies": {
         "@lit-labs/ssr-dom-shim": "^1.5.0"
+      }
+    },
+    "node_modules/@preact/signals": {
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/@preact/signals/-/signals-2.9.1.tgz",
+      "integrity": "sha512-xVqN8mJjbSN5IB/8Ubmd9NN+Ew6zJswoRxrjZbH3YsgkMshFeO6d8zxEFpHRTq9GJZx7cnPs2CnCpFqtGXGNsw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@preact/signals-core": "^1.14.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/preact"
+      },
+      "peerDependencies": {
+        "preact": ">= 10.25.0 || >=11.0.0-0"
+      }
+    },
+    "node_modules/@preact/signals-core": {
+      "version": "1.14.2",
+      "resolved": "https://registry.npmjs.org/@preact/signals-core/-/signals-core-1.14.2.tgz",
+      "integrity": "sha512-RZHdBj9ZF4n40Rp4jS052EHHjBWf96P9oNdXPfhQTovCuWY9iQn3Gq+gOTJSgBO9A/JBuPfMOWsSX/lIU9Pc/A==",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/preact"
       }
     },
     "node_modules/@rollup/plugin-node-resolve": {
@@ -568,6 +601,22 @@
         "win32"
       ]
     },
+    "node_modules/@schedule-x/calendar": {
+      "version": "2.36.0",
+      "resolved": "https://registry.npmjs.org/@schedule-x/calendar/-/calendar-2.36.0.tgz",
+      "integrity": "sha512-UqPMoxjok3SFNvgx1+PY5Whmoig+gU7sjy80z68A9QQ1FjIt1Q3ODPZKdA3G0spDss9lDtKilpO393vWpXJyfg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@preact/signals": "^2.0.2",
+        "preact": "^10.19.2"
+      }
+    },
+    "node_modules/@schedule-x/theme-default": {
+      "version": "2.36.0",
+      "resolved": "https://registry.npmjs.org/@schedule-x/theme-default/-/theme-default-2.36.0.tgz",
+      "integrity": "sha512-jkN9/srYS54dO2h12iCvNMMrLEiod6BAoUc47KbOgGE66zyUU+kmQwUOYQ3A2LrKyIWjwtCp3Ewdd4h/HHvG9A==",
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
@@ -806,6 +855,17 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/preact": {
+      "version": "10.29.2",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.29.2.tgz",
+      "integrity": "sha512-7tNmwg/7mzzAoB/8kSg6Hl37JraAZw3Z3A0JSY7VXlZwo82Xn0G7wKbNNs2qoF4ZEEsQGTwDAroNdqKs1ofJxQ==",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/preact"
+      }
+    },
     "node_modules/resolve": {
       "version": "1.22.12",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
@@ -871,6 +931,22 @@
         "@rollup/rollup-win32-x64-gnu": "4.60.4",
         "@rollup/rollup-win32-x64-msvc": "4.60.4",
         "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/rollup-plugin-import-css": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-import-css/-/rollup-plugin-import-css-4.2.1.tgz",
+      "integrity": "sha512-X0TbADEYeCWx0ULS3d9I2vRHT9smhSDkCol8bTCDyI0pAJAZStK0EGo9c4i9hUbOoPeTgWE+hcUjm0V/GoseUQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@rollup/pluginutils": "^5.3.0"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "rollup": "^2.x.x || ^3.x.x || ^4.x.x"
       }
     },
     "node_modules/rollup/node_modules/@types/estree": {

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -13,7 +13,12 @@
     "custom-card-helpers": "^2.0.0",
     "lit": "^3.0.0",
     "rollup": "^4.0.0",
+    "rollup-plugin-import-css": "^4.2.1",
     "tslib": "^2.0.0",
     "typescript": "^6.0.3"
+  },
+  "dependencies": {
+    "@schedule-x/calendar": "^2.36.0",
+    "@schedule-x/theme-default": "^2.36.0"
   }
 }

--- a/dashboard/pnpm-lock.yaml
+++ b/dashboard/pnpm-lock.yaml
@@ -1,0 +1,717 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      '@schedule-x/calendar':
+        specifier: ^2.36.0
+        version: 2.36.0(@preact/signals@2.9.1(preact@10.29.2))(preact@10.29.2)
+      '@schedule-x/theme-default':
+        specifier: ^2.36.0
+        version: 2.36.0
+    devDependencies:
+      '@rollup/plugin-node-resolve':
+        specifier: ^16.0.3
+        version: 16.0.3(rollup@4.61.0)
+      '@rollup/plugin-terser':
+        specifier: ^1.0.0
+        version: 1.0.0(rollup@4.61.0)
+      '@rollup/plugin-typescript':
+        specifier: ^12.3.0
+        version: 12.3.0(rollup@4.61.0)(tslib@2.8.1)(typescript@6.0.3)
+      custom-card-helpers:
+        specifier: ^2.0.0
+        version: 2.0.0(lit@3.3.3)
+      lit:
+        specifier: ^3.0.0
+        version: 3.3.3
+      rollup:
+        specifier: ^4.0.0
+        version: 4.61.0
+      rollup-plugin-import-css:
+        specifier: ^4.2.1
+        version: 4.2.1(rollup@4.61.0)
+      tslib:
+        specifier: ^2.0.0
+        version: 2.8.1
+      typescript:
+        specifier: ^6.0.3
+        version: 6.0.3
+
+packages:
+
+  '@formatjs/fast-memoize@3.1.5':
+    resolution: {integrity: sha512-KLi3fan6WnCHmigd9pmEEN8Hid0v4wiFBW576M/d07KMWYecf1CvyMI3n34vCmHT4AoVqG2n702kiHbXjzZX2A==}
+
+  '@formatjs/icu-messageformat-parser@3.5.10':
+    resolution: {integrity: sha512-XeJihYLy1lCe19xfK1KWKG/betBOK2rB0luL8lSkjfvJj0zP+LTJvkC+RKd0jsFI8mWxN71LrarHSrEXE8xxOQ==}
+
+  '@formatjs/icu-skeleton-parser@2.1.9':
+    resolution: {integrity: sha512-rsxswgHMfU1zUgB2byc08fesf83wLGjFnzLCEtuf00mx2doiqc6pYrf67raI37XqdRcGUviQepk2UKGqpng74Q==}
+
+  '@formatjs/intl-utils@3.8.4':
+    resolution: {integrity: sha512-j5C6NyfKevIxsfLK8KwO1C0vvP7k1+h4A9cFpc+cr6mEwCc1sPkr17dzh0Ke6k9U5pQccAQoXdcNBl3IYa4+ZQ==}
+    deprecated: the package is rather renamed to @formatjs/ecma-abstract with some changes in functionality (primarily selectUnit is removed and we don't plan to make any further changes to this package
+
+  '@jridgewell/gen-mapping@0.3.13':
+    resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
+
+  '@jridgewell/resolve-uri@3.1.2':
+    resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
+    engines: {node: '>=6.0.0'}
+
+  '@jridgewell/source-map@0.3.11':
+    resolution: {integrity: sha512-ZMp1V8ZFcPG5dIWnQLr3NSI1MiCU7UETdS/A0G8V/XWHvJv3ZsFqutJn1Y5RPmAPX6F3BiE397OqveU/9NCuIA==}
+
+  '@jridgewell/sourcemap-codec@1.5.5':
+    resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
+
+  '@lit-labs/ssr-dom-shim@1.6.0':
+    resolution: {integrity: sha512-VHb0ALPMTlgKjM6yIxxoQNnpKyUKLD04VzeQdsiXkMqkvYlAHxq9glGLmgbb889/1GsohSOAjvQYoiBppXFqrQ==}
+
+  '@lit/reactive-element@2.1.2':
+    resolution: {integrity: sha512-pbCDiVMnne1lYUIaYNN5wrwQXDtHaYtg7YEFPeW+hws6U47WeFvISGUWekPGKWOP1ygrs0ef0o1VJMk1exos5A==}
+
+  '@preact/signals-core@1.14.2':
+    resolution: {integrity: sha512-RZHdBj9ZF4n40Rp4jS052EHHjBWf96P9oNdXPfhQTovCuWY9iQn3Gq+gOTJSgBO9A/JBuPfMOWsSX/lIU9Pc/A==}
+
+  '@preact/signals@2.9.1':
+    resolution: {integrity: sha512-xVqN8mJjbSN5IB/8Ubmd9NN+Ew6zJswoRxrjZbH3YsgkMshFeO6d8zxEFpHRTq9GJZx7cnPs2CnCpFqtGXGNsw==}
+    peerDependencies:
+      preact: '>= 10.25.0 || >=11.0.0-0'
+
+  '@rollup/plugin-node-resolve@16.0.3':
+    resolution: {integrity: sha512-lUYM3UBGuM93CnMPG1YocWu7X802BrNF3jW2zny5gQyLQgRFJhV1Sq0Zi74+dh/6NBx1DxFC4b4GXg9wUCG5Qg==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      rollup: ^2.78.0||^3.0.0||^4.0.0
+    peerDependenciesMeta:
+      rollup:
+        optional: true
+
+  '@rollup/plugin-terser@1.0.0':
+    resolution: {integrity: sha512-FnCxhTBx6bMOYQrar6C8h3scPt8/JwIzw3+AJ2K++6guogH5fYaIFia+zZuhqv0eo1RN7W1Pz630SyvLbDjhtQ==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      rollup: ^2.0.0||^3.0.0||^4.0.0
+    peerDependenciesMeta:
+      rollup:
+        optional: true
+
+  '@rollup/plugin-typescript@12.3.0':
+    resolution: {integrity: sha512-7DP0/p7y3t67+NabT9f8oTBFE6gGkto4SA6Np2oudYmZE/m1dt8RB0SjL1msMxFpLo631qjRCcBlAbq1ml/Big==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      rollup: ^2.14.0||^3.0.0||^4.0.0
+      tslib: '*'
+      typescript: '>=3.7.0'
+    peerDependenciesMeta:
+      rollup:
+        optional: true
+      tslib:
+        optional: true
+
+  '@rollup/pluginutils@5.4.0':
+    resolution: {integrity: sha512-MfPp06CjRLfXQ3wY0R8vJDYBy/MvVcc9OulEfR0B8Iv9ko+GCNaRZ+EpJYFl27LhKsZK0o420sYCRHCjfCgeUg==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      rollup: ^1.20.0||^2.0.0||^3.0.0||^4.0.0
+    peerDependenciesMeta:
+      rollup:
+        optional: true
+
+  '@rollup/rollup-android-arm-eabi@4.61.0':
+    resolution: {integrity: sha512-dnxczajOqt0gesZlN5pGQ1s1imQVrsmCw5G2Ci4oM+0WvNz3pyRnlWrT7McoZIb8VlFwCawdmbWRmxRn7HI+VQ==}
+    cpu: [arm]
+    os: [android]
+
+  '@rollup/rollup-android-arm64@4.61.0':
+    resolution: {integrity: sha512-Bp3JpGP00Vu3f238ivRrjf7z3xSzVPXqCmaJYA9t2c+c8vKYvOzmXF7LkkeUalTEGd6cZcSWe+PFIP3Vy48fRg==}
+    cpu: [arm64]
+    os: [android]
+
+  '@rollup/rollup-darwin-arm64@4.61.0':
+    resolution: {integrity: sha512-zaYIpr670mUmmZ1tVzUFplbQbG7h3Gugx3L5FoqhsC2m/YnLlR1a7zVLmXNPy+iY1tFPEbNG+HHBXZGyId0G5w==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rollup/rollup-darwin-x64@4.61.0':
+    resolution: {integrity: sha512-+P49fvkv2dSoeevUW+lgZ/I2JHSsJCK1Lyjj7Cu6E4UHG4tS9XIefzIjo5qhgELjAclnen1rLzK2PMKJdo+Dyg==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rollup/rollup-freebsd-arm64@4.61.0':
+    resolution: {integrity: sha512-l3FAAOyKJXH2ea6KNFN+MMgC/rnE94YGLXs2ehYqDcCoHt1DpvgWX75BhUJxN38XojP7Ul+4H8PRn7EdyqSDrw==}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@rollup/rollup-freebsd-x64@4.61.0':
+    resolution: {integrity: sha512-VokPN3TSctKj65cyCNPaUh4vMFA8awxOot/0sp+4J7ZlNRKQEhXhawqPwajoi8H5ZFt61i0ugZJuTKXBjGJ17Q==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.61.0':
+    resolution: {integrity: sha512-DxH0P3wxm+Yzs/p3zrk9dw1rURu8p0Nv5+MRK/L7OtnLNg5rLZraSBFZ8iUXOd9f2BlhJyEpIZUH/emjq4UJ4g==}
+    cpu: [arm]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-arm-musleabihf@4.61.0':
+    resolution: {integrity: sha512-T6ZvMNe84kAz6TBWHC7hGAoEtzP1LWYw/AqayGWEF6uISt3Abk/st06LqRD9THd7Xz3NxzurUpzAuEAUbZf+nw==}
+    cpu: [arm]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-arm64-gnu@4.61.0':
+    resolution: {integrity: sha512-q/4hzvQkDs8b4jIBab1pnLiiM0ayTZsN2amBFPDzuyZxjEd4wDwx0UJFYM3cOZzSf5Kw8fnWSprJzIBMkcR44Q==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-arm64-musl@4.61.0':
+    resolution: {integrity: sha512-vvYWX3akdEAY6km+9wAqFDnk6pQsbJKVnj7xawcvs/+fdlYBGp+U+Qq/lLfpIxYIZvZLHMAKD9HLdacSx/r3dw==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-loong64-gnu@4.61.0':
+    resolution: {integrity: sha512-DePa5cqOxDP/Zp0VOXpeWaGew5iIv5DXp9NYbzkX5PFQyWVX9184WCTh3hvr/7lhXo8ZVlbFLkz8+o/q1dU6gA==}
+    cpu: [loong64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-loong64-musl@4.61.0':
+    resolution: {integrity: sha512-LV8aWMB8UChglMCEzs7RkN0GsH29RJaLLqwm9fCIjlqwxQTiWAqNcc7wjBkH31hV0PU/yVxGYvrYsgfea2qw6g==}
+    cpu: [loong64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-ppc64-gnu@4.61.0':
+    resolution: {integrity: sha512-QoNSnwQtaeNu5grdBbsL0tt1uyl5EnS8DA8Mr3nluMXbhdQNyhN+G4tBax7VCdxLKj8YJ0/4OO9Ho84jMnJtKA==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-ppc64-musl@4.61.0':
+    resolution: {integrity: sha512-/zZp5MKapIIApE8trN8qLGNSiRN9TUoaUZ1cmVu4XnVdd5LQLOXTtyi+vtfUbNnT3iyjzpPqYeKXmvJ+gJGYWw==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-riscv64-gnu@4.61.0':
+    resolution: {integrity: sha512-RbrzcD3aJ1k3UbtMRRBNwojdVVyXjuVAFTfn/xPa6EEl6GE9Sm/akPgFTb9aAC9pMKGJ6CtWxaGrqWcabH+ySg==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-riscv64-musl@4.61.0':
+    resolution: {integrity: sha512-ZF+onDsBso8PJf1XaG9lB+O9RnBpKGnY6OrzC4CSHrtC1jb6jWLTKK4bRqdoCXHd22gyr2hiYmEAm8Wns/BOCw==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-s390x-gnu@4.61.0':
+    resolution: {integrity: sha512-Atk0aSIk5Zx2Wuh9dgRQgLP0Koc8hOeYpbWryMXyk8G8/HmPkwPPkMqIIDhrXHHYqfUzSJA/I7IWSBv8xSmRBA==}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-x64-gnu@4.61.0':
+    resolution: {integrity: sha512-0uMOcf3eZ5K+K4cYHkdxShFMPlPXCOdfDFEFn9dNYAEEd2cVvmOfH7zFgRVoDgmtQ1m9k5q7qfrHzyMAubKYUA==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-x64-musl@4.61.0':
+    resolution: {integrity: sha512-mvFtE4A/t/7hRJ7X8Ozmu8FsIkAUat2nzl12pgU337BRmq87AQUJztwHz2Zv5/tjo9/C95E66CK03SI/ToEDJw==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-openbsd-x64@4.61.0':
+    resolution: {integrity: sha512-z9b9+aTxvt8n2rNltMPvyaUfB8NJ+CVyOrGK/MdIKHx7B+lXmZpm/XbRsU7Rpf3fRqJ2uS6mBJiJveCtq8LHDg==}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@rollup/rollup-openharmony-arm64@4.61.0':
+    resolution: {integrity: sha512-jXaXFqKMehsOc+g8R6oo33RRC6w07G9jDBxAE5eAKX7mOcCbZloYIPNhfG9Wl+P9O9IWHFO4OJgPi1Ml2qkt7w==}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rollup/rollup-win32-arm64-msvc@4.61.0':
+    resolution: {integrity: sha512-OXNWVFocS2IA4+QplhTZZ2a+8hPZR7T8KuozsNmJKK8y7cp83StHvGksfHzPG3wczWTczyWHVQuqeiTUbjiyBg==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rollup/rollup-win32-ia32-msvc@4.61.0':
+    resolution: {integrity: sha512-AlAbNtBO637LxSldqV43z0FfXoGfl2TW1DgAg/bs7aQswFbDewz2SJm3BUhiGfbOVtW571xbc9p+REdxhyN/Eg==}
+    cpu: [ia32]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-gnu@4.61.0':
+    resolution: {integrity: sha512-QRSrQXyJ1M4tjNXdR0/G/IgV6lzfQQJYBjlWIEYkY2Xs86DRl/iEpQ4blMDjJxSl7n19eDKKXMg0AmuBVYy8pQ==}
+    cpu: [x64]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-msvc@4.61.0':
+    resolution: {integrity: sha512-tkuFxhvKO/HlGd0VsINF6vHSYH8AF8W0TcNxKDK6JZmrehngFj78pToc8iemtnvwilDjs2G/qSzYFhe9U8q+fw==}
+    cpu: [x64]
+    os: [win32]
+
+  '@schedule-x/calendar@2.36.0':
+    resolution: {integrity: sha512-UqPMoxjok3SFNvgx1+PY5Whmoig+gU7sjy80z68A9QQ1FjIt1Q3ODPZKdA3G0spDss9lDtKilpO393vWpXJyfg==}
+    peerDependencies:
+      '@preact/signals': ^2.0.2
+      preact: ^10.19.2
+
+  '@schedule-x/theme-default@2.36.0':
+    resolution: {integrity: sha512-jkN9/srYS54dO2h12iCvNMMrLEiod6BAoUc47KbOgGE66zyUU+kmQwUOYQ3A2LrKyIWjwtCp3Ewdd4h/HHvG9A==}
+
+  '@types/estree@1.0.9':
+    resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
+
+  '@types/resolve@1.20.2':
+    resolution: {integrity: sha512-60BCwRFOZCQhDncwQdxxeOEEkbc5dIMccYLwbxsS4TUNeVECQ/pBJ0j09mrHOl/JJvpRPGwO9SvE4nR2Nb/a4Q==}
+
+  '@types/trusted-types@2.0.7':
+    resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
+
+  acorn@8.16.0:
+    resolution: {integrity: sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
+
+  buffer-from@1.1.2:
+    resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
+
+  commander@2.20.3:
+    resolution: {integrity: sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==}
+
+  custom-card-helpers@2.0.0:
+    resolution: {integrity: sha512-TrWc9lybHFrbdZFv1kzKaiFY/vYon08N1k4iUS8EDLIJObWP0K+B1lU0XCAG6Q/3euAyM5nn1QjUSvcnCYpNtg==}
+    engines: {node: '>=24', npm: '>=11'}
+    peerDependencies:
+      lit: '>=3.0.0'
+
+  deepmerge@4.3.1:
+    resolution: {integrity: sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==}
+    engines: {node: '>=0.10.0'}
+
+  emojis-list@3.0.0:
+    resolution: {integrity: sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q==}
+    engines: {node: '>= 4'}
+
+  es-errors@1.3.0:
+    resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
+    engines: {node: '>= 0.4'}
+
+  estree-walker@2.0.2:
+    resolution: {integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==}
+
+  fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
+  function-bind@1.1.2:
+    resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
+
+  hasown@2.0.4:
+    resolution: {integrity: sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==}
+    engines: {node: '>= 0.4'}
+
+  home-assistant-js-websocket@9.6.0:
+    resolution: {integrity: sha512-TK8HWW6UjCsUdjIBQRB2sBbEya0VniOBFqFjgqSznJiB7YriNgN8jghyThxOkgxwrnt2eN6oWoZMCTSp1o7H+w==}
+
+  intl-messageformat@11.2.7:
+    resolution: {integrity: sha512-+q6Ktg119nULZEpZ8YTuGOst9MyEzFtjD63FTGBlN1mLz0Z/MOUYDIvnpVKwq17eezIEh+cfJIebfJoCetpiNw==}
+
+  is-core-module@2.16.2:
+    resolution: {integrity: sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==}
+    engines: {node: '>= 0.4'}
+
+  is-module@1.0.0:
+    resolution: {integrity: sha512-51ypPSPCoTEIN9dy5Oy+h4pShgJmPCygKfyRCISBI+JoWT/2oJvK8QPxmwv7b/p239jXrm9M1mlQbyKJ5A152g==}
+
+  lit-element@4.2.2:
+    resolution: {integrity: sha512-aFKhNToWxoyhkNDmWZwEva2SlQia+jfG0fjIWV//YeTaWrVnOxD89dPKfigCUspXFmjzOEUQpOkejH5Ly6sG0w==}
+
+  lit-html@3.3.3:
+    resolution: {integrity: sha512-el8M6jK2o3RXBnrSHX3ZKrsN8zEV63pSExTO1wYJz7QndGYZ8353e2a5PPX+qHe2aGayfnchQmkAojaWAREOIA==}
+
+  lit@3.3.3:
+    resolution: {integrity: sha512-fycuvZg/hkpozL00lm1pEJH5nN/lr9ZXd6mJI2HSN4+Bzc+LDNdEApJ6HFbPkdFNHLvOplIIuJvxkS4XUxqirw==}
+
+  path-parse@1.0.7:
+    resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
+
+  picomatch@4.0.4:
+    resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
+    engines: {node: '>=12'}
+
+  preact@10.29.2:
+    resolution: {integrity: sha512-7tNmwg/7mzzAoB/8kSg6Hl37JraAZw3Z3A0JSY7VXlZwo82Xn0G7wKbNNs2qoF4ZEEsQGTwDAroNdqKs1ofJxQ==}
+
+  resolve@1.22.12:
+    resolution: {integrity: sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==}
+    engines: {node: '>= 0.4'}
+    hasBin: true
+
+  rollup-plugin-import-css@4.2.1:
+    resolution: {integrity: sha512-X0TbADEYeCWx0ULS3d9I2vRHT9smhSDkCol8bTCDyI0pAJAZStK0EGo9c4i9hUbOoPeTgWE+hcUjm0V/GoseUQ==}
+    engines: {node: '>=16'}
+    peerDependencies:
+      rollup: ^2.x.x || ^3.x.x || ^4.x.x
+
+  rollup@4.61.0:
+    resolution: {integrity: sha512-T9mWdbWfQtp0B5lv/HX+wrhYsmXRlcWnXXmJbXqKJhlRaoS6KMhq0gpyzW4UJfclcxrEdLnTgjT2NjruLONu0g==}
+    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
+    hasBin: true
+
+  serialize-javascript@7.0.5:
+    resolution: {integrity: sha512-F4LcB0UqUl1zErq+1nYEEzSHJnIwb3AF2XWB94b+afhrekOUijwooAYqFyRbjYkm2PAKBabx6oYv/xDxNi8IBw==}
+    engines: {node: '>=20.0.0'}
+
+  smob@1.6.2:
+    resolution: {integrity: sha512-RQsvleCbF8cVHEv+xuDGaA4pOizFqJ0GgjtMSRo6oP8pnN7WsigHgVGey6aILRBKv4W2YOMHLqbKdnB6hpB9fw==}
+    engines: {node: '>=20.0.0'}
+
+  source-map-support@0.5.21:
+    resolution: {integrity: sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==}
+
+  source-map@0.6.1:
+    resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
+    engines: {node: '>=0.10.0'}
+
+  superstruct@2.0.2:
+    resolution: {integrity: sha512-uV+TFRZdXsqXTL2pRvujROjdZQ4RAlBUS5BTh9IGm+jTqQntYThciG/qu57Gs69yjnVUSqdxF9YLmSnpupBW9A==}
+    engines: {node: '>=14.0.0'}
+
+  supports-preserve-symlinks-flag@1.0.0:
+    resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
+    engines: {node: '>= 0.4'}
+
+  terser@5.48.0:
+    resolution: {integrity: sha512-J/9An6vs9Us6wKRriSFXBWdRZapREHqFzdNUKk0pmu804EMR6dr6winwo7e5JDxN4xahxQsuysyYFwlwj4XN/Q==}
+    engines: {node: '>=10'}
+    hasBin: true
+
+  tslib@2.8.1:
+    resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
+  typescript@6.0.3:
+    resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+snapshots:
+
+  '@formatjs/fast-memoize@3.1.5': {}
+
+  '@formatjs/icu-messageformat-parser@3.5.10':
+    dependencies:
+      '@formatjs/icu-skeleton-parser': 2.1.9
+
+  '@formatjs/icu-skeleton-parser@2.1.9': {}
+
+  '@formatjs/intl-utils@3.8.4':
+    dependencies:
+      emojis-list: 3.0.0
+
+  '@jridgewell/gen-mapping@0.3.13':
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+      '@jridgewell/trace-mapping': 0.3.31
+
+  '@jridgewell/resolve-uri@3.1.2': {}
+
+  '@jridgewell/source-map@0.3.11':
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+
+  '@jridgewell/sourcemap-codec@1.5.5': {}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.2
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@lit-labs/ssr-dom-shim@1.6.0': {}
+
+  '@lit/reactive-element@2.1.2':
+    dependencies:
+      '@lit-labs/ssr-dom-shim': 1.6.0
+
+  '@preact/signals-core@1.14.2': {}
+
+  '@preact/signals@2.9.1(preact@10.29.2)':
+    dependencies:
+      '@preact/signals-core': 1.14.2
+      preact: 10.29.2
+
+  '@rollup/plugin-node-resolve@16.0.3(rollup@4.61.0)':
+    dependencies:
+      '@rollup/pluginutils': 5.4.0(rollup@4.61.0)
+      '@types/resolve': 1.20.2
+      deepmerge: 4.3.1
+      is-module: 1.0.0
+      resolve: 1.22.12
+    optionalDependencies:
+      rollup: 4.61.0
+
+  '@rollup/plugin-terser@1.0.0(rollup@4.61.0)':
+    dependencies:
+      serialize-javascript: 7.0.5
+      smob: 1.6.2
+      terser: 5.48.0
+    optionalDependencies:
+      rollup: 4.61.0
+
+  '@rollup/plugin-typescript@12.3.0(rollup@4.61.0)(tslib@2.8.1)(typescript@6.0.3)':
+    dependencies:
+      '@rollup/pluginutils': 5.4.0(rollup@4.61.0)
+      resolve: 1.22.12
+      typescript: 6.0.3
+    optionalDependencies:
+      rollup: 4.61.0
+      tslib: 2.8.1
+
+  '@rollup/pluginutils@5.4.0(rollup@4.61.0)':
+    dependencies:
+      '@types/estree': 1.0.9
+      estree-walker: 2.0.2
+      picomatch: 4.0.4
+    optionalDependencies:
+      rollup: 4.61.0
+
+  '@rollup/rollup-android-arm-eabi@4.61.0':
+    optional: true
+
+  '@rollup/rollup-android-arm64@4.61.0':
+    optional: true
+
+  '@rollup/rollup-darwin-arm64@4.61.0':
+    optional: true
+
+  '@rollup/rollup-darwin-x64@4.61.0':
+    optional: true
+
+  '@rollup/rollup-freebsd-arm64@4.61.0':
+    optional: true
+
+  '@rollup/rollup-freebsd-x64@4.61.0':
+    optional: true
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.61.0':
+    optional: true
+
+  '@rollup/rollup-linux-arm-musleabihf@4.61.0':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-gnu@4.61.0':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-musl@4.61.0':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-gnu@4.61.0':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-musl@4.61.0':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-gnu@4.61.0':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-musl@4.61.0':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-gnu@4.61.0':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-musl@4.61.0':
+    optional: true
+
+  '@rollup/rollup-linux-s390x-gnu@4.61.0':
+    optional: true
+
+  '@rollup/rollup-linux-x64-gnu@4.61.0':
+    optional: true
+
+  '@rollup/rollup-linux-x64-musl@4.61.0':
+    optional: true
+
+  '@rollup/rollup-openbsd-x64@4.61.0':
+    optional: true
+
+  '@rollup/rollup-openharmony-arm64@4.61.0':
+    optional: true
+
+  '@rollup/rollup-win32-arm64-msvc@4.61.0':
+    optional: true
+
+  '@rollup/rollup-win32-ia32-msvc@4.61.0':
+    optional: true
+
+  '@rollup/rollup-win32-x64-gnu@4.61.0':
+    optional: true
+
+  '@rollup/rollup-win32-x64-msvc@4.61.0':
+    optional: true
+
+  '@schedule-x/calendar@2.36.0(@preact/signals@2.9.1(preact@10.29.2))(preact@10.29.2)':
+    dependencies:
+      '@preact/signals': 2.9.1(preact@10.29.2)
+      preact: 10.29.2
+
+  '@schedule-x/theme-default@2.36.0': {}
+
+  '@types/estree@1.0.9': {}
+
+  '@types/resolve@1.20.2': {}
+
+  '@types/trusted-types@2.0.7': {}
+
+  acorn@8.16.0: {}
+
+  buffer-from@1.1.2: {}
+
+  commander@2.20.3: {}
+
+  custom-card-helpers@2.0.0(lit@3.3.3):
+    dependencies:
+      '@formatjs/intl-utils': 3.8.4
+      home-assistant-js-websocket: 9.6.0
+      intl-messageformat: 11.2.7
+      lit: 3.3.3
+      superstruct: 2.0.2
+
+  deepmerge@4.3.1: {}
+
+  emojis-list@3.0.0: {}
+
+  es-errors@1.3.0: {}
+
+  estree-walker@2.0.2: {}
+
+  fsevents@2.3.3:
+    optional: true
+
+  function-bind@1.1.2: {}
+
+  hasown@2.0.4:
+    dependencies:
+      function-bind: 1.1.2
+
+  home-assistant-js-websocket@9.6.0: {}
+
+  intl-messageformat@11.2.7:
+    dependencies:
+      '@formatjs/fast-memoize': 3.1.5
+      '@formatjs/icu-messageformat-parser': 3.5.10
+
+  is-core-module@2.16.2:
+    dependencies:
+      hasown: 2.0.4
+
+  is-module@1.0.0: {}
+
+  lit-element@4.2.2:
+    dependencies:
+      '@lit-labs/ssr-dom-shim': 1.6.0
+      '@lit/reactive-element': 2.1.2
+      lit-html: 3.3.3
+
+  lit-html@3.3.3:
+    dependencies:
+      '@types/trusted-types': 2.0.7
+
+  lit@3.3.3:
+    dependencies:
+      '@lit/reactive-element': 2.1.2
+      lit-element: 4.2.2
+      lit-html: 3.3.3
+
+  path-parse@1.0.7: {}
+
+  picomatch@4.0.4: {}
+
+  preact@10.29.2: {}
+
+  resolve@1.22.12:
+    dependencies:
+      es-errors: 1.3.0
+      is-core-module: 2.16.2
+      path-parse: 1.0.7
+      supports-preserve-symlinks-flag: 1.0.0
+
+  rollup-plugin-import-css@4.2.1(rollup@4.61.0):
+    dependencies:
+      '@rollup/pluginutils': 5.4.0(rollup@4.61.0)
+      rollup: 4.61.0
+
+  rollup@4.61.0:
+    dependencies:
+      '@types/estree': 1.0.9
+    optionalDependencies:
+      '@rollup/rollup-android-arm-eabi': 4.61.0
+      '@rollup/rollup-android-arm64': 4.61.0
+      '@rollup/rollup-darwin-arm64': 4.61.0
+      '@rollup/rollup-darwin-x64': 4.61.0
+      '@rollup/rollup-freebsd-arm64': 4.61.0
+      '@rollup/rollup-freebsd-x64': 4.61.0
+      '@rollup/rollup-linux-arm-gnueabihf': 4.61.0
+      '@rollup/rollup-linux-arm-musleabihf': 4.61.0
+      '@rollup/rollup-linux-arm64-gnu': 4.61.0
+      '@rollup/rollup-linux-arm64-musl': 4.61.0
+      '@rollup/rollup-linux-loong64-gnu': 4.61.0
+      '@rollup/rollup-linux-loong64-musl': 4.61.0
+      '@rollup/rollup-linux-ppc64-gnu': 4.61.0
+      '@rollup/rollup-linux-ppc64-musl': 4.61.0
+      '@rollup/rollup-linux-riscv64-gnu': 4.61.0
+      '@rollup/rollup-linux-riscv64-musl': 4.61.0
+      '@rollup/rollup-linux-s390x-gnu': 4.61.0
+      '@rollup/rollup-linux-x64-gnu': 4.61.0
+      '@rollup/rollup-linux-x64-musl': 4.61.0
+      '@rollup/rollup-openbsd-x64': 4.61.0
+      '@rollup/rollup-openharmony-arm64': 4.61.0
+      '@rollup/rollup-win32-arm64-msvc': 4.61.0
+      '@rollup/rollup-win32-ia32-msvc': 4.61.0
+      '@rollup/rollup-win32-x64-gnu': 4.61.0
+      '@rollup/rollup-win32-x64-msvc': 4.61.0
+      fsevents: 2.3.3
+
+  serialize-javascript@7.0.5: {}
+
+  smob@1.6.2: {}
+
+  source-map-support@0.5.21:
+    dependencies:
+      buffer-from: 1.1.2
+      source-map: 0.6.1
+
+  source-map@0.6.1: {}
+
+  superstruct@2.0.2: {}
+
+  supports-preserve-symlinks-flag@1.0.0: {}
+
+  terser@5.48.0:
+    dependencies:
+      '@jridgewell/source-map': 0.3.11
+      acorn: 8.16.0
+      commander: 2.20.3
+      source-map-support: 0.5.21
+
+  tslib@2.8.1: {}
+
+  typescript@6.0.3: {}

--- a/dashboard/rollup.config.mjs
+++ b/dashboard/rollup.config.mjs
@@ -1,6 +1,7 @@
 import { nodeResolve } from "@rollup/plugin-node-resolve";
 import terser from "@rollup/plugin-terser";
 import typescript from "@rollup/plugin-typescript";
+import css from "rollup-plugin-import-css";
 
 export default {
   input: "src/daynest-card.ts",
@@ -8,5 +9,5 @@ export default {
     file: "../custom_components/daynest/frontend/daynest-card.js",
     format: "es",
   },
-  plugins: [nodeResolve(), typescript(), !process.env.ROLLUP_WATCH && terser()].filter(Boolean),
+  plugins: [nodeResolve(), css(), typescript(), !process.env.ROLLUP_WATCH && terser()].filter(Boolean),
 };

--- a/dashboard/src/css.d.ts
+++ b/dashboard/src/css.d.ts
@@ -1,0 +1,4 @@
+declare module "*.css" {
+  const styles: string;
+  export default styles;
+}

--- a/dashboard/src/daynest-card.ts
+++ b/dashboard/src/daynest-card.ts
@@ -163,6 +163,7 @@ class DaynestCard extends LitElement {
     super.connectedCallback();
     void this._fetchItems();
     void this._fetchWeek();
+    this.requestUpdate();
   }
 
   disconnectedCallback() {
@@ -454,7 +455,7 @@ class DaynestCard extends LitElement {
   }
 
   private async _fetchCalendarRange(start?: string, end?: string) {
-    if (!this._config?.show_calendar || !this._calendar) return;
+    if (!this.hass || !this._config?.show_calendar || !this._calendar) return;
 
     const rangeStart = start ?? this._toIsoDate(new Date());
     const rangeEnd = end ?? this._toIsoDate(this._addDays(new Date(), this._calendarDaysAhead()));
@@ -466,26 +467,28 @@ class DaynestCard extends LitElement {
       const endpoint = `${configuredBase}/api/calendar/range?${params.toString()}`;
       const response = await fetch(endpoint, { headers: this._apiHeaders(configuredBase) });
       if (!response.ok) return;
-      const payload = (await response.json()) as CalendarRangeResponse;
+      const payload = (await response.json()) as CalendarRangeResponse | null;
       if (requestId !== this._calendarRequestId) return;
-      this._calendar.events.set(this._mapCalendarEvents(payload.items));
+      this._calendar.events.set(this._mapCalendarEvents(payload?.items ?? []));
     } catch (error) {
       console.error("Failed to fetch Daynest calendar range", error);
     }
   }
 
   private _mapCalendarEvents(items: UnifiedDayItem[]): CalendarEvent[] {
+    if (!Array.isArray(items)) return [];
     return items.flatMap((item) => {
       const start = item.scheduled_at ? new Date(item.scheduled_at) : null;
+      const isValidStart = start !== null && !isNaN(start.getTime());
       const allDayDate = item.scheduled_date;
-      if (!start && !allDayDate) return [];
+      if (!isValidStart && !allDayDate) return [];
 
       return [{
         id: `${item.item_type}-${item.item_id}`,
         title: item.title,
-        start: start ? this._toScheduleXDateTime(start) : allDayDate!,
-        end: start
-          ? this._toScheduleXDateTime(this._addMinutes(start, item.duration_minutes ?? DEFAULT_EVENT_DURATION_MINUTES))
+        start: isValidStart ? this._toScheduleXDateTime(start!) : allDayDate!,
+        end: isValidStart
+          ? this._toScheduleXDateTime(this._addMinutes(start!, item.duration_minutes ?? DEFAULT_EVENT_DURATION_MINUTES))
           : allDayDate!,
         calendarId: item.item_type,
         _type: item.item_type,
@@ -498,15 +501,23 @@ class DaynestCard extends LitElement {
 
   private _apiHeaders(configuredBase: string): HeadersInit | undefined {
     const accessToken = (this.hass as { auth?: { data?: { access_token?: string } } })?.auth?.data?.access_token;
-    const sameOrigin = configuredBase
-      ? new URL(configuredBase, window.location.origin).origin === window.location.origin
-      : true;
+    let sameOrigin = true;
+    if (configuredBase) {
+      try {
+        sameOrigin = new URL(configuredBase, window.location.origin).origin === window.location.origin;
+      } catch {
+        sameOrigin = false;
+      }
+    }
     return accessToken && sameOrigin ? { Authorization: `Bearer ${accessToken}` } : undefined;
   }
 
   private _calendarDaysAhead() {
     const daysAhead = Number(this._config.calendar_days_ahead);
-    return Number.isFinite(daysAhead) && daysAhead > 0 ? Math.round(daysAhead) : DEFAULT_CALENDAR_DAYS_AHEAD;
+    if (Number.isFinite(daysAhead) && daysAhead > 0) {
+      return Math.min(Math.round(daysAhead), 90);
+    }
+    return DEFAULT_CALENDAR_DAYS_AHEAD;
   }
 
   private _addDays(date: Date, days: number) {

--- a/dashboard/src/daynest-card.ts
+++ b/dashboard/src/daynest-card.ts
@@ -1,6 +1,8 @@
-import { LitElement, PropertyValues, html } from "lit";
+import { LitElement, PropertyValues, html, unsafeCSS } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
 import { HomeAssistant } from "custom-card-helpers";
+import { CalendarApp, CalendarEvent, createCalendar, createViewMonthAgenda } from "@schedule-x/calendar";
+import scheduleXTheme from "@schedule-x/theme-default/dist/index.css";
 import { DaynestCardConfig, sensorNum, sensorStr } from "./types";
 import { cardStyles } from "./styles";
 
@@ -9,6 +11,21 @@ interface TodoItem {
   summary: string;
   status: "needs_action" | "completed";
   description?: string;
+}
+
+interface UnifiedDayItem {
+  item_type: "routine" | "chore" | "medication" | "planned";
+  item_id: number;
+  title: string;
+  status: string;
+  scheduled_at: string | null;
+  scheduled_date: string | null;
+  duration_minutes?: number | null;
+  module_key: string | null;
+}
+
+interface CalendarRangeResponse {
+  items: UnifiedDayItem[];
 }
 
 interface DailyCount {
@@ -44,6 +61,15 @@ type CardGridOptions = {
 };
 
 const DEFAULT_SENSOR_PREFIX = "sensor.daynest_";
+const DEFAULT_CALENDAR_DAYS_AHEAD = 30;
+const DEFAULT_EVENT_DURATION_MINUTES = 30;
+
+const calendarColors = {
+  routine: "#0d6efd",
+  chore: "#ffc107",
+  medication: "#0dcaf0",
+  planned: "#6f42c1",
+} as const;
 
 const serviceMap = {
   due: {
@@ -120,7 +146,7 @@ type WindowWithCustomCards = Window & {
 
 @customElement("daynest-card")
 class DaynestCard extends LitElement {
-  static styles = cardStyles;
+  static styles = [unsafeCSS(scheduleXTheme), cardStyles];
 
   @property({ attribute: false }) public hass!: HomeAssistant;
   @state() private _config!: DaynestCardConfig;
@@ -130,11 +156,18 @@ class DaynestCard extends LitElement {
   @state() private _quickAddTitle = "";
   @state() private _quickAddPlannedFor = "";
   @state() private _quickAddPending = false;
+  private _calendar?: CalendarApp;
+  private _calendarRequestId = 0;
 
   connectedCallback() {
     super.connectedCallback();
     void this._fetchItems();
     void this._fetchWeek();
+  }
+
+  disconnectedCallback() {
+    this._destroyCalendar();
+    super.disconnectedCallback();
   }
 
   static getConfigForm() {
@@ -179,6 +212,18 @@ class DaynestCard extends LitElement {
           default: true,
         },
         {
+          name: "show_calendar",
+          label: "Show calendar",
+          selector: { boolean: {} },
+          default: false,
+        },
+        {
+          name: "calendar_days_ahead",
+          label: "Calendar days ahead",
+          selector: { number: { min: 1, max: 90, mode: "box" } },
+          default: DEFAULT_CALENDAR_DAYS_AHEAD,
+        },
+        {
           name: "snooze_days",
           label: "Snooze days override",
           selector: { number: { min: 1, max: 14, mode: "box" } },
@@ -199,6 +244,8 @@ class DaynestCard extends LitElement {
       todo_entity: "todo.daynest_today",
       view: "full",
       show_quick_add: true,
+      show_calendar: false,
+      calendar_days_ahead: DEFAULT_CALENDAR_DAYS_AHEAD,
     };
   }
 
@@ -207,6 +254,11 @@ class DaynestCard extends LitElement {
     this._config = config;
     void this._fetchItems();
     void this._fetchWeek();
+    void this._fetchCalendarRange();
+  }
+
+  protected firstUpdated() {
+    this._syncCalendar();
   }
 
   getCardSize(): number {
@@ -218,6 +270,7 @@ class DaynestCard extends LitElement {
   }
 
   protected updated(changedProps: PropertyValues<this>) {
+    this._syncCalendar();
     if (!changedProps.has("hass")) return;
     const todoEntity = this._config?.todo_entity ?? "todo.daynest_today";
     const prevHass = changedProps.get("hass") as HomeAssistant | undefined;
@@ -255,6 +308,7 @@ class DaynestCard extends LitElement {
             .map((metric) => this._metricTile(metricValue(metric.suffix), metric.label))}
         </div>
         ${showMed ? html`<div class="med-chip">💊 Next: ${nextMed}</div>` : ""}
+        ${this._config.show_calendar ? html`<div class="calendar-section"><div id="daynest-calendar"></div></div>` : ""}
         ${view === "week"
           ? this._renderWeekView()
           : html`
@@ -361,6 +415,123 @@ class DaynestCard extends LitElement {
     }
   }
 
+  private _syncCalendar() {
+    if (!this._config?.show_calendar) {
+      this._destroyCalendar();
+      return;
+    }
+    if (this._calendar) return;
+
+    const container = this.renderRoot.querySelector<HTMLElement>("#daynest-calendar");
+    if (!container) return;
+
+    this._calendar = createCalendar({
+      views: [createViewMonthAgenda()],
+      defaultView: "month-agenda",
+      events: [],
+      calendars: Object.fromEntries(
+        Object.entries(calendarColors).map(([name, color]) => [
+          name,
+          {
+            colorName: name,
+            lightColors: { main: color, container: color, onContainer: "#111111" },
+            darkColors: { main: color, container: color, onContainer: "#111111" },
+          },
+        ]),
+      ),
+      callbacks: {
+        onRangeUpdate: ({ start, end }) => void this._fetchCalendarRange(start, end),
+      },
+    });
+    this._calendar.render(container);
+    void this._fetchCalendarRange();
+  }
+
+  private _destroyCalendar() {
+    this._calendarRequestId += 1;
+    this._calendar?.destroy();
+    this._calendar = undefined;
+  }
+
+  private async _fetchCalendarRange(start?: string, end?: string) {
+    if (!this._config?.show_calendar || !this._calendar) return;
+
+    const rangeStart = start ?? this._toIsoDate(new Date());
+    const rangeEnd = end ?? this._toIsoDate(this._addDays(new Date(), this._calendarDaysAhead()));
+    const params = new URLSearchParams({ start: rangeStart, end: rangeEnd });
+    const requestId = ++this._calendarRequestId;
+
+    try {
+      const configuredBase = (this._config.api_base_url ?? "").trim().replace(/\/$/, "");
+      const endpoint = `${configuredBase}/api/calendar/range?${params.toString()}`;
+      const response = await fetch(endpoint, { headers: this._apiHeaders(configuredBase) });
+      if (!response.ok) return;
+      const payload = (await response.json()) as CalendarRangeResponse;
+      if (requestId !== this._calendarRequestId) return;
+      this._calendar.events.set(this._mapCalendarEvents(payload.items));
+    } catch (error) {
+      console.error("Failed to fetch Daynest calendar range", error);
+    }
+  }
+
+  private _mapCalendarEvents(items: UnifiedDayItem[]): CalendarEvent[] {
+    return items.flatMap((item) => {
+      const start = item.scheduled_at ? new Date(item.scheduled_at) : null;
+      const allDayDate = item.scheduled_date;
+      if (!start && !allDayDate) return [];
+
+      return [{
+        id: `${item.item_type}-${item.item_id}`,
+        title: item.title,
+        start: start ? this._toScheduleXDateTime(start) : allDayDate!,
+        end: start
+          ? this._toScheduleXDateTime(this._addMinutes(start, item.duration_minutes ?? DEFAULT_EVENT_DURATION_MINUTES))
+          : allDayDate!,
+        calendarId: item.item_type,
+        _type: item.item_type,
+        _status: item.status,
+        _itemId: item.item_id,
+        _moduleKey: item.module_key,
+      }];
+    });
+  }
+
+  private _apiHeaders(configuredBase: string): HeadersInit | undefined {
+    const accessToken = (this.hass as { auth?: { data?: { access_token?: string } } })?.auth?.data?.access_token;
+    const sameOrigin = configuredBase
+      ? new URL(configuredBase, window.location.origin).origin === window.location.origin
+      : true;
+    return accessToken && sameOrigin ? { Authorization: `Bearer ${accessToken}` } : undefined;
+  }
+
+  private _calendarDaysAhead() {
+    const daysAhead = Number(this._config.calendar_days_ahead);
+    return Number.isFinite(daysAhead) && daysAhead > 0 ? Math.round(daysAhead) : DEFAULT_CALENDAR_DAYS_AHEAD;
+  }
+
+  private _addDays(date: Date, days: number) {
+    const next = new Date(date);
+    next.setDate(next.getDate() + days);
+    return next;
+  }
+
+  private _addMinutes(date: Date, minutes: number) {
+    return new Date(date.getTime() + minutes * 60_000);
+  }
+
+  private _toIsoDate(date: Date) {
+    const year = date.getFullYear();
+    const month = String(date.getMonth() + 1).padStart(2, "0");
+    const day = String(date.getDate()).padStart(2, "0");
+    return `${year}-${month}-${day}`;
+  }
+
+  private _toScheduleXDateTime(date: Date) {
+    const hours = String(date.getHours()).padStart(2, "0");
+    const minutes = String(date.getMinutes()).padStart(2, "0");
+    return `${this._toIsoDate(date)} ${hours}:${minutes}`;
+  }
+
   private async _fetchWeek() {
     if ((this._config?.view ?? "full") !== "week") return;
     try {
@@ -368,13 +539,7 @@ class DaynestCard extends LitElement {
       const endpoint = configuredBase
         ? `${configuredBase}/api/analytics/summary?period=week`
         : "/api/analytics/summary?period=week";
-      const accessToken = (this.hass as { auth?: { data?: { access_token?: string } } })?.auth?.data?.access_token;
-      const sameOrigin = configuredBase
-        ? new URL(configuredBase, window.location.origin).origin === window.location.origin
-        : true;
-      const response = await fetch(endpoint, {
-        headers: accessToken && sameOrigin ? { Authorization: `Bearer ${accessToken}` } : undefined,
-      });
+      const response = await fetch(endpoint, { headers: this._apiHeaders(configuredBase) });
       if (!response.ok) return;
       const summary = (await response.json()) as WeekSummaryResponse;
       this._week = this._normalizeWeek(summary);
@@ -508,6 +673,7 @@ class DaynestCard extends LitElement {
     }
     await this._fetchItems();
     await this._fetchWeek();
+    await this._fetchCalendarRange();
   }
 
   private _renderQuickAdd() {
@@ -556,6 +722,7 @@ class DaynestCard extends LitElement {
       this._quickAddPlannedFor = "";
       await this._fetchItems();
       await this._fetchWeek();
+      await this._fetchCalendarRange();
     } catch (error) {
       console.error("Failed to create Daynest planned item", error);
     } finally {

--- a/dashboard/src/styles.ts
+++ b/dashboard/src/styles.ts
@@ -7,6 +7,22 @@ export const cardStyles = css`
     --daynest-color-overdue: var(--error-color, #dc3545);
     --daynest-color-skipped: var(--disabled-color, #6c757d);
     --daynest-color-pending: var(--info-color, #17a2b8);
+    --sx-color-primary: var(--primary-color);
+    --sx-color-on-primary: var(--text-primary-color, #ffffff);
+    --sx-color-primary-container: color-mix(in srgb, var(--primary-color) 20%, var(--card-background-color));
+    --sx-color-on-primary-container: var(--primary-text-color);
+    --sx-color-surface: var(--card-background-color);
+    --sx-color-surface-dim: var(--secondary-background-color, var(--card-background-color));
+    --sx-color-surface-container: var(--secondary-background-color, var(--card-background-color));
+    --sx-color-surface-container-low: var(--secondary-background-color, var(--card-background-color));
+    --sx-color-surface-container-high: var(--divider-color);
+    --sx-color-background: var(--card-background-color);
+    --sx-color-on-background: var(--primary-text-color);
+    --sx-color-on-surface: var(--primary-text-color);
+    --sx-color-neutral: var(--secondary-text-color);
+    --sx-color-neutral-variant: var(--secondary-text-color);
+    --sx-color-outline: var(--divider-color);
+    --sx-color-outline-variant: var(--divider-color);
   }
 
   ha-card {
@@ -73,6 +89,16 @@ export const cardStyles = css`
     background: color-mix(in srgb, var(--primary-color) 18%, transparent);
     color: var(--primary-text-color);
     font-size: 0.85rem;
+  }
+
+  .calendar-section {
+    margin-top: 12px;
+  }
+
+  #daynest-calendar {
+    height: 430px;
+    max-height: 60vh;
+    overflow: auto;
   }
 
   .task-list {

--- a/dashboard/src/types.ts
+++ b/dashboard/src/types.ts
@@ -7,6 +7,8 @@ export interface DaynestCardConfig {
   todo_entity?: string;
   view?: "full" | "compact" | "week";
   show_quick_add?: boolean;
+  show_calendar?: boolean;
+  calendar_days_ahead?: number;
   snooze_days?: number;
   api_base_url?: string;
 }

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -132,6 +132,7 @@
   "calendar_n_items": "{count} items",
   "calendar_no_items": "No items",
   "calendar_module_label": "Module: {key}",
+  "calendar_status_label": "Status",
   "calendar_repeats": "🔁 Repeats",
   "calendar_repeat_hint": "🔁 {hint}",
   "calendar_repeat_label": "Repeat",

--- a/frontend/messages/nl.json
+++ b/frontend/messages/nl.json
@@ -132,6 +132,7 @@
   "calendar_n_items": "{count} items",
   "calendar_no_items": "Geen items",
   "calendar_module_label": "Module: {key}",
+  "calendar_status_label": "Status",
   "calendar_repeats": "🔁 Herhaalt",
   "calendar_repeat_hint": "🔁 {hint}",
   "calendar_repeat_label": "Herhalen",

--- a/frontend/src/features/calendar/CalendarEventModal.tsx
+++ b/frontend/src/features/calendar/CalendarEventModal.tsx
@@ -1,0 +1,140 @@
+import type { UnifiedDayItem } from "@/lib/api/today";
+import * as m from "@/paraglide/messages";
+
+export function CalendarEventModal({
+  item,
+  isRunning,
+  onClose,
+  onStartRoutine,
+  onCompleteRoutine,
+  onSkipRoutine,
+  onCompleteChore,
+  onSkipChore,
+  onRescheduleChore,
+  onEditPlanned,
+}: {
+  item: UnifiedDayItem | null;
+  isRunning: boolean;
+  onClose: () => void;
+  onStartRoutine: (itemId: number) => void;
+  onCompleteRoutine: (itemId: number) => void;
+  onSkipRoutine: (itemId: number) => void;
+  onCompleteChore: (itemId: number) => void;
+  onSkipChore: (itemId: number) => void;
+  onRescheduleChore: (itemId: number, scheduledDate: string) => void;
+  onEditPlanned: (itemId: number) => void;
+}) {
+  if (!item) return null;
+
+  return (
+    <div
+      className="calendar-event-modal modal d-block"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="calendar-event-modal-title"
+    >
+      <div className="modal-dialog modal-dialog-centered">
+        <div className="modal-content shadow">
+          <div className="modal-header">
+            <div>
+              <span
+                className={`badge text-bg-${item.item_type === "planned" ? "secondary" : item.item_type === "chore" ? "warning" : item.item_type === "medication" ? "info" : "primary"} mb-2`}
+              >
+                {item.item_type}
+              </span>
+              <h2 id="calendar-event-modal-title" className="h5 mb-0">
+                {item.title}
+              </h2>
+            </div>
+            <button type="button" className="btn-close" aria-label="Close" onClick={onClose} />
+          </div>
+          <div className="modal-body d-grid gap-2">
+            <div>
+              <strong>{m.calendar_status_label()}:</strong>{" "}
+              {item.status.charAt(0).toUpperCase() + item.status.slice(1)}
+            </div>
+            {item.detail ? <div>{item.detail}</div> : null}
+            {item.scheduled_date ? (
+              <div className="text-muted small">{item.scheduled_date}</div>
+            ) : null}
+          </div>
+          <div className="modal-footer justify-content-start">
+            {item.item_type === "routine" ? (
+              <>
+                {item.status === "pending" ? (
+                  <button
+                    type="button"
+                    className="btn btn-primary"
+                    disabled={isRunning}
+                    onClick={() => onStartRoutine(item.item_id)}
+                  >
+                    {m.action_start()}
+                  </button>
+                ) : null}
+                <button
+                  type="button"
+                  className="btn btn-success"
+                  disabled={isRunning}
+                  onClick={() => onCompleteRoutine(item.item_id)}
+                >
+                  {m.action_done()}
+                </button>
+                <button
+                  type="button"
+                  className="btn btn-outline-secondary"
+                  disabled={isRunning}
+                  onClick={() => onSkipRoutine(item.item_id)}
+                >
+                  {m.action_skip()}
+                </button>
+              </>
+            ) : null}
+            {item.item_type === "chore" ? (
+              <>
+                <button
+                  type="button"
+                  className="btn btn-success"
+                  disabled={isRunning}
+                  onClick={() => onCompleteChore(item.item_id)}
+                >
+                  {m.action_done()}
+                </button>
+                <button
+                  type="button"
+                  className="btn btn-outline-secondary"
+                  disabled={isRunning}
+                  onClick={() => onSkipChore(item.item_id)}
+                >
+                  {m.action_skip()}
+                </button>
+                {item.scheduled_date ? (
+                  <button
+                    type="button"
+                    className="btn btn-outline-primary"
+                    disabled={isRunning}
+                    onClick={() => onRescheduleChore(item.item_id, item.scheduled_date!)}
+                  >
+                    {m.action_reschedule_1_day()}
+                  </button>
+                ) : null}
+              </>
+            ) : null}
+            {item.item_type === "planned" ? (
+              <button
+                type="button"
+                className="btn btn-primary"
+                disabled={isRunning}
+                onClick={() => onEditPlanned(item.item_id)}
+              >
+                {m.action_edit()}
+              </button>
+            ) : null}
+            <button type="button" className="btn btn-outline-secondary ms-auto" onClick={onClose}>
+              {m.action_cancel()}
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/features/calendar/CalendarPage.tsx
+++ b/frontend/src/features/calendar/CalendarPage.tsx
@@ -1,19 +1,23 @@
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useNavigate, useSearch } from "@tanstack/react-router";
+import {
+  createViewDay,
+  createViewMonthAgenda,
+  createViewMonthGrid,
+  createViewWeek,
+} from "@schedule-x/calendar";
+import { createDragAndDropPlugin } from "@schedule-x/drag-and-drop";
+import { createEventModalPlugin } from "@schedule-x/event-modal";
+import { ScheduleXCalendar, useCalendarApp } from "@schedule-x/react";
 import * as m from "@/paraglide/messages";
-import {
-  isRetryableApiError,
-} from "@/lib/api/today";
-import { dayjs, formatMonthYear, toIsoDate } from "@/lib/dateUtils";
-import {
-  CalendarMonthGrid,
-  DayDetailsPanel,
-  MonthNavigationControls,
-  PlannedItemsSidebar,
-} from "@/features/calendar/CalendarPageSections";
+import { isRetryableApiError, type UnifiedDayItem } from "@/lib/api/today";
+import { dayjs, toIsoDate } from "@/lib/dateUtils";
+import { CalendarEventModal } from "@/features/calendar/CalendarEventModal";
+import { PlannedItemsSidebar } from "@/features/calendar/CalendarPageSections";
+import { CALENDAR_COLORS, mapToScheduleXEvents } from "@/features/calendar/mapToScheduleXEvents";
+import { useCalendarPlannedItems } from "@/features/calendar/useCalendarPlannedItems";
 import {
   useCalendarDayQuery,
-  useCalendarMonthQuery,
   useCalendarPlannedItemsQuery,
   useCompleteChoreMutation,
   useCompleteRoutineTaskMutation,
@@ -22,40 +26,42 @@ import {
   useSkipRoutineTaskMutation,
   useStartRoutineTaskMutation,
 } from "@/features/calendar/useCalendarQueries";
-import { useCalendarPlannedItems } from "@/features/calendar/useCalendarPlannedItems";
-
-function parseMonth(value?: string) {
-  if (!value) return null;
-  const parsed = dayjs(`${value}-01`);
-  if (!parsed.isValid() || parsed.format("YYYY-MM") !== value) {
-    return null;
-  }
-  return parsed;
-}
+import { useCalendarRangeQuery } from "@/features/calendar/useCalendarRangeQuery";
+import "@/features/calendar/calendar.css";
 
 function parseDate(value?: string) {
   if (!value) return null;
   const parsed = dayjs(value);
-  if (!parsed.isValid() || parsed.format("YYYY-MM-DD") !== value) {
-    return null;
-  }
-  return parsed;
+  return parsed.isValid() && parsed.format("YYYY-MM-DD") === value ? parsed : null;
 }
+
+const calendarDefinitions = Object.fromEntries(
+  Object.entries(CALENDAR_COLORS).map(([id, color]) => [
+    id,
+    {
+      colorName: id,
+      lightColors: { main: color, container: `${color}22`, onContainer: "#212529" },
+      darkColors: { main: color, container: `${color}44`, onContainer: "#f8f9fa" },
+    },
+  ]),
+);
 
 export function CalendarPage() {
   const navigate = useNavigate();
   const search = useSearch({ from: "/protected/calendar" });
-  const currentMonth = useMemo(() => parseMonth(search.month) ?? dayjs(), [search.month]);
   const selectedDate = useMemo(() => toIsoDate(parseDate(search.date) ?? dayjs()), [search.date]);
+  const initialMonth = useMemo(
+    () => parseDate(search.month ? `${search.month}-01` : undefined) ?? dayjs(),
+    [search.month],
+  );
+  const [range, setRange] = useState(() => ({
+    start: initialMonth.startOf("month").format("YYYY-MM-DD"),
+    end: initialMonth.endOf("month").format("YYYY-MM-DD"),
+  }));
+  const [selectedItem, setSelectedItem] = useState<UnifiedDayItem | null>(null);
   const [dayActionStatus, setDayActionStatus] = useState<string | null>(null);
   const [isRunningDayAction, setIsRunningDayAction] = useState(false);
-
-  const monthKey = useMemo(
-    () => ({ year: currentMonth.year(), month: currentMonth.month() + 1 }),
-    [currentMonth],
-  );
-  const monthStart = currentMonth.startOf("month");
-  const monthQuery = useCalendarMonthQuery(monthKey.year, monthKey.month);
+  const rangeQuery = useCalendarRangeQuery(range);
   const dayQuery = useCalendarDayQuery(selectedDate);
   const plannedQuery = useCalendarPlannedItemsQuery(selectedDate);
   const startRoutineTaskMutation = useStartRoutineTaskMutation();
@@ -65,31 +71,39 @@ export function CalendarPage() {
   const skipChoreMutation = useSkipChoreMutation();
   const rescheduleChoreMutation = useRescheduleChoreMutation();
 
-  const updateSearch = (nextMonth: dayjs.Dayjs, nextDate: string) => {
-    void navigate({
-      to: "/calendar",
-      search: {
-        month: nextMonth.format("YYYY-MM"),
-        date: nextDate,
-      },
-      replace: true,
-    });
-  };
-
+  const updateSearch = (date: string) =>
+    void navigate({ to: "/calendar", search: { date, month: date.slice(0, 7) }, replace: true });
   const reloadCalendar = async () => {
-    await Promise.all([monthQuery.refetch(), dayQuery.refetch(), plannedQuery.refetch()]);
+    await Promise.all([rangeQuery.refetch(), dayQuery.refetch(), plannedQuery.refetch()]);
   };
-
   const planned = useCalendarPlannedItems({
     selectedDate,
-    monthStart,
-    monthKey,
+    monthStart: dayjs(range.start),
+    monthKey: { year: dayjs(range.start).year(), month: dayjs(range.start).month() + 1 },
     loadCalendar: reloadCalendar,
   });
 
-  useEffect(() => {
-    planned.setPlannedItems(plannedQuery.data ?? []);
-  }, [plannedQuery.data]);
+  useEffect(() => planned.setPlannedItems(plannedQuery.data ?? []), [plannedQuery.data]);
+
+  const itemsByEventId = useMemo(
+    () =>
+      new Map(
+        (rangeQuery.data?.items ?? []).map((item) => [`${item.item_type}-${item.item_id}`, item]),
+      ),
+    [rangeQuery.data],
+  );
+  const liveRef = useRef({ itemsByEventId, planned });
+  liveRef.current = { itemsByEventId, planned };
+  const events = useMemo(
+    () => mapToScheduleXEvents(rangeQuery.data?.items ?? []),
+    [rangeQuery.data],
+  );
+  const plugins = useMemo(() => [createDragAndDropPlugin(), createEventModalPlugin()], []);
+  const views = useMemo(
+    () =>
+      [createViewMonthGrid(), createViewWeek(), createViewDay(), createViewMonthAgenda()] as const,
+    [],
+  );
 
   const runDayItemAction = async (action: () => Promise<unknown>, successMessage: string) => {
     setDayActionStatus(null);
@@ -98,6 +112,7 @@ export function CalendarPage() {
     try {
       await action();
       setDayActionStatus(successMessage);
+      setSelectedItem(null);
     } catch (err) {
       planned.setAddError(err instanceof Error ? err.message : "Action failed.");
     } finally {
@@ -105,37 +120,75 @@ export function CalendarPage() {
     }
   };
 
-  const loading = monthQuery.isPending || dayQuery.isPending || plannedQuery.isPending;
-  const queryError = monthQuery.error ?? dayQuery.error ?? plannedQuery.error;
-  const error = queryError instanceof Error ? queryError.message : queryError ? "Unable to load calendar view." : null;
-  const canRetry = queryError ? isRetryableApiError(queryError) : false;
+  const calendar = useCalendarApp(
+    {
+      views: [...views],
+      events,
+      selectedDate,
+      calendars: calendarDefinitions,
+      callbacks: {
+        onRangeUpdate: (nextRange) => {
+          setRange(nextRange);
+        },
+        onSelectedDateUpdate: updateSearch,
+        onEventClick: (event) =>
+          setSelectedItem(liveRef.current.itemsByEventId.get(String(event.id)) ?? null),
+        onEventUpdate: (event) => {
+          if (event._type !== "planned") return;
+          void liveRef.current.planned.dragReschedulePlannedItem(
+            Number(event._itemId),
+            event.start.slice(0, 10),
+          );
+        },
+        onClickDate: (date) => {
+          updateSearch(date);
+          liveRef.current.planned.resetPlannedForm();
+        },
+        onClickDateTime: (dateTime) => {
+          updateSearch(dateTime.slice(0, 10));
+          liveRef.current.planned.resetPlannedForm();
+          liveRef.current.planned.setTimeOfDay(dateTime.slice(11, 16));
+        },
+      },
+    },
+    plugins,
+  );
+
+  useEffect(() => {
+    calendar?.events.set(events);
+  }, [calendar, events]);
+
+  const loading = rangeQuery.isPending || dayQuery.isPending || plannedQuery.isPending;
+  const queryError = rangeQuery.error ?? dayQuery.error ?? plannedQuery.error;
+  const error =
+    queryError instanceof Error
+      ? queryError.message
+      : queryError
+        ? "Unable to load calendar view."
+        : null;
 
   return (
     <section>
-      <MonthNavigationControls
-        onRefresh={() => void reloadCalendar()}
-        onPrevMonth={() => {
-          const nextMonth = currentMonth.subtract(1, "month");
-          updateSearch(nextMonth, selectedDate);
-        }}
-        onCurrentMonth={() => {
-          const nextMonth = dayjs();
-          const nextDate = toIsoDate(nextMonth);
-          updateSearch(nextMonth, nextDate);
-        }}
-        onNextMonth={() => {
-          const nextMonth = currentMonth.add(1, "month");
-          updateSearch(nextMonth, selectedDate);
-        }}
-      />
-      <p className="text-muted">{formatMonthYear(monthStart)} {m.calendar_subtitle()}</p>
-
+      <div className="d-flex justify-content-between align-items-center gap-2 mb-2">
+        <h2 className="h4 mb-0">{m.calendar_title()}</h2>
+        <button
+          type="button"
+          className="btn btn-outline-primary btn-sm"
+          onClick={() => void reloadCalendar()}
+        >
+          {m.action_refresh()}
+        </button>
+      </div>
       {loading ? <div className="alert alert-info py-2">{m.calendar_loading()}</div> : null}
       {error ? (
-        <div className="alert alert-danger py-2 d-flex justify-content-between align-items-center gap-2 flex-wrap">
+        <div className="alert alert-danger py-2 d-flex justify-content-between align-items-center gap-2">
           <span>{error}</span>
-          {canRetry ? (
-            <button type="button" className="btn btn-danger btn-sm" onClick={() => void reloadCalendar()}>
+          {isRetryableApiError(queryError) ? (
+            <button
+              type="button"
+              className="btn btn-danger btn-sm"
+              onClick={() => void reloadCalendar()}
+            >
               {m.action_retry()}
             </button>
           ) : null}
@@ -147,50 +200,16 @@ export function CalendarPage() {
       {planned.addError && planned.editingPlannedItemId === null ? (
         <div className="alert alert-danger py-2">{planned.addError}</div>
       ) : null}
-
       <div className="row g-3">
-        <div className="col-lg-7">
-          <CalendarMonthGrid
-            monthStart={monthStart}
-            monthItems={monthQuery.data?.days ?? []}
-            selectedDate={selectedDate}
-            onSelectDate={(date) => {
-              updateSearch(currentMonth, date);
-            }}
-            onDropReschedule={planned.dragReschedulePlannedItem}
-          />
+        <div className="col-xl-8">
+          <div className="daynest-calendar card p-2">
+            <ScheduleXCalendar
+              calendarApp={calendar}
+              customComponents={{ eventModal: () => null }}
+            />
+          </div>
         </div>
-
-        <div className="col-lg-5">
-          <DayDetailsPanel
-            selectedDate={selectedDate}
-            dayItems={dayQuery.data?.items ?? []}
-            isAdding={planned.isAdding || isRunningDayAction}
-            onStartRoutine={(itemId) =>
-              runDayItemAction(() => startRoutineTaskMutation.mutateAsync(itemId), m.action_start())
-            }
-            onCompleteRoutine={(itemId) =>
-              runDayItemAction(() => completeRoutineTaskMutation.mutateAsync(itemId), m.action_done())
-            }
-            onSkipRoutine={(itemId) =>
-              runDayItemAction(() => skipRoutineTaskMutation.mutateAsync(itemId), m.action_skip())
-            }
-            onCompleteChore={(itemId) =>
-              runDayItemAction(() => completeChoreMutation.mutateAsync(itemId), m.action_done())
-            }
-            onSkipChore={(itemId) => runDayItemAction(() => skipChoreMutation.mutateAsync(itemId), m.action_skip())}
-            onRescheduleChore={(itemId, scheduledDate) =>
-              runDayItemAction(
-                () =>
-                  rescheduleChoreMutation.mutateAsync({
-                    choreInstanceId: itemId,
-                    scheduledDate: toIsoDate(dayjs(scheduledDate).add(1, "day")),
-                  }),
-                m.action_reschedule_1_day(),
-              )
-            }
-          />
-
+        <div className="col-xl-4">
           <PlannedItemsSidebar
             selectedDate={selectedDate}
             plannedItems={planned.plannedItems}
@@ -211,54 +230,18 @@ export function CalendarPage() {
             confirmDeleteId={planned.confirmDeleteId}
             isAdding={planned.isAdding || isRunningDayAction}
             addError={planned.addError}
-            onSetTitle={(value) => {
-              planned.setTitle(value);
-              planned.setAddError(null);
-            }}
-            onSetTimeOfDay={(value) => {
-              planned.setTimeOfDay(value);
-              planned.setAddError(null);
-            }}
-            onSetDurationMinutes={(value) => {
-              planned.setDurationMinutes(value);
-              planned.setAddError(null);
-            }}
-            onSetNotes={(value) => {
-              planned.setNotes(value);
-              planned.setAddError(null);
-            }}
-            onSetModuleKey={(value) => {
-              planned.setModuleKey(value);
-              planned.setAddError(null);
-            }}
-            onSetRecurrenceHint={(value) => {
-              planned.setRecurrenceHint(value);
-              planned.setAddError(null);
-            }}
-            onSetIsRepeating={(value) => {
-              planned.setIsRepeating(value);
-              planned.setAddError(null);
-            }}
-            onSetRepeatPreset={(value) => {
-              planned.setRepeatPreset(value);
-              planned.setAddError(null);
-            }}
-            onSetRepeatWeekdays={(value) => {
-              planned.setRepeatWeekdays(value);
-              planned.setAddError(null);
-            }}
-            onSetCustomInterval={(value) => {
-              planned.setCustomInterval(value);
-              planned.setAddError(null);
-            }}
-            onSetLinkedSource={(value) => {
-              planned.setLinkedSource(value);
-              planned.setAddError(null);
-            }}
-            onSetLinkedRef={(value) => {
-              planned.setLinkedRef(value);
-              planned.setAddError(null);
-            }}
+            onSetTitle={planned.setTitle}
+            onSetTimeOfDay={planned.setTimeOfDay}
+            onSetDurationMinutes={planned.setDurationMinutes}
+            onSetNotes={planned.setNotes}
+            onSetModuleKey={planned.setModuleKey}
+            onSetRecurrenceHint={planned.setRecurrenceHint}
+            onSetIsRepeating={planned.setIsRepeating}
+            onSetRepeatPreset={planned.setRepeatPreset}
+            onSetRepeatWeekdays={planned.setRepeatWeekdays}
+            onSetCustomInterval={planned.setCustomInterval}
+            onSetLinkedSource={planned.setLinkedSource}
+            onSetLinkedRef={planned.setLinkedRef}
             onSetEditScope={planned.setEditScope}
             onAddPlanned={planned.onAddPlanned}
             onCancelEdit={planned.resetPlannedForm}
@@ -272,10 +255,44 @@ export function CalendarPage() {
             fileInputRef={planned.fileInputRef}
             onExportBackup={planned.onExportBackup}
             onImportFile={planned.onImportFile}
-            onDropReschedule={planned.dragReschedulePlannedItem}
           />
         </div>
       </div>
+      <CalendarEventModal
+        item={selectedItem}
+        isRunning={isRunningDayAction}
+        onClose={() => setSelectedItem(null)}
+        onStartRoutine={(id) =>
+          void runDayItemAction(() => startRoutineTaskMutation.mutateAsync(id), m.action_start())
+        }
+        onCompleteRoutine={(id) =>
+          void runDayItemAction(() => completeRoutineTaskMutation.mutateAsync(id), m.action_done())
+        }
+        onSkipRoutine={(id) =>
+          void runDayItemAction(() => skipRoutineTaskMutation.mutateAsync(id), m.action_skip())
+        }
+        onCompleteChore={(id) =>
+          void runDayItemAction(() => completeChoreMutation.mutateAsync(id), m.action_done())
+        }
+        onSkipChore={(id) =>
+          void runDayItemAction(() => skipChoreMutation.mutateAsync(id), m.action_skip())
+        }
+        onRescheduleChore={(id, date) =>
+          void runDayItemAction(
+            () =>
+              rescheduleChoreMutation.mutateAsync({
+                choreInstanceId: id,
+                scheduledDate: toIsoDate(dayjs(date).add(1, "day")),
+              }),
+            m.action_reschedule_1_day(),
+          )
+        }
+        onEditPlanned={(id) => {
+          const item = planned.plannedItems.find((candidate) => candidate.id === id);
+          if (item) planned.startEditing(item);
+          setSelectedItem(null);
+        }}
+      />
     </section>
   );
 }

--- a/frontend/src/features/calendar/CalendarPageSections.tsx
+++ b/frontend/src/features/calendar/CalendarPageSections.tsx
@@ -1,23 +1,11 @@
-import { useMemo, useRef, useState, type ChangeEvent, type RefObject } from "react";
-import type { Dayjs } from "dayjs";
+import type { ChangeEvent, RefObject } from "react";
 import * as m from "@/paraglide/messages";
-import { capitalize, formatDate, toIsoDate } from "@/lib/dateUtils";
-import { type CalendarDayPayload, type CalendarMonthDaySummary, type PlannedItemEditScope, type PlannedItemModuleKey, type PlannedTodayItem } from "@/lib/api/today";
-
-function itemBadgeClass(itemType: string): string {
-  if (itemType === "medication") return "text-bg-info";
-  if (itemType === "routine") return "text-bg-primary";
-  if (itemType === "chore") return "text-bg-warning";
-  return "text-bg-secondary";
-}
-
-function dayItemStatusClass(status: string): string {
-  if (status === "done" || status === "completed" || status === "taken") return "text-bg-success";
-  if (status === "pending") return "text-bg-warning";
-  if (status === "scheduled") return "text-bg-info";
-  if (status === "missed") return "text-bg-danger";
-  return "text-bg-secondary";
-}
+import { formatDate } from "@/lib/dateUtils";
+import {
+  type PlannedItemEditScope,
+  type PlannedItemModuleKey,
+  type PlannedTodayItem,
+} from "@/lib/api/today";
 
 function formatPlannedMeta(item: PlannedTodayItem): string {
   const timeAndDuration = [
@@ -41,16 +29,6 @@ function formatPlannedMeta(item: PlannedTodayItem): string {
   return values.filter(Boolean).join(" • ");
 }
 
-const WEEKDAYS = [
-  m.calendar_weekday_mon,
-  m.calendar_weekday_tue,
-  m.calendar_weekday_wed,
-  m.calendar_weekday_thu,
-  m.calendar_weekday_fri,
-  m.calendar_weekday_sat,
-  m.calendar_weekday_sun,
-];
-
 const WEEKDAY_REPEAT_OPTIONS = [
   { code: "MO", label: m.calendar_weekday_mon },
   { code: "TU", label: m.calendar_weekday_tue },
@@ -60,252 +38,6 @@ const WEEKDAY_REPEAT_OPTIONS = [
   { code: "SA", label: m.calendar_weekday_sat },
   { code: "SU", label: m.calendar_weekday_sun },
 ] as const;
-
-export function MonthNavigationControls({
-  onRefresh,
-  onPrevMonth,
-  onCurrentMonth,
-  onNextMonth,
-}: {
-  onRefresh: () => void;
-  onPrevMonth: () => void;
-  onCurrentMonth: () => void;
-  onNextMonth: () => void;
-}) {
-  return (
-    <div className="d-flex flex-column gap-2 mb-2">
-      <div className="d-flex justify-content-between align-items-center">
-        <h2 className="h4 mb-0">{m.calendar_title()}</h2>
-        <button type="button" className="btn btn-outline-primary btn-sm" onClick={onRefresh}>
-          {m.action_refresh()}
-        </button>
-      </div>
-      <div className="btn-group btn-group-sm w-100" role="group" aria-label="Quick month controls">
-        <button type="button" className="btn btn-outline-secondary" onClick={onPrevMonth}>
-          {m.calendar_prev()}
-        </button>
-        <button type="button" className="btn btn-outline-secondary" onClick={onCurrentMonth}>
-          {m.calendar_this_month()}
-        </button>
-        <button type="button" className="btn btn-outline-secondary" onClick={onNextMonth}>
-          {m.calendar_next()}
-        </button>
-      </div>
-    </div>
-  );
-}
-
-export function CalendarMonthGrid({
-  monthStart,
-  monthItems,
-  selectedDate,
-  onSelectDate,
-  onDropReschedule,
-}: {
-  monthStart: Dayjs;
-  monthItems: CalendarMonthDaySummary[];
-  selectedDate: string;
-  onSelectDate: (date: string) => void;
-  onDropReschedule?: (itemId: number, date: string) => void;
-}) {
-  const daysInMonth = monthStart.daysInMonth();
-  const leadingEmptyDays = (monthStart.day() + 6) % 7;
-  const totalCalendarCells = Math.ceil((leadingEmptyDays + daysInMonth) / 7) * 7;
-  const itemsByDate = useMemo(() => new Map(monthItems.map((item) => [item.date, item])), [monthItems]);
-  const [dragOverDate, setDragOverDate] = useState<string | null>(null);
-
-  return (
-    <div className="card">
-      <div className="card-body p-2 p-md-3">
-        <div className="row row-cols-7 g-1 g-md-2">
-          {WEEKDAYS.map((wd) => (
-            <div key={wd()} className="col text-center small fw-semibold text-muted">
-              {wd()}
-            </div>
-          ))}
-          {Array.from({ length: totalCalendarCells }).map((_, idx) => {
-            const dayNumber = idx - leadingEmptyDays + 1;
-            if (dayNumber < 1 || dayNumber > daysInMonth) {
-              return <div key={`empty-${idx}`} className="col" aria-hidden="true" />;
-            }
-            const dateValue = toIsoDate(monthStart.date(dayNumber));
-            const summary = itemsByDate.get(dateValue);
-            const selected = selectedDate === dateValue;
-            const isDragTarget = !selected && dragOverDate === dateValue;
-            const cellClass = `btn w-100 text-start py-2 ${selected ? "btn-primary" : isDragTarget ? "btn-outline-success" : "btn-outline-secondary"}`;
-            return (
-              <div key={dateValue} className="col">
-                <button
-                  type="button"
-                  className={cellClass}
-                  onClick={() => onSelectDate(dateValue)}
-                  data-date={dateValue}
-                  onDragOver={onDropReschedule ? (e) => { e.preventDefault(); setDragOverDate(dateValue); } : undefined}
-                  onDragLeave={onDropReschedule ? () => setDragOverDate(null) : undefined}
-                  onDrop={onDropReschedule ? (e) => {
-                    e.preventDefault();
-                    setDragOverDate(null);
-                    const rawId = e.dataTransfer.getData("plannedItemId");
-                    const itemId = parseInt(rawId, 10);
-                    if (!isNaN(itemId)) onDropReschedule(itemId, dateValue);
-                  } : undefined}
-                >
-                  <div className="fw-semibold lh-1">{dayNumber}</div>
-                  <small>{summary ? m.calendar_n_items({ count: summary.total }) : m.calendar_no_items()}</small>
-                  {summary ? (
-                    <div className="calendar-cell-meta mt-2">
-                      {summary.routines ? (
-                        <span className="badge text-bg-primary-subtle text-primary-emphasis">
-                          {summary.routines}R
-                        </span>
-                      ) : null}
-                      {summary.chores ? (
-                        <span className="badge text-bg-warning-subtle text-warning-emphasis">
-                          {summary.chores}C
-                        </span>
-                      ) : null}
-                      {summary.medications ? (
-                        <span className="badge text-bg-info-subtle text-info-emphasis">
-                          {summary.medications}M
-                        </span>
-                      ) : null}
-                      {summary.planned ? (
-                        <span className="badge text-bg-secondary">{summary.planned}P</span>
-                      ) : null}
-                    </div>
-                  ) : null}
-                </button>
-              </div>
-            );
-          })}
-        </div>
-      </div>
-    </div>
-  );
-}
-
-export function DayDetailsPanel({
-  selectedDate,
-  dayItems,
-  isAdding,
-  onStartRoutine,
-  onCompleteRoutine,
-  onSkipRoutine,
-  onCompleteChore,
-  onSkipChore,
-  onRescheduleChore,
-}: {
-  selectedDate: string;
-  dayItems: CalendarDayPayload["items"];
-  isAdding: boolean;
-  onStartRoutine: (itemId: number) => Promise<void>;
-  onCompleteRoutine: (itemId: number) => Promise<void>;
-  onSkipRoutine: (itemId: number) => Promise<void>;
-  onCompleteChore: (itemId: number) => Promise<void>;
-  onSkipChore: (itemId: number) => Promise<void>;
-  onRescheduleChore: (itemId: number, scheduledDate: string) => Promise<void>;
-}) {
-  return (
-    <div className="card mb-3">
-      <div className="card-header fw-semibold py-2">{m.calendar_day_details_header({ date: formatDate(selectedDate) })}</div>
-      <ul className="list-group list-group-flush">
-        {dayItems.length === 0 ? (
-          <li className="list-group-item py-2 text-muted">{m.calendar_no_items_for_day()}</li>
-        ) : (
-          dayItems.map((item) => (
-            <li key={`${item.item_type}-${item.item_id}`} className="list-group-item py-2">
-              <div className="d-flex justify-content-between align-items-start gap-3">
-                <div>
-                  <div className="fw-semibold">
-                    {item.rrule || item.recurrence_series_id ? "🔁 " : ""}
-                    {item.title}
-                  </div>
-                  <small className="text-muted">{capitalize(item.status)}</small>
-                  {item.detail ? <small className="d-block">{item.detail}</small> : null}
-                  {item.module_key ? (
-                    <small className="d-block text-muted">{m.calendar_module_label({ key: item.module_key })}</small>
-                  ) : null}
-                  <div className="d-flex gap-2 flex-wrap mt-2">
-                    {item.item_type === "routine" && item.status === "pending" ? (
-                      <button
-                        type="button"
-                        className="btn btn-outline-primary btn-sm"
-                        disabled={isAdding}
-                        onClick={() => void onStartRoutine(item.item_id)}
-                      >
-                        {m.action_start()}
-                      </button>
-                    ) : null}
-                    {item.item_type === "routine" &&
-                    item.status !== "completed" &&
-                    item.status !== "skipped" ? (
-                      <>
-                        <button
-                          type="button"
-                          className="btn btn-success btn-sm"
-                          disabled={isAdding}
-                          onClick={() => void onCompleteRoutine(item.item_id)}
-                        >
-                          {m.action_done()}
-                        </button>
-                        <button
-                          type="button"
-                          className="btn btn-outline-secondary btn-sm"
-                          disabled={isAdding}
-                          onClick={() => void onSkipRoutine(item.item_id)}
-                        >
-                          {m.action_skip()}
-                        </button>
-                      </>
-                    ) : null}
-                    {item.item_type === "chore" && item.status === "pending" ? (
-                      <>
-                        <button
-                          type="button"
-                          className="btn btn-success btn-sm"
-                          disabled={isAdding}
-                          onClick={() => void onCompleteChore(item.item_id)}
-                        >
-                          {m.action_done()}
-                        </button>
-                        <button
-                          type="button"
-                          className="btn btn-outline-secondary btn-sm"
-                          disabled={isAdding}
-                          onClick={() => void onSkipChore(item.item_id)}
-                        >
-                          {m.action_skip()}
-                        </button>
-                        {item.scheduled_date ? (
-                          <button
-                            type="button"
-                            className="btn btn-outline-primary btn-sm"
-                            disabled={isAdding}
-                            onClick={() =>
-                              void onRescheduleChore(item.item_id, item.scheduled_date as string)
-                            }
-                          >
-                            {m.action_reschedule_1_day()}
-                          </button>
-                        ) : null}
-                      </>
-                    ) : null}
-                  </div>
-                </div>
-                <div className="d-grid gap-1 text-end">
-                  <span className={`badge ${itemBadgeClass(item.item_type)}`}>{item.item_type}</span>
-                  <span className={`badge ${dayItemStatusClass(item.status)}`}>
-                    {capitalize(item.status)}
-                  </span>
-                </div>
-              </div>
-            </li>
-          ))
-        )}
-      </ul>
-    </div>
-  );
-}
 
 export function PlannedItemsSidebar({
   selectedDate,
@@ -352,7 +84,6 @@ export function PlannedItemsSidebar({
   fileInputRef,
   onExportBackup,
   onImportFile,
-  onDropReschedule,
 }: {
   selectedDate: string;
   plannedItems: PlannedTodayItem[];
@@ -398,9 +129,7 @@ export function PlannedItemsSidebar({
   fileInputRef: RefObject<HTMLInputElement | null>;
   onExportBackup: () => Promise<void>;
   onImportFile: (event: ChangeEvent<HTMLInputElement>) => Promise<void>;
-  onDropReschedule?: (itemId: number, date: string) => void;
 }) {
-  const touchCloneRef = useRef<HTMLElement | null>(null);
   return (
     <>
       <div className="card mb-3">
@@ -474,7 +203,9 @@ export function PlannedItemsSidebar({
                   className="form-select"
                   value={repeatPreset}
                   onChange={(event) =>
-                    onSetRepeatPreset(event.target.value as "daily" | "weekly" | "monthly" | "custom")
+                    onSetRepeatPreset(
+                      event.target.value as "daily" | "weekly" | "monthly" | "custom",
+                    )
                   }
                   aria-label={m.calendar_repeat_schedule_aria()}
                 >
@@ -591,48 +322,15 @@ export function PlannedItemsSidebar({
       </div>
 
       <div className="card mb-3">
-        <div className="card-header fw-semibold py-2">{m.calendar_planned_items_header({ date: formatDate(selectedDate) })}</div>
+        <div className="card-header fw-semibold py-2">
+          {m.calendar_planned_items_header({ date: formatDate(selectedDate) })}
+        </div>
         <ul className="list-group list-group-flush">
           {plannedItems.length === 0 ? (
             <li className="list-group-item py-2 text-muted">{m.calendar_no_planned_items()}</li>
           ) : (
             plannedItems.map((item) => (
-              <li
-                key={item.id}
-                className="list-group-item py-2"
-                draggable
-                onDragStart={(e) => {
-                  e.dataTransfer.setData("plannedItemId", String(item.id));
-                  e.dataTransfer.effectAllowed = "move";
-                }}
-                onTouchStart={(e) => {
-                  if (!onDropReschedule) return;
-                  const rect = e.currentTarget.getBoundingClientRect();
-                  const clone = e.currentTarget.cloneNode(true) as HTMLElement;
-                  clone.style.cssText = `position:fixed;top:${rect.top}px;left:${rect.left}px;width:${rect.width}px;opacity:0.75;pointer-events:none;z-index:9999;background:var(--bs-body-bg);border:1px solid var(--bs-border-color);border-radius:4px;`;
-                  document.body.appendChild(clone);
-                  touchCloneRef.current = clone;
-                }}
-                onTouchMove={(e) => {
-                  if (!touchCloneRef.current) return;
-                  e.preventDefault();
-                  const touch = e.touches[0];
-                  if (!touch) return;
-                  touchCloneRef.current.style.top = `${touch.clientY - 20}px`;
-                  touchCloneRef.current.style.left = `${touch.clientX - 20}px`;
-                }}
-                onTouchEnd={(e) => {
-                  touchCloneRef.current?.remove();
-                  touchCloneRef.current = null;
-                  if (!onDropReschedule) return;
-                  const touch = e.changedTouches[0];
-                  if (!touch) return;
-                  const el = document.elementFromPoint(touch.clientX, touch.clientY);
-                  const cell = el?.closest("[data-date]") as HTMLElement | null;
-                  const date = cell?.dataset.date;
-                  if (date) onDropReschedule(item.id, date);
-                }}
-              >
+              <li key={item.id} className="list-group-item py-2">
                 <div className="d-flex justify-content-between align-items-start gap-3">
                   <div>
                     <div className="fw-semibold">
@@ -642,7 +340,9 @@ export function PlannedItemsSidebar({
                     <small className="text-muted d-block">{formatPlannedMeta(item)}</small>
                     {item.notes ? <small className="d-block mt-1">{item.notes}</small> : null}
                     {item.linked_ref ? (
-                      <small className="d-block text-muted">{m.calendar_ref_label({ ref: item.linked_ref })}</small>
+                      <small className="d-block text-muted">
+                        {m.calendar_ref_label({ ref: item.linked_ref })}
+                      </small>
                     ) : null}
                   </div>
                   <div className="d-grid gap-2">

--- a/frontend/src/features/calendar/calendar.css
+++ b/frontend/src/features/calendar/calendar.css
@@ -1,0 +1,22 @@
+@import "@schedule-x/theme-default/dist/index.css";
+
+.daynest-calendar {
+  --sx-color-primary: var(--bs-primary);
+  --sx-color-on-primary: #fff;
+  --sx-color-primary-container: rgba(var(--bs-primary-rgb), 0.14);
+  --sx-color-on-primary-container: var(--bs-body-color);
+  --sx-color-surface: var(--bs-body-bg);
+  --sx-color-surface-container: var(--bs-tertiary-bg);
+  --sx-color-on-surface: var(--bs-body-color);
+  --sx-color-outline: var(--bs-border-color);
+  min-height: 44rem;
+}
+
+.daynest-calendar .sx-react-calendar-wrapper {
+  height: min(74vh, 52rem);
+}
+
+.calendar-event-modal {
+  background: rgba(0, 0, 0, 0.45);
+  z-index: 1080;
+}

--- a/frontend/src/features/calendar/mapToScheduleXEvents.ts
+++ b/frontend/src/features/calendar/mapToScheduleXEvents.ts
@@ -29,6 +29,7 @@ export function mapToScheduleXEvents(items: UnifiedDayItem[]): CalendarEvent[] {
       _status: item.status,
       _itemId: item.item_id,
       _moduleKey: item.module_key,
+      _options: item.item_type === "planned" ? undefined : { disableDND: true },
     };
   });
 }

--- a/frontend/src/mocks/handlers/today.ts
+++ b/frontend/src/mocks/handlers/today.ts
@@ -50,6 +50,49 @@ export const todayHandlers = [
     return HttpResponse.json({ year, month, days });
   }),
 
+  http.get("/api/calendar/range", ({ request }) => {
+    const url = new URL(request.url);
+    const start = url.searchParams.get("start") ?? MOCK_TODAY;
+    const payload = getTodayPayload();
+    return HttpResponse.json({
+      items: [
+        ...payload.routines.map((r) => ({
+          item_type: "routine" as const,
+          item_id: r.task_instance_id,
+          title: r.title,
+          status: r.status,
+          scheduled_at: r.due_at,
+          scheduled_date: r.scheduled_date,
+          detail: null,
+          module_key: null,
+        })),
+        ...payload.due_today.map((c) => ({
+          item_type: "chore" as const,
+          item_id: c.chore_instance_id,
+          title: c.title,
+          status: c.status,
+          scheduled_at: null,
+          scheduled_date: c.scheduled_date,
+          detail: null,
+          module_key: null,
+        })),
+        ...getMockState()
+          .plannedItems.filter((item) => item.planned_for >= start)
+          .map((item) => ({
+            item_type: "planned" as const,
+            item_id: item.id,
+            title: item.title,
+            status: item.is_done ? "done" : "planned",
+            scheduled_at: item.time_of_day ? `${item.planned_for}T${item.time_of_day}` : null,
+            scheduled_date: item.planned_for,
+            duration_minutes: item.duration_minutes,
+            detail: item.notes,
+            module_key: item.module_key,
+          })),
+      ],
+    });
+  }),
+
   http.get("/api/calendar/day", ({ request }) => {
     const url = new URL(request.url);
     const date = url.searchParams.get("date") ?? MOCK_TODAY;

--- a/frontend/tests/features/calendar/CalendarPage.test.tsx
+++ b/frontend/tests/features/calendar/CalendarPage.test.tsx
@@ -9,12 +9,15 @@ vi.mock("@tanstack/react-router", async (importOriginal) => {
   return {
     ...actual,
     useNavigate: () => vi.fn(),
-    useSearch: () => ({ month: undefined as string | undefined, date: undefined as string | undefined }),
+    useSearch: () => ({
+      month: undefined as string | undefined,
+      date: undefined as string | undefined,
+    }),
   };
 });
 
 const calendarApiMock = vi.hoisted(() => ({
-  fetchCalendarMonth: vi.fn(),
+  fetchCalendarRange: vi.fn(),
   fetchCalendarDay: vi.fn(),
   listPlannedItems: vi.fn(),
 }));
@@ -23,7 +26,7 @@ vi.mock("@/lib/api/today", async () => {
   const actual = await vi.importActual<typeof import("@/lib/api/today")>("@/lib/api/today");
   return {
     ...actual,
-    fetchCalendarMonth: calendarApiMock.fetchCalendarMonth,
+    fetchCalendarRange: calendarApiMock.fetchCalendarRange,
     fetchCalendarDay: calendarApiMock.fetchCalendarDay,
     listPlannedItems: calendarApiMock.listPlannedItems,
   };
@@ -31,22 +34,42 @@ vi.mock("@/lib/api/today", async () => {
 
 describe("CalendarPage", () => {
   beforeEach(() => {
-    calendarApiMock.fetchCalendarMonth.mockReset();
+    calendarApiMock.fetchCalendarRange.mockReset();
     calendarApiMock.fetchCalendarDay.mockReset();
     calendarApiMock.listPlannedItems.mockReset();
-    calendarApiMock.fetchCalendarMonth.mockResolvedValue({
-      year: 2026,
-      month: 5,
-      days: [{ date: "2026-05-16", total: 2, routines: 1, chores: 1, medications: 0, planned: 0 }],
+    calendarApiMock.fetchCalendarRange.mockResolvedValue({
+      items: [
+        {
+          item_type: "routine",
+          item_id: 1,
+          title: "Morning stretch",
+          status: "pending",
+          scheduled_at: null,
+          scheduled_date: "2026-05-16",
+          detail: null,
+          module_key: null,
+        },
+      ],
     });
     calendarApiMock.fetchCalendarDay.mockResolvedValue({
       date: "2026-05-16",
-      items: [{ item_type: "routine", item_id: 1, title: "Morning stretch", status: "pending", scheduled_at: null, scheduled_date: "2026-05-16", detail: null, module_key: null }],
+      items: [
+        {
+          item_type: "routine",
+          item_id: 1,
+          title: "Morning stretch",
+          status: "pending",
+          scheduled_at: null,
+          scheduled_date: "2026-05-16",
+          detail: null,
+          module_key: null,
+        },
+      ],
     });
     calendarApiMock.listPlannedItems.mockResolvedValue([]);
   });
 
-  it("renders month controls and extracted side panels", async () => {
+  it("renders Schedule-X controls and the retained planned item sidebar", async () => {
     render(
       <QueryTestProvider>
         <CalendarPage />
@@ -54,8 +77,9 @@ describe("CalendarPage", () => {
     );
 
     expect(await screen.findByRole("heading", { name: "Calendar" })).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "This month" })).toBeInTheDocument();
-    expect(await screen.findByText(/Day details/i)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Today" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Next period" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Select View" })).toBeInTheDocument();
     expect(screen.getByText("Quick add planned item")).toBeInTheDocument();
     expect(screen.getByLabelText("Repeat")).toBeInTheDocument();
     expect(screen.getByText("Backup export/import")).toBeInTheDocument();

--- a/frontend/tests/lib/calendar/mapToScheduleXEvents.test.ts
+++ b/frontend/tests/lib/calendar/mapToScheduleXEvents.test.ts
@@ -30,6 +30,7 @@ describe("mapToScheduleXEvents", () => {
         _status: "pending",
         _itemId: 42,
         _moduleKey: "shared_calendar",
+        _options: { disableDND: true },
       },
     ]);
   });


### PR DESCRIPTION
### Motivation
- Provide an opt-in, compact month-agenda calendar inside the Daynest Lovelace card so users can see scheduled routines, chores, medications and planned items in a navigable month view.
- Use the existing backend calendar range endpoint shape to fetch events on-demand and refresh on navigation or quick-add actions.

### Description
- Added two new Lovelace card options: `show_calendar` and `calendar_days_ahead` with editor controls and defaults, keeping the calendar opt-in. 
- Embedded Schedule‑X month‑agenda by adding `@schedule-x/calendar` and `@schedule-x/theme-default`, bundling its CSS into the card shadow DOM and mapping Home Assistant theme variables to Schedule‑X CSS variables. 
- Implemented calendar lifecycle and mapping: `createCalendar` is initialized after render, destroyed on disconnect or when disabled, and events are populated by `_fetchCalendarRange` which maps backend `UnifiedDayItem` objects to Schedule‑X `CalendarEvent`s. 
- Reused existing same‑origin bearer token behavior for calendar and analytics requests, added request-stale protection, and wired navigation callbacks to trigger range refetches; Rollup was configured to import CSS (`rollup-plugin-import-css`) and `src/css.d.ts` added for typings.

### Testing
- TypeScript type check: `cd dashboard && npx tsc --noEmit` — succeeded.
- Build: `cd dashboard && npm run build` (Rollup bundle created) — succeeded.
- Whitespace/patch check: `git diff --check` — no issues found.
- Preview capture with Playwright was attempted but failed because the runtime container lacks Playwright's Chromium executable; the mocked preview harness was created but screenshot could not be produced.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1ca772f8ec832eb40133b0979e6e0d)