### PR TITLE
feat(calendar): replace custom month grid with Schedule‑X calendar and add event modal

### DIFF
--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -132,6 +132,7 @@
   "calendar_n_items": "{count} items",
   "calendar_no_items": "No items",
   "calendar_module_label": "Module: {key}",
+  "calendar_status_label": "Status",
   "calendar_repeats": "🔁 Repeats",
   "calendar_repeat_hint": "🔁 {hint}",
   "calendar_repeat_label": "Repeat",

--- a/frontend/messages/nl.json
+++ b/frontend/messages/nl.json
@@ -132,6 +132,7 @@
   "calendar_n_items": "{count} items",
   "calendar_no_items": "Geen items",
   "calendar_module_label": "Module: {key}",
+  "calendar_status_label": "Status",
   "calendar_repeats": "🔁 Herhaalt",
   "calendar_repeat_hint": "🔁 {hint}",
   "calendar_repeat_label": "Herhalen",

--- a/frontend/src/features/calendar/CalendarEventModal.tsx
+++ b/frontend/src/features/calendar/CalendarEventModal.tsx
@@ -50,7 +50,8 @@ export function CalendarEventModal({
           </div>
           <div className="modal-body d-grid gap-2">
             <div>
-              <strong>Status:</strong> {item.status}
+              <strong>{m.calendar_status_label()}:</strong>{" "}
+              {item.status.charAt(0).toUpperCase() + item.status.slice(1)}
             </div>
             {item.detail ? <div>{item.detail}</div> : null}
             {item.scheduled_date ? (

--- a/frontend/src/features/calendar/CalendarEventModal.tsx
+++ b/frontend/src/features/calendar/CalendarEventModal.tsx
@@ -1,0 +1,139 @@
+import type { UnifiedDayItem } from "@/lib/api/today";
+import * as m from "@/paraglide/messages";
+
+export function CalendarEventModal({
+  item,
+  isRunning,
+  onClose,
+  onStartRoutine,
+  onCompleteRoutine,
+  onSkipRoutine,
+  onCompleteChore,
+  onSkipChore,
+  onRescheduleChore,
+  onEditPlanned,
+}: {
+  item: UnifiedDayItem | null;
+  isRunning: boolean;
+  onClose: () => void;
+  onStartRoutine: (itemId: number) => void;
+  onCompleteRoutine: (itemId: number) => void;
+  onSkipRoutine: (itemId: number) => void;
+  onCompleteChore: (itemId: number) => void;
+  onSkipChore: (itemId: number) => void;
+  onRescheduleChore: (itemId: number, scheduledDate: string) => void;
+  onEditPlanned: (itemId: number) => void;
+}) {
+  if (!item) return null;
+
+  return (
+    <div
+      className="calendar-event-modal modal d-block"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="calendar-event-modal-title"
+    >
+      <div className="modal-dialog modal-dialog-centered">
+        <div className="modal-content shadow">
+          <div className="modal-header">
+            <div>
+              <span
+                className={`badge text-bg-${item.item_type === "planned" ? "secondary" : item.item_type === "chore" ? "warning" : item.item_type === "medication" ? "info" : "primary"} mb-2`}
+              >
+                {item.item_type}
+              </span>
+              <h2 id="calendar-event-modal-title" className="h5 mb-0">
+                {item.title}
+              </h2>
+            </div>
+            <button type="button" className="btn-close" aria-label="Close" onClick={onClose} />
+          </div>
+          <div className="modal-body d-grid gap-2">
+            <div>
+              <strong>Status:</strong> {item.status}
+            </div>
+            {item.detail ? <div>{item.detail}</div> : null}
+            {item.scheduled_date ? (
+              <div className="text-muted small">{item.scheduled_date}</div>
+            ) : null}
+          </div>
+          <div className="modal-footer justify-content-start">
+            {item.item_type === "routine" ? (
+              <>
+                {item.status === "pending" ? (
+                  <button
+                    type="button"
+                    className="btn btn-primary"
+                    disabled={isRunning}
+                    onClick={() => onStartRoutine(item.item_id)}
+                  >
+                    {m.action_start()}
+                  </button>
+                ) : null}
+                <button
+                  type="button"
+                  className="btn btn-success"
+                  disabled={isRunning}
+                  onClick={() => onCompleteRoutine(item.item_id)}
+                >
+                  {m.action_done()}
+                </button>
+                <button
+                  type="button"
+                  className="btn btn-outline-secondary"
+                  disabled={isRunning}
+                  onClick={() => onSkipRoutine(item.item_id)}
+                >
+                  {m.action_skip()}
+                </button>
+              </>
+            ) : null}
+            {item.item_type === "chore" ? (
+              <>
+                <button
+                  type="button"
+                  className="btn btn-success"
+                  disabled={isRunning}
+                  onClick={() => onCompleteChore(item.item_id)}
+                >
+                  {m.action_done()}
+                </button>
+                <button
+                  type="button"
+                  className="btn btn-outline-secondary"
+                  disabled={isRunning}
+                  onClick={() => onSkipChore(item.item_id)}
+                >
+                  {m.action_skip()}
+                </button>
+                {item.scheduled_date ? (
+                  <button
+                    type="button"
+                    className="btn btn-outline-primary"
+                    disabled={isRunning}
+                    onClick={() => onRescheduleChore(item.item_id, item.scheduled_date!)}
+                  >
+                    {m.action_reschedule_1_day()}
+                  </button>
+                ) : null}
+              </>
+            ) : null}
+            {item.item_type === "planned" ? (
+              <button
+                type="button"
+                className="btn btn-primary"
+                disabled={isRunning}
+                onClick={() => onEditPlanned(item.item_id)}
+              >
+                {m.action_edit()}
+              </button>
+            ) : null}
+            <button type="button" className="btn btn-outline-secondary ms-auto" onClick={onClose}>
+              {m.action_cancel()}
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/features/calendar/CalendarPage.tsx
+++ b/frontend/src/features/calendar/CalendarPage.tsx
@@ -1,5 +1,4 @@
 import { useEffect, useMemo, useRef, useState } from "react";
-import { useQueryClient } from "@tanstack/react-query";
 import { useNavigate, useSearch } from "@tanstack/react-router";
 import {
   createViewDay,
@@ -13,7 +12,6 @@ import { ScheduleXCalendar, useCalendarApp } from "@schedule-x/react";
 import * as m from "@/paraglide/messages";
 import { isRetryableApiError, type UnifiedDayItem } from "@/lib/api/today";
 import { dayjs, toIsoDate } from "@/lib/dateUtils";
-import { queryKeys } from "@/lib/query/queryKeys";
 import { CalendarEventModal } from "@/features/calendar/CalendarEventModal";
 import { PlannedItemsSidebar } from "@/features/calendar/CalendarPageSections";
 import { CALENDAR_COLORS, mapToScheduleXEvents } from "@/features/calendar/mapToScheduleXEvents";
@@ -51,7 +49,6 @@ const calendarDefinitions = Object.fromEntries(
 export function CalendarPage() {
   const navigate = useNavigate();
   const search = useSearch({ from: "/protected/calendar" });
-  const queryClient = useQueryClient();
   const selectedDate = useMemo(() => toIsoDate(parseDate(search.date) ?? dayjs()), [search.date]);
   const initialMonth = useMemo(
     () => parseDate(search.month ? `${search.month}-01` : undefined) ?? dayjs(),
@@ -132,7 +129,6 @@ export function CalendarPage() {
       callbacks: {
         onRangeUpdate: (nextRange) => {
           setRange(nextRange);
-          void queryClient.invalidateQueries({ queryKey: queryKeys.calendarRange.all });
         },
         onSelectedDateUpdate: updateSearch,
         onEventClick: (event) =>

--- a/frontend/src/features/calendar/CalendarPage.tsx
+++ b/frontend/src/features/calendar/CalendarPage.tsx
@@ -1,19 +1,25 @@
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
+import { useQueryClient } from "@tanstack/react-query";
 import { useNavigate, useSearch } from "@tanstack/react-router";
+import {
+  createViewDay,
+  createViewMonthAgenda,
+  createViewMonthGrid,
+  createViewWeek,
+} from "@schedule-x/calendar";
+import { createDragAndDropPlugin } from "@schedule-x/drag-and-drop";
+import { createEventModalPlugin } from "@schedule-x/event-modal";
+import { ScheduleXCalendar, useCalendarApp } from "@schedule-x/react";
 import * as m from "@/paraglide/messages";
-import {
-  isRetryableApiError,
-} from "@/lib/api/today";
-import { dayjs, formatMonthYear, toIsoDate } from "@/lib/dateUtils";
-import {
-  CalendarMonthGrid,
-  DayDetailsPanel,
-  MonthNavigationControls,
-  PlannedItemsSidebar,
-} from "@/features/calendar/CalendarPageSections";
+import { isRetryableApiError, type UnifiedDayItem } from "@/lib/api/today";
+import { dayjs, toIsoDate } from "@/lib/dateUtils";
+import { queryKeys } from "@/lib/query/queryKeys";
+import { CalendarEventModal } from "@/features/calendar/CalendarEventModal";
+import { PlannedItemsSidebar } from "@/features/calendar/CalendarPageSections";
+import { CALENDAR_COLORS, mapToScheduleXEvents } from "@/features/calendar/mapToScheduleXEvents";
+import { useCalendarPlannedItems } from "@/features/calendar/useCalendarPlannedItems";
 import {
   useCalendarDayQuery,
-  useCalendarMonthQuery,
   useCalendarPlannedItemsQuery,
   useCompleteChoreMutation,
   useCompleteRoutineTaskMutation,
@@ -22,40 +28,43 @@ import {
   useSkipRoutineTaskMutation,
   useStartRoutineTaskMutation,
 } from "@/features/calendar/useCalendarQueries";
-import { useCalendarPlannedItems } from "@/features/calendar/useCalendarPlannedItems";
-
-function parseMonth(value?: string) {
-  if (!value) return null;
-  const parsed = dayjs(`${value}-01`);
-  if (!parsed.isValid() || parsed.format("YYYY-MM") !== value) {
-    return null;
-  }
-  return parsed;
-}
+import { useCalendarRangeQuery } from "@/features/calendar/useCalendarRangeQuery";
+import "@/features/calendar/calendar.css";
 
 function parseDate(value?: string) {
   if (!value) return null;
   const parsed = dayjs(value);
-  if (!parsed.isValid() || parsed.format("YYYY-MM-DD") !== value) {
-    return null;
-  }
-  return parsed;
+  return parsed.isValid() && parsed.format("YYYY-MM-DD") === value ? parsed : null;
 }
+
+const calendarDefinitions = Object.fromEntries(
+  Object.entries(CALENDAR_COLORS).map(([id, color]) => [
+    id,
+    {
+      colorName: id,
+      lightColors: { main: color, container: `${color}22`, onContainer: "#212529" },
+      darkColors: { main: color, container: `${color}44`, onContainer: "#f8f9fa" },
+    },
+  ]),
+);
 
 export function CalendarPage() {
   const navigate = useNavigate();
   const search = useSearch({ from: "/protected/calendar" });
-  const currentMonth = useMemo(() => parseMonth(search.month) ?? dayjs(), [search.month]);
+  const queryClient = useQueryClient();
   const selectedDate = useMemo(() => toIsoDate(parseDate(search.date) ?? dayjs()), [search.date]);
+  const initialMonth = useMemo(
+    () => parseDate(search.month ? `${search.month}-01` : undefined) ?? dayjs(),
+    [search.month],
+  );
+  const [range, setRange] = useState(() => ({
+    start: initialMonth.startOf("month").format("YYYY-MM-DD"),
+    end: initialMonth.endOf("month").format("YYYY-MM-DD"),
+  }));
+  const [selectedItem, setSelectedItem] = useState<UnifiedDayItem | null>(null);
   const [dayActionStatus, setDayActionStatus] = useState<string | null>(null);
   const [isRunningDayAction, setIsRunningDayAction] = useState(false);
-
-  const monthKey = useMemo(
-    () => ({ year: currentMonth.year(), month: currentMonth.month() + 1 }),
-    [currentMonth],
-  );
-  const monthStart = currentMonth.startOf("month");
-  const monthQuery = useCalendarMonthQuery(monthKey.year, monthKey.month);
+  const rangeQuery = useCalendarRangeQuery(range);
   const dayQuery = useCalendarDayQuery(selectedDate);
   const plannedQuery = useCalendarPlannedItemsQuery(selectedDate);
   const startRoutineTaskMutation = useStartRoutineTaskMutation();
@@ -65,31 +74,39 @@ export function CalendarPage() {
   const skipChoreMutation = useSkipChoreMutation();
   const rescheduleChoreMutation = useRescheduleChoreMutation();
 
-  const updateSearch = (nextMonth: dayjs.Dayjs, nextDate: string) => {
-    void navigate({
-      to: "/calendar",
-      search: {
-        month: nextMonth.format("YYYY-MM"),
-        date: nextDate,
-      },
-      replace: true,
-    });
-  };
-
+  const updateSearch = (date: string) =>
+    void navigate({ to: "/calendar", search: { date, month: date.slice(0, 7) }, replace: true });
   const reloadCalendar = async () => {
-    await Promise.all([monthQuery.refetch(), dayQuery.refetch(), plannedQuery.refetch()]);
+    await Promise.all([rangeQuery.refetch(), dayQuery.refetch(), plannedQuery.refetch()]);
   };
-
   const planned = useCalendarPlannedItems({
     selectedDate,
-    monthStart,
-    monthKey,
+    monthStart: dayjs(range.start),
+    monthKey: { year: dayjs(range.start).year(), month: dayjs(range.start).month() + 1 },
     loadCalendar: reloadCalendar,
   });
 
-  useEffect(() => {
-    planned.setPlannedItems(plannedQuery.data ?? []);
-  }, [plannedQuery.data]);
+  useEffect(() => planned.setPlannedItems(plannedQuery.data ?? []), [plannedQuery.data]);
+
+  const itemsByEventId = useMemo(
+    () =>
+      new Map(
+        (rangeQuery.data?.items ?? []).map((item) => [`${item.item_type}-${item.item_id}`, item]),
+      ),
+    [rangeQuery.data],
+  );
+  const liveRef = useRef({ itemsByEventId, planned });
+  liveRef.current = { itemsByEventId, planned };
+  const events = useMemo(
+    () => mapToScheduleXEvents(rangeQuery.data?.items ?? []),
+    [rangeQuery.data],
+  );
+  const plugins = useMemo(() => [createDragAndDropPlugin(), createEventModalPlugin()], []);
+  const views = useMemo(
+    () =>
+      [createViewMonthGrid(), createViewWeek(), createViewDay(), createViewMonthAgenda()] as const,
+    [],
+  );
 
   const runDayItemAction = async (action: () => Promise<unknown>, successMessage: string) => {
     setDayActionStatus(null);
@@ -98,6 +115,7 @@ export function CalendarPage() {
     try {
       await action();
       setDayActionStatus(successMessage);
+      setSelectedItem(null);
     } catch (err) {
       planned.setAddError(err instanceof Error ? err.message : "Action failed.");
     } finally {
@@ -105,37 +123,76 @@ export function CalendarPage() {
     }
   };
 
-  const loading = monthQuery.isPending || dayQuery.isPending || plannedQuery.isPending;
-  const queryError = monthQuery.error ?? dayQuery.error ?? plannedQuery.error;
-  const error = queryError instanceof Error ? queryError.message : queryError ? "Unable to load calendar view." : null;
-  const canRetry = queryError ? isRetryableApiError(queryError) : false;
+  const calendar = useCalendarApp(
+    {
+      views: [...views],
+      events,
+      selectedDate,
+      calendars: calendarDefinitions,
+      callbacks: {
+        onRangeUpdate: (nextRange) => {
+          setRange(nextRange);
+          void queryClient.invalidateQueries({ queryKey: queryKeys.calendarRange.all });
+        },
+        onSelectedDateUpdate: updateSearch,
+        onEventClick: (event) =>
+          setSelectedItem(liveRef.current.itemsByEventId.get(String(event.id)) ?? null),
+        onEventUpdate: (event) => {
+          if (event._type !== "planned") return;
+          void liveRef.current.planned.dragReschedulePlannedItem(
+            Number(event._itemId),
+            event.start.slice(0, 10),
+          );
+        },
+        onClickDate: (date) => {
+          updateSearch(date);
+          liveRef.current.planned.resetPlannedForm();
+        },
+        onClickDateTime: (dateTime) => {
+          updateSearch(dateTime.slice(0, 10));
+          liveRef.current.planned.resetPlannedForm();
+          liveRef.current.planned.setTimeOfDay(dateTime.slice(11, 16));
+        },
+      },
+    },
+    plugins,
+  );
+
+  useEffect(() => {
+    calendar?.events.set(events);
+  }, [calendar, events]);
+
+  const loading = rangeQuery.isPending || dayQuery.isPending || plannedQuery.isPending;
+  const queryError = rangeQuery.error ?? dayQuery.error ?? plannedQuery.error;
+  const error =
+    queryError instanceof Error
+      ? queryError.message
+      : queryError
+        ? "Unable to load calendar view."
+        : null;
 
   return (
     <section>
-      <MonthNavigationControls
-        onRefresh={() => void reloadCalendar()}
-        onPrevMonth={() => {
-          const nextMonth = currentMonth.subtract(1, "month");
-          updateSearch(nextMonth, selectedDate);
-        }}
-        onCurrentMonth={() => {
-          const nextMonth = dayjs();
-          const nextDate = toIsoDate(nextMonth);
-          updateSearch(nextMonth, nextDate);
-        }}
-        onNextMonth={() => {
-          const nextMonth = currentMonth.add(1, "month");
-          updateSearch(nextMonth, selectedDate);
-        }}
-      />
-      <p className="text-muted">{formatMonthYear(monthStart)} {m.calendar_subtitle()}</p>
-
+      <div className="d-flex justify-content-between align-items-center gap-2 mb-2">
+        <h2 className="h4 mb-0">{m.calendar_title()}</h2>
+        <button
+          type="button"
+          className="btn btn-outline-primary btn-sm"
+          onClick={() => void reloadCalendar()}
+        >
+          {m.action_refresh()}
+        </button>
+      </div>
       {loading ? <div className="alert alert-info py-2">{m.calendar_loading()}</div> : null}
       {error ? (
-        <div className="alert alert-danger py-2 d-flex justify-content-between align-items-center gap-2 flex-wrap">
+        <div className="alert alert-danger py-2 d-flex justify-content-between align-items-center gap-2">
           <span>{error}</span>
-          {canRetry ? (
-            <button type="button" className="btn btn-danger btn-sm" onClick={() => void reloadCalendar()}>
+          {isRetryableApiError(queryError) ? (
+            <button
+              type="button"
+              className="btn btn-danger btn-sm"
+              onClick={() => void reloadCalendar()}
+            >
               {m.action_retry()}
             </button>
           ) : null}
@@ -147,50 +204,16 @@ export function CalendarPage() {
       {planned.addError && planned.editingPlannedItemId === null ? (
         <div className="alert alert-danger py-2">{planned.addError}</div>
       ) : null}
-
       <div className="row g-3">
-        <div className="col-lg-7">
-          <CalendarMonthGrid
-            monthStart={monthStart}
-            monthItems={monthQuery.data?.days ?? []}
-            selectedDate={selectedDate}
-            onSelectDate={(date) => {
-              updateSearch(currentMonth, date);
-            }}
-            onDropReschedule={planned.dragReschedulePlannedItem}
-          />
+        <div className="col-xl-8">
+          <div className="daynest-calendar card p-2">
+            <ScheduleXCalendar
+              calendarApp={calendar}
+              customComponents={{ eventModal: () => null }}
+            />
+          </div>
         </div>
-
-        <div className="col-lg-5">
-          <DayDetailsPanel
-            selectedDate={selectedDate}
-            dayItems={dayQuery.data?.items ?? []}
-            isAdding={planned.isAdding || isRunningDayAction}
-            onStartRoutine={(itemId) =>
-              runDayItemAction(() => startRoutineTaskMutation.mutateAsync(itemId), m.action_start())
-            }
-            onCompleteRoutine={(itemId) =>
-              runDayItemAction(() => completeRoutineTaskMutation.mutateAsync(itemId), m.action_done())
-            }
-            onSkipRoutine={(itemId) =>
-              runDayItemAction(() => skipRoutineTaskMutation.mutateAsync(itemId), m.action_skip())
-            }
-            onCompleteChore={(itemId) =>
-              runDayItemAction(() => completeChoreMutation.mutateAsync(itemId), m.action_done())
-            }
-            onSkipChore={(itemId) => runDayItemAction(() => skipChoreMutation.mutateAsync(itemId), m.action_skip())}
-            onRescheduleChore={(itemId, scheduledDate) =>
-              runDayItemAction(
-                () =>
-                  rescheduleChoreMutation.mutateAsync({
-                    choreInstanceId: itemId,
-                    scheduledDate: toIsoDate(dayjs(scheduledDate).add(1, "day")),
-                  }),
-                m.action_reschedule_1_day(),
-              )
-            }
-          />
-
+        <div className="col-xl-4">
           <PlannedItemsSidebar
             selectedDate={selectedDate}
             plannedItems={planned.plannedItems}
@@ -211,54 +234,18 @@ export function CalendarPage() {
             confirmDeleteId={planned.confirmDeleteId}
             isAdding={planned.isAdding || isRunningDayAction}
             addError={planned.addError}
-            onSetTitle={(value) => {
-              planned.setTitle(value);
-              planned.setAddError(null);
-            }}
-            onSetTimeOfDay={(value) => {
-              planned.setTimeOfDay(value);
-              planned.setAddError(null);
-            }}
-            onSetDurationMinutes={(value) => {
-              planned.setDurationMinutes(value);
-              planned.setAddError(null);
-            }}
-            onSetNotes={(value) => {
-              planned.setNotes(value);
-              planned.setAddError(null);
-            }}
-            onSetModuleKey={(value) => {
-              planned.setModuleKey(value);
-              planned.setAddError(null);
-            }}
-            onSetRecurrenceHint={(value) => {
-              planned.setRecurrenceHint(value);
-              planned.setAddError(null);
-            }}
-            onSetIsRepeating={(value) => {
-              planned.setIsRepeating(value);
-              planned.setAddError(null);
-            }}
-            onSetRepeatPreset={(value) => {
-              planned.setRepeatPreset(value);
-              planned.setAddError(null);
-            }}
-            onSetRepeatWeekdays={(value) => {
-              planned.setRepeatWeekdays(value);
-              planned.setAddError(null);
-            }}
-            onSetCustomInterval={(value) => {
-              planned.setCustomInterval(value);
-              planned.setAddError(null);
-            }}
-            onSetLinkedSource={(value) => {
-              planned.setLinkedSource(value);
-              planned.setAddError(null);
-            }}
-            onSetLinkedRef={(value) => {
-              planned.setLinkedRef(value);
-              planned.setAddError(null);
-            }}
+            onSetTitle={planned.setTitle}
+            onSetTimeOfDay={planned.setTimeOfDay}
+            onSetDurationMinutes={planned.setDurationMinutes}
+            onSetNotes={planned.setNotes}
+            onSetModuleKey={planned.setModuleKey}
+            onSetRecurrenceHint={planned.setRecurrenceHint}
+            onSetIsRepeating={planned.setIsRepeating}
+            onSetRepeatPreset={planned.setRepeatPreset}
+            onSetRepeatWeekdays={planned.setRepeatWeekdays}
+            onSetCustomInterval={planned.setCustomInterval}
+            onSetLinkedSource={planned.setLinkedSource}
+            onSetLinkedRef={planned.setLinkedRef}
             onSetEditScope={planned.setEditScope}
             onAddPlanned={planned.onAddPlanned}
             onCancelEdit={planned.resetPlannedForm}
@@ -272,10 +259,44 @@ export function CalendarPage() {
             fileInputRef={planned.fileInputRef}
             onExportBackup={planned.onExportBackup}
             onImportFile={planned.onImportFile}
-            onDropReschedule={planned.dragReschedulePlannedItem}
           />
         </div>
       </div>
+      <CalendarEventModal
+        item={selectedItem}
+        isRunning={isRunningDayAction}
+        onClose={() => setSelectedItem(null)}
+        onStartRoutine={(id) =>
+          void runDayItemAction(() => startRoutineTaskMutation.mutateAsync(id), m.action_start())
+        }
+        onCompleteRoutine={(id) =>
+          void runDayItemAction(() => completeRoutineTaskMutation.mutateAsync(id), m.action_done())
+        }
+        onSkipRoutine={(id) =>
+          void runDayItemAction(() => skipRoutineTaskMutation.mutateAsync(id), m.action_skip())
+        }
+        onCompleteChore={(id) =>
+          void runDayItemAction(() => completeChoreMutation.mutateAsync(id), m.action_done())
+        }
+        onSkipChore={(id) =>
+          void runDayItemAction(() => skipChoreMutation.mutateAsync(id), m.action_skip())
+        }
+        onRescheduleChore={(id, date) =>
+          void runDayItemAction(
+            () =>
+              rescheduleChoreMutation.mutateAsync({
+                choreInstanceId: id,
+                scheduledDate: toIsoDate(dayjs(date).add(1, "day")),
+              }),
+            m.action_reschedule_1_day(),
+          )
+        }
+        onEditPlanned={(id) => {
+          const item = planned.plannedItems.find((candidate) => candidate.id === id);
+          if (item) planned.startEditing(item);
+          setSelectedItem(null);
+        }}
+      />
     </section>
   );
 }

--- a/frontend/src/features/calendar/CalendarPageSections.tsx
+++ b/frontend/src/features/calendar/CalendarPageSections.tsx
@@ -1,23 +1,11 @@
-import { useMemo, useRef, useState, type ChangeEvent, type RefObject } from "react";
-import type { Dayjs } from "dayjs";
+import type { ChangeEvent, RefObject } from "react";
 import * as m from "@/paraglide/messages";
-import { capitalize, formatDate, toIsoDate } from "@/lib/dateUtils";
-import { type CalendarDayPayload, type CalendarMonthDaySummary, type PlannedItemEditScope, type PlannedItemModuleKey, type PlannedTodayItem } from "@/lib/api/today";
-
-function itemBadgeClass(itemType: string): string {
-  if (itemType === "medication") return "text-bg-info";
-  if (itemType === "routine") return "text-bg-primary";
-  if (itemType === "chore") return "text-bg-warning";
-  return "text-bg-secondary";
-}
-
-function dayItemStatusClass(status: string): string {
-  if (status === "done" || status === "completed" || status === "taken") return "text-bg-success";
-  if (status === "pending") return "text-bg-warning";
-  if (status === "scheduled") return "text-bg-info";
-  if (status === "missed") return "text-bg-danger";
-  return "text-bg-secondary";
-}
+import { formatDate } from "@/lib/dateUtils";
+import {
+  type PlannedItemEditScope,
+  type PlannedItemModuleKey,
+  type PlannedTodayItem,
+} from "@/lib/api/today";
 
 function formatPlannedMeta(item: PlannedTodayItem): string {
   const timeAndDuration = [
@@ -41,16 +29,6 @@ function formatPlannedMeta(item: PlannedTodayItem): string {
   return values.filter(Boolean).join(" • ");
 }
 
-const WEEKDAYS = [
-  m.calendar_weekday_mon,
-  m.calendar_weekday_tue,
-  m.calendar_weekday_wed,
-  m.calendar_weekday_thu,
-  m.calendar_weekday_fri,
-  m.calendar_weekday_sat,
-  m.calendar_weekday_sun,
-];
-
 const WEEKDAY_REPEAT_OPTIONS = [
   { code: "MO", label: m.calendar_weekday_mon },
   { code: "TU", label: m.calendar_weekday_tue },
@@ -60,252 +38,6 @@ const WEEKDAY_REPEAT_OPTIONS = [
   { code: "SA", label: m.calendar_weekday_sat },
   { code: "SU", label: m.calendar_weekday_sun },
 ] as const;
-
-export function MonthNavigationControls({
-  onRefresh,
-  onPrevMonth,
-  onCurrentMonth,
-  onNextMonth,
-}: {
-  onRefresh: () => void;
-  onPrevMonth: () => void;
-  onCurrentMonth: () => void;
-  onNextMonth: () => void;
-}) {
-  return (
-    <div className="d-flex flex-column gap-2 mb-2">
-      <div className="d-flex justify-content-between align-items-center">
-        <h2 className="h4 mb-0">{m.calendar_title()}</h2>
-        <button type="button" className="btn btn-outline-primary btn-sm" onClick={onRefresh}>
-          {m.action_refresh()}
-        </button>
-      </div>
-      <div className="btn-group btn-group-sm w-100" role="group" aria-label="Quick month controls">
-        <button type="button" className="btn btn-outline-secondary" onClick={onPrevMonth}>
-          {m.calendar_prev()}
-        </button>
-        <button type="button" className="btn btn-outline-secondary" onClick={onCurrentMonth}>
-          {m.calendar_this_month()}
-        </button>
-        <button type="button" className="btn btn-outline-secondary" onClick={onNextMonth}>
-          {m.calendar_next()}
-        </button>
-      </div>
-    </div>
-  );
-}
-
-export function CalendarMonthGrid({
-  monthStart,
-  monthItems,
-  selectedDate,
-  onSelectDate,
-  onDropReschedule,
-}: {
-  monthStart: Dayjs;
-  monthItems: CalendarMonthDaySummary[];
-  selectedDate: string;
-  onSelectDate: (date: string) => void;
-  onDropReschedule?: (itemId: number, date: string) => void;
-}) {
-  const daysInMonth = monthStart.daysInMonth();
-  const leadingEmptyDays = (monthStart.day() + 6) % 7;
-  const totalCalendarCells = Math.ceil((leadingEmptyDays + daysInMonth) / 7) * 7;
-  const itemsByDate = useMemo(() => new Map(monthItems.map((item) => [item.date, item])), [monthItems]);
-  const [dragOverDate, setDragOverDate] = useState<string | null>(null);
-
-  return (
-    <div className="card">
-      <div className="card-body p-2 p-md-3">
-        <div className="row row-cols-7 g-1 g-md-2">
-          {WEEKDAYS.map((wd) => (
-            <div key={wd()} className="col text-center small fw-semibold text-muted">
-              {wd()}
-            </div>
-          ))}
-          {Array.from({ length: totalCalendarCells }).map((_, idx) => {
-            const dayNumber = idx - leadingEmptyDays + 1;
-            if (dayNumber < 1 || dayNumber > daysInMonth) {
-              return <div key={`empty-${idx}`} className="col" aria-hidden="true" />;
-            }
-            const dateValue = toIsoDate(monthStart.date(dayNumber));
-            const summary = itemsByDate.get(dateValue);
-            const selected = selectedDate === dateValue;
-            const isDragTarget = !selected && dragOverDate === dateValue;
-            const cellClass = `btn w-100 text-start py-2 ${selected ? "btn-primary" : isDragTarget ? "btn-outline-success" : "btn-outline-secondary"}`;
-            return (
-              <div key={dateValue} className="col">
-                <button
-                  type="button"
-                  className={cellClass}
-                  onClick={() => onSelectDate(dateValue)}
-                  data-date={dateValue}
-                  onDragOver={onDropReschedule ? (e) => { e.preventDefault(); setDragOverDate(dateValue); } : undefined}
-                  onDragLeave={onDropReschedule ? () => setDragOverDate(null) : undefined}
-                  onDrop={onDropReschedule ? (e) => {
-                    e.preventDefault();
-                    setDragOverDate(null);
-                    const rawId = e.dataTransfer.getData("plannedItemId");
-                    const itemId = parseInt(rawId, 10);
-                    if (!isNaN(itemId)) onDropReschedule(itemId, dateValue);
-                  } : undefined}
-                >
-                  <div className="fw-semibold lh-1">{dayNumber}</div>
-                  <small>{summary ? m.calendar_n_items({ count: summary.total }) : m.calendar_no_items()}</small>
-                  {summary ? (
-                    <div className="calendar-cell-meta mt-2">
-                      {summary.routines ? (
-                        <span className="badge text-bg-primary-subtle text-primary-emphasis">
-                          {summary.routines}R
-                        </span>
-                      ) : null}
-                      {summary.chores ? (
-                        <span className="badge text-bg-warning-subtle text-warning-emphasis">
-                          {summary.chores}C
-                        </span>
-                      ) : null}
-                      {summary.medications ? (
-                        <span className="badge text-bg-info-subtle text-info-emphasis">
-                          {summary.medications}M
-                        </span>
-                      ) : null}
-                      {summary.planned ? (
-                        <span className="badge text-bg-secondary">{summary.planned}P</span>
-                      ) : null}
-                    </div>
-                  ) : null}
-                </button>
-              </div>
-            );
-          })}
-        </div>
-      </div>
-    </div>
-  );
-}
-
-export function DayDetailsPanel({
-  selectedDate,
-  dayItems,
-  isAdding,
-  onStartRoutine,
-  onCompleteRoutine,
-  onSkipRoutine,
-  onCompleteChore,
-  onSkipChore,
-  onRescheduleChore,
-}: {
-  selectedDate: string;
-  dayItems: CalendarDayPayload["items"];
-  isAdding: boolean;
-  onStartRoutine: (itemId: number) => Promise<void>;
-  onCompleteRoutine: (itemId: number) => Promise<void>;
-  onSkipRoutine: (itemId: number) => Promise<void>;
-  onCompleteChore: (itemId: number) => Promise<void>;
-  onSkipChore: (itemId: number) => Promise<void>;
-  onRescheduleChore: (itemId: number, scheduledDate: string) => Promise<void>;
-}) {
-  return (
-    <div className="card mb-3">
-      <div className="card-header fw-semibold py-2">{m.calendar_day_details_header({ date: formatDate(selectedDate) })}</div>
-      <ul className="list-group list-group-flush">
-        {dayItems.length === 0 ? (
-          <li className="list-group-item py-2 text-muted">{m.calendar_no_items_for_day()}</li>
-        ) : (
-          dayItems.map((item) => (
-            <li key={`${item.item_type}-${item.item_id}`} className="list-group-item py-2">
-              <div className="d-flex justify-content-between align-items-start gap-3">
-                <div>
-                  <div className="fw-semibold">
-                    {item.rrule || item.recurrence_series_id ? "🔁 " : ""}
-                    {item.title}
-                  </div>
-                  <small className="text-muted">{capitalize(item.status)}</small>
-                  {item.detail ? <small className="d-block">{item.detail}</small> : null}
-                  {item.module_key ? (
-                    <small className="d-block text-muted">{m.calendar_module_label({ key: item.module_key })}</small>
-                  ) : null}
-                  <div className="d-flex gap-2 flex-wrap mt-2">
-                    {item.item_type === "routine" && item.status === "pending" ? (
-                      <button
-                        type="button"
-                        className="btn btn-outline-primary btn-sm"
-                        disabled={isAdding}
-                        onClick={() => void onStartRoutine(item.item_id)}
-                      >
-                        {m.action_start()}
-                      </button>
-                    ) : null}
-                    {item.item_type === "routine" &&
-                    item.status !== "completed" &&
-                    item.status !== "skipped" ? (
-                      <>
-                        <button
-                          type="button"
-                          className="btn btn-success btn-sm"
-                          disabled={isAdding}
-                          onClick={() => void onCompleteRoutine(item.item_id)}
-                        >
-                          {m.action_done()}
-                        </button>
-                        <button
-                          type="button"
-                          className="btn btn-outline-secondary btn-sm"
-                          disabled={isAdding}
-                          onClick={() => void onSkipRoutine(item.item_id)}
-                        >
-                          {m.action_skip()}
-                        </button>
-                      </>
-                    ) : null}
-                    {item.item_type === "chore" && item.status === "pending" ? (
-                      <>
-                        <button
-                          type="button"
-                          className="btn btn-success btn-sm"
-                          disabled={isAdding}
-                          onClick={() => void onCompleteChore(item.item_id)}
-                        >
-                          {m.action_done()}
-                        </button>
-                        <button
-                          type="button"
-                          className="btn btn-outline-secondary btn-sm"
-                          disabled={isAdding}
-                          onClick={() => void onSkipChore(item.item_id)}
-                        >
-                          {m.action_skip()}
-                        </button>
-                        {item.scheduled_date ? (
-                          <button
-                            type="button"
-                            className="btn btn-outline-primary btn-sm"
-                            disabled={isAdding}
-                            onClick={() =>
-                              void onRescheduleChore(item.item_id, item.scheduled_date as string)
-                            }
-                          >
-                            {m.action_reschedule_1_day()}
-                          </button>
-                        ) : null}
-                      </>
-                    ) : null}
-                  </div>
-                </div>
-                <div className="d-grid gap-1 text-end">
-                  <span className={`badge ${itemBadgeClass(item.item_type)}`}>{item.item_type}</span>
-                  <span className={`badge ${dayItemStatusClass(item.status)}`}>
-                    {capitalize(item.status)}
-                  </span>
-                </div>
-              </div>
-            </li>
-          ))
-        )}
-      </ul>
-    </div>
-  );
-}
 
 export function PlannedItemsSidebar({
   selectedDate,
@@ -352,7 +84,6 @@ export function PlannedItemsSidebar({
   fileInputRef,
   onExportBackup,
   onImportFile,
-  onDropReschedule,
 }: {
   selectedDate: string;
   plannedItems: PlannedTodayItem[];
@@ -398,9 +129,7 @@ export function PlannedItemsSidebar({
   fileInputRef: RefObject<HTMLInputElement | null>;
   onExportBackup: () => Promise<void>;
   onImportFile: (event: ChangeEvent<HTMLInputElement>) => Promise<void>;
-  onDropReschedule?: (itemId: number, date: string) => void;
 }) {
-  const touchCloneRef = useRef<HTMLElement | null>(null);
   return (
     <>
       <div className="card mb-3">
@@ -474,7 +203,9 @@ export function PlannedItemsSidebar({
                   className="form-select"
                   value={repeatPreset}
                   onChange={(event) =>
-                    onSetRepeatPreset(event.target.value as "daily" | "weekly" | "monthly" | "custom")
+                    onSetRepeatPreset(
+                      event.target.value as "daily" | "weekly" | "monthly" | "custom",
+                    )
                   }
                   aria-label={m.calendar_repeat_schedule_aria()}
                 >
@@ -591,48 +322,15 @@ export function PlannedItemsSidebar({
       </div>
 
       <div className="card mb-3">
-        <div className="card-header fw-semibold py-2">{m.calendar_planned_items_header({ date: formatDate(selectedDate) })}</div>
+        <div className="card-header fw-semibold py-2">
+          {m.calendar_planned_items_header({ date: formatDate(selectedDate) })}
+        </div>
         <ul className="list-group list-group-flush">
           {plannedItems.length === 0 ? (
             <li className="list-group-item py-2 text-muted">{m.calendar_no_planned_items()}</li>
           ) : (
             plannedItems.map((item) => (
-              <li
-                key={item.id}
-                className="list-group-item py-2"
-                draggable
-                onDragStart={(e) => {
-                  e.dataTransfer.setData("plannedItemId", String(item.id));
-                  e.dataTransfer.effectAllowed = "move";
-                }}
-                onTouchStart={(e) => {
-                  if (!onDropReschedule) return;
-                  const rect = e.currentTarget.getBoundingClientRect();
-                  const clone = e.currentTarget.cloneNode(true) as HTMLElement;
-                  clone.style.cssText = `position:fixed;top:${rect.top}px;left:${rect.left}px;width:${rect.width}px;opacity:0.75;pointer-events:none;z-index:9999;background:var(--bs-body-bg);border:1px solid var(--bs-border-color);border-radius:4px;`;
-                  document.body.appendChild(clone);
-                  touchCloneRef.current = clone;
-                }}
-                onTouchMove={(e) => {
-                  if (!touchCloneRef.current) return;
-                  e.preventDefault();
-                  const touch = e.touches[0];
-                  if (!touch) return;
-                  touchCloneRef.current.style.top = `${touch.clientY - 20}px`;
-                  touchCloneRef.current.style.left = `${touch.clientX - 20}px`;
-                }}
-                onTouchEnd={(e) => {
-                  touchCloneRef.current?.remove();
-                  touchCloneRef.current = null;
-                  if (!onDropReschedule) return;
-                  const touch = e.changedTouches[0];
-                  if (!touch) return;
-                  const el = document.elementFromPoint(touch.clientX, touch.clientY);
-                  const cell = el?.closest("[data-date]") as HTMLElement | null;
-                  const date = cell?.dataset.date;
-                  if (date) onDropReschedule(item.id, date);
-                }}
-              >
+              <li key={item.id} className="list-group-item py-2">
                 <div className="d-flex justify-content-between align-items-start gap-3">
                   <div>
                     <div className="fw-semibold">
@@ -642,7 +340,9 @@ export function PlannedItemsSidebar({
                     <small className="text-muted d-block">{formatPlannedMeta(item)}</small>
                     {item.notes ? <small className="d-block mt-1">{item.notes}</small> : null}
                     {item.linked_ref ? (
-                      <small className="d-block text-muted">{m.calendar_ref_label({ ref: item.linked_ref })}</small>
+                      <small className="d-block text-muted">
+                        {m.calendar_ref_label({ ref: item.linked_ref })}
+                      </small>
                     ) : null}
                   </div>
                   <div className="d-grid gap-2">

--- a/frontend/src/features/calendar/calendar.css
+++ b/frontend/src/features/calendar/calendar.css
@@ -1,0 +1,22 @@
+@import "@schedule-x/theme-default/dist/index.css";
+
+.daynest-calendar {
+  --sx-color-primary: var(--bs-primary);
+  --sx-color-on-primary: #fff;
+  --sx-color-primary-container: rgba(var(--bs-primary-rgb), 0.14);
+  --sx-color-on-primary-container: var(--bs-body-color);
+  --sx-color-surface: var(--bs-body-bg);
+  --sx-color-surface-container: var(--bs-tertiary-bg);
+  --sx-color-on-surface: var(--bs-body-color);
+  --sx-color-outline: var(--bs-border-color);
+  min-height: 44rem;
+}
+
+.daynest-calendar .sx-react-calendar-wrapper {
+  height: min(74vh, 52rem);
+}
+
+.calendar-event-modal {
+  background: rgba(0, 0, 0, 0.45);
+  z-index: 1080;
+}

--- a/frontend/src/features/calendar/mapToScheduleXEvents.ts
+++ b/frontend/src/features/calendar/mapToScheduleXEvents.ts
@@ -29,6 +29,7 @@ export function mapToScheduleXEvents(items: UnifiedDayItem[]): CalendarEvent[] {
       _status: item.status,
       _itemId: item.item_id,
       _moduleKey: item.module_key,
+      _options: item.item_type === "planned" ? undefined : { disableDND: true },
     };
   });
 }

--- a/frontend/src/mocks/handlers/today.ts
+++ b/frontend/src/mocks/handlers/today.ts
@@ -50,6 +50,49 @@ export const todayHandlers = [
     return HttpResponse.json({ year, month, days });
   }),
 
+  http.get("/api/calendar/range", ({ request }) => {
+    const url = new URL(request.url);
+    const start = url.searchParams.get("start") ?? MOCK_TODAY;
+    const payload = getTodayPayload();
+    return HttpResponse.json({
+      items: [
+        ...payload.routines.map((r) => ({
+          item_type: "routine" as const,
+          item_id: r.task_instance_id,
+          title: r.title,
+          status: r.status,
+          scheduled_at: r.due_at,
+          scheduled_date: r.scheduled_date,
+          detail: null,
+          module_key: null,
+        })),
+        ...payload.due_today.map((c) => ({
+          item_type: "chore" as const,
+          item_id: c.chore_instance_id,
+          title: c.title,
+          status: c.status,
+          scheduled_at: null,
+          scheduled_date: c.scheduled_date,
+          detail: null,
+          module_key: null,
+        })),
+        ...getMockState()
+          .plannedItems.filter((item) => item.planned_for >= start)
+          .map((item) => ({
+            item_type: "planned" as const,
+            item_id: item.id,
+            title: item.title,
+            status: item.is_done ? "done" : "planned",
+            scheduled_at: item.time_of_day ? `${item.planned_for}T${item.time_of_day}` : null,
+            scheduled_date: item.planned_for,
+            duration_minutes: item.duration_minutes,
+            detail: item.notes,
+            module_key: item.module_key,
+          })),
+      ],
+    });
+  }),
+
   http.get("/api/calendar/day", ({ request }) => {
     const url = new URL(request.url);
     const date = url.searchParams.get("date") ?? MOCK_TODAY;

--- a/frontend/tests/features/calendar/CalendarPage.test.tsx
+++ b/frontend/tests/features/calendar/CalendarPage.test.tsx
@@ -9,12 +9,15 @@ vi.mock("@tanstack/react-router", async (importOriginal) => {
   return {
     ...actual,
     useNavigate: () => vi.fn(),
-    useSearch: () => ({ month: undefined as string | undefined, date: undefined as string | undefined }),
+    useSearch: () => ({
+      month: undefined as string | undefined,
+      date: undefined as string | undefined,
+    }),
   };
 });
 
 const calendarApiMock = vi.hoisted(() => ({
-  fetchCalendarMonth: vi.fn(),
+  fetchCalendarRange: vi.fn(),
   fetchCalendarDay: vi.fn(),
   listPlannedItems: vi.fn(),
 }));
@@ -23,7 +26,7 @@ vi.mock("@/lib/api/today", async () => {
   const actual = await vi.importActual<typeof import("@/lib/api/today")>("@/lib/api/today");
   return {
     ...actual,
-    fetchCalendarMonth: calendarApiMock.fetchCalendarMonth,
+    fetchCalendarRange: calendarApiMock.fetchCalendarRange,
     fetchCalendarDay: calendarApiMock.fetchCalendarDay,
     listPlannedItems: calendarApiMock.listPlannedItems,
   };
@@ -31,22 +34,42 @@ vi.mock("@/lib/api/today", async () => {
 
 describe("CalendarPage", () => {
   beforeEach(() => {
-    calendarApiMock.fetchCalendarMonth.mockReset();
+    calendarApiMock.fetchCalendarRange.mockReset();
     calendarApiMock.fetchCalendarDay.mockReset();
     calendarApiMock.listPlannedItems.mockReset();
-    calendarApiMock.fetchCalendarMonth.mockResolvedValue({
-      year: 2026,
-      month: 5,
-      days: [{ date: "2026-05-16", total: 2, routines: 1, chores: 1, medications: 0, planned: 0 }],
+    calendarApiMock.fetchCalendarRange.mockResolvedValue({
+      items: [
+        {
+          item_type: "routine",
+          item_id: 1,
+          title: "Morning stretch",
+          status: "pending",
+          scheduled_at: null,
+          scheduled_date: "2026-05-16",
+          detail: null,
+          module_key: null,
+        },
+      ],
     });
     calendarApiMock.fetchCalendarDay.mockResolvedValue({
       date: "2026-05-16",
-      items: [{ item_type: "routine", item_id: 1, title: "Morning stretch", status: "pending", scheduled_at: null, scheduled_date: "2026-05-16", detail: null, module_key: null }],
+      items: [
+        {
+          item_type: "routine",
+          item_id: 1,
+          title: "Morning stretch",
+          status: "pending",
+          scheduled_at: null,
+          scheduled_date: "2026-05-16",
+          detail: null,
+          module_key: null,
+        },
+      ],
     });
     calendarApiMock.listPlannedItems.mockResolvedValue([]);
   });
 
-  it("renders month controls and extracted side panels", async () => {
+  it("renders Schedule-X controls and the retained planned item sidebar", async () => {
     render(
       <QueryTestProvider>
         <CalendarPage />
@@ -54,8 +77,9 @@ describe("CalendarPage", () => {
     );
 
     expect(await screen.findByRole("heading", { name: "Calendar" })).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "This month" })).toBeInTheDocument();
-    expect(await screen.findByText(/Day details/i)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Today" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Next period" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Select View" })).toBeInTheDocument();
     expect(screen.getByText("Quick add planned item")).toBeInTheDocument();
     expect(screen.getByLabelText("Repeat")).toBeInTheDocument();
     expect(screen.getByText("Backup export/import")).toBeInTheDocument();

--- a/frontend/tests/lib/calendar/mapToScheduleXEvents.test.ts
+++ b/frontend/tests/lib/calendar/mapToScheduleXEvents.test.ts
@@ -30,6 +30,7 @@ describe("mapToScheduleXEvents", () => {
         _status: "pending",
         _itemId: 42,
         _moduleKey: "shared_calendar",
+        _options: { disableDND: true },
       },
     ]);
   });


### PR DESCRIPTION
### Motivation
- Replace the hand-rolled month grid + duplicated day-details UI with a maintained calendar library to provide month/week/day/agenda views, built-in navigation, drag & drop and event interactions.
- Simplify and centralize planned-item editing and rescheduling while keeping the existing sidebar editor, recurrence controls and backup tools.
- Keep the UI consistent with the Bootstrap theme and avoid fragile custom touch/drag logic.

### Description
- Integrate Schedule‑X into the calendar page and wire its range callbacks, navigation and plugins by adding `ScheduleXCalendar` and `useCalendarApp` usage in `CalendarPage.tsx` and registering `createDragAndDropPlugin` and `createEventModalPlugin`.
- Add a Bootstrap-styled event action modal component `CalendarEventModal.tsx` to present routines/chores/planned actions and reuse existing mutation hooks for actions (start/complete/skip/reschedule/edit).
- Replace the custom `CalendarMonthGrid`, `DayDetailsPanel` and `MonthNavigationControls` usage with the new Schedule‑X view and keep the `PlannedItemsSidebar` for editing and backups; remove manual touch/drag handlers from sidebar item elements.
- Update event mapping in `mapToScheduleXEvents.ts` to include `_options` (disable DND for non-planned events) and add `calendar.css` with Schedule‑X theme overrides to match Bootstrap colors and sizing.
- Add a mock endpoint for `/api/calendar/range` and update tests that previously depended on the custom month/day APIs to exercise the Schedule‑X range behavior; update unit tests to reflect mapped event fields and the new controls.

### Testing
- Built production frontend with `NODE_USE_ENV_PROXY=1 corepack pnpm --dir frontend build` and verified successful build (vite production output created).
- Ran formatting and lint checks with `oxfmt` and `oxlint`; lint finished with pre-existing TypeScript warnings unrelated to these changes, formatting checks passed after fixup.
- Ran the test suite with `corepack pnpm --dir frontend test`; all tests passed (`120` tests) after updates to tests and mocks.
- Verified formatting-check with `oxfmt --check` and `git diff --check`; both succeeded with no outstanding issues.
- Performed a Playwright visual smoke check against the mock dev server and captured a screenshot saved to `artifacts/calendar-schedule-x.png` (mock server started and Chromium deps installed during the run).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1df05c09d8832e9fa18c91c0b00bad)