### PR TITLE
feat(shopping-list): expose shopping lists as Home Assistant todo entities

### DIFF
--- a/custom_components/daynest/coordinator.py
+++ b/custom_components/daynest/coordinator.py
@@ -218,6 +218,24 @@ class DaynestDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             settings = {}
         normalized["default_snooze_days"] = max(1, min(_safe_int(settings.get("default_snooze_days"), 1), 14))
         normalized["medication_reminder_minutes"] = max(0, _safe_int(settings.get("medication_reminder_minutes"), 0))
+
+        try:
+            shopping_lists = await self._client.async_list_shopping_lists(status="active")
+            normalized["shopping_lists"] = _safe_dict_list(shopping_lists)
+            shopping_items: dict[int, list[dict[str, Any]]] = {}
+            for shopping_list in normalized["shopping_lists"]:
+                list_id = _safe_int(shopping_list.get("id"), default=0)
+                if list_id <= 0:
+                    continue
+                shopping_items[list_id] = _safe_dict_list(await self._client.async_list_shopping_items(list_id))
+            normalized["shopping_items"] = shopping_items
+        except DaynestCommunicationError as err:
+            raise UpdateFailed(f"Temporary communication failure while updating shopping lists: {err}") from err
+        except DaynestMalformedResponseError as err:
+            raise UpdateFailed(f"Malformed shopping list response: {err}") from err
+        except DaynestError as err:
+            raise UpdateFailed(f"Unexpected API error while updating shopping lists: {err}") from err
+
         if self._last_dashboard_data is not None:
             self._fire_transition_events(self._last_dashboard_data, normalized)
         self._last_dashboard_data = normalized

--- a/custom_components/daynest/manifest.json
+++ b/custom_components/daynest/manifest.json
@@ -10,6 +10,6 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/tjorim/daynest/issues",
   "homeassistant": "2024.4.0",
-  "requirements": ["python-daynest==0.1.9"],
-  "version": "0.1.9"
+  "requirements": ["python-daynest==0.1.10"],
+  "version": "0.1.10"
 }

--- a/custom_components/daynest/todo.py
+++ b/custom_components/daynest/todo.py
@@ -1,4 +1,4 @@
-"""To-do platform for Daynest tasks due today."""
+"""To-do platform for Daynest tasks due today and shopping lists."""
 
 from __future__ import annotations
 
@@ -30,6 +30,12 @@ try:
 except AttributeError:  # pragma: no cover - compatibility with enum name changes across HA versions
     COMPLETE_STATUS = TodoItemStatus.COMPLETED
 
+TODO_FEATURES = (
+    TodoListEntityFeature.CREATE_TODO_ITEM
+    | TodoListEntityFeature.UPDATE_TODO_ITEM
+    | TodoListEntityFeature.DELETE_TODO_ITEM
+)
+
 
 async def async_setup_entry(
     hass: HomeAssistant,
@@ -37,25 +43,157 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up Daynest to-do entities for a config entry."""
-    async_add_entities(
-        [
-            DaynestTodoListEntity(
-                coordinator=entry.runtime_data.coordinator,
-                entity_description=ENTITY_DESCRIPTION,
+    coordinator = entry.runtime_data.coordinator
+    entities: list[TodoListEntity] = [
+        DaynestTodoListEntity(
+            coordinator=coordinator,
+            entity_description=ENTITY_DESCRIPTION,
+        )
+    ]
+
+    if isinstance(coordinator.data, dict):
+        for shopping_list in coordinator.data.get("shopping_lists", []):
+            if not isinstance(shopping_list, dict):
+                continue
+            list_id = _coerce_positive_int(shopping_list.get("id"))
+            if list_id is None:
+                continue
+            entities.append(
+                DaynestShoppingListTodoEntity(
+                    coordinator=coordinator,
+                    shopping_list_id=list_id,
+                    shopping_list_name=str(shopping_list.get("name") or "Shopping List"),
+                )
             )
-        ]
-    )
+
+    async_add_entities(entities)
 
 
-class DaynestTodoListEntity(TodoListEntity, DaynestEntity):
+def _coerce_positive_int(value: Any) -> int | None:
+    """Return value as a positive integer, or None when invalid."""
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return None
+    return parsed if parsed > 0 else None
+
+
+class DaynestTodoBaseEntity(TodoListEntity, DaynestEntity):
+    """Shared helpers for Daynest Home Assistant to-do entities."""
+
+    _attr_supported_features = TODO_FEATURES
+
+    def _build_items(self, source: Any, *, id_key: str, kind: str) -> list[TodoItem]:
+        """Build Home Assistant todo items from a payload list."""
+        if not isinstance(source, list):
+            return []
+
+        items: list[TodoItem] = []
+        for item in source:
+            if not isinstance(item, dict):
+                continue
+
+            item_id = self._format_item_id(kind, item.get(id_key))
+            if item_id is None:
+                continue
+            status = self._status_from_item(item)
+            summary = str(item.get("title") or "Task")
+            due_value = item.get("scheduled_date") or item.get("planned_for")
+            due = self._parse_due(due_value)
+
+            kwargs: dict[str, Any] = {
+                "summary": summary,
+                "status": status,
+            }
+            notes = item.get("notes")
+            if isinstance(notes, str) and notes.strip():
+                kwargs["description"] = notes
+            if due is not None:
+                kwargs["due"] = due
+
+            try:
+                items.append(TodoItem(item_id=item_id, **kwargs))
+            except TypeError:
+                items.append(TodoItem(uid=item_id, **kwargs))
+
+        return items
+
+    def _format_item_id(self, kind: str, raw_id: Any) -> str | None:
+        """Build a stable item ID string from Daynest IDs."""
+        parsed_id = _coerce_positive_int(raw_id)
+        if parsed_id is None:
+            return None
+        return f"{kind}:{parsed_id}"
+
+    def _parse_item_id(self, item_id: str, allowed_kinds: set[str]) -> tuple[str, int]:
+        """Parse item IDs encoded as '<kind>:<id>'."""
+        kind, separator, raw_id = item_id.partition(":")
+        if not separator or kind not in allowed_kinds:
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="todo_invalid_item_id",
+                translation_placeholders={"item_id": item_id},
+            )
+        parsed_id = _coerce_positive_int(raw_id)
+        if parsed_id is None:
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="todo_invalid_item_id",
+                translation_placeholders={"item_id": item_id},
+            )
+        return kind, parsed_id
+
+    def _is_complete_status(self, status: Any) -> bool:
+        """Return true when status maps to a completed todo item."""
+        if status == COMPLETE_STATUS:
+            return True
+        if isinstance(status, str) and status.lower() in {"completed", "complete"}:
+            return True
+        return False
+
+    def _format_due_for_payload(self, value: Any) -> str:
+        """Serialize due values into YYYY-MM-DD for planned-item write calls."""
+        if isinstance(value, datetime):
+            return value.date().isoformat()
+        if isinstance(value, date):
+            return value.isoformat()
+        if isinstance(value, str):
+            try:
+                return datetime.fromisoformat(value).date().isoformat()
+            except ValueError:
+                try:
+                    return date.fromisoformat(value).isoformat()
+                except ValueError:
+                    pass
+        fallback = self.coordinator.data.get("for_date") if isinstance(self.coordinator.data, dict) else None
+        if isinstance(fallback, str):
+            try:
+                return date.fromisoformat(fallback).isoformat()
+            except ValueError:
+                pass
+        return date.today().isoformat()
+
+    def _status_from_item(self, item: dict[str, Any]) -> TodoItemStatus:
+        """Convert Daynest item status to Home Assistant to-do status."""
+        raw_status = item.get("status")
+        if isinstance(raw_status, str) and raw_status.lower() in {"completed", "complete", "done", "skipped", "taken"}:
+            return COMPLETE_STATUS
+        if item.get("is_done") is True:
+            return COMPLETE_STATUS
+        return TodoItemStatus.NEEDS_ACTION
+
+    def _parse_due(self, value: Any) -> datetime | None:
+        """Parse due date values from coordinator data into datetime objects."""
+        if not isinstance(value, str):
+            return None
+        try:
+            return datetime.fromisoformat(value)
+        except ValueError:
+            return None
+
+
+class DaynestTodoListEntity(DaynestTodoBaseEntity):
     """Expose due-today and planned Daynest tasks as a Home Assistant to-do list."""
-
-    _attr_supported_features = (
-        TodoListEntityFeature.CREATE_TODO_ITEM
-        |
-        TodoListEntityFeature.UPDATE_TODO_ITEM
-        | TodoListEntityFeature.DELETE_TODO_ITEM
-    )
 
     def __init__(
         self,
@@ -81,7 +219,7 @@ class DaynestTodoListEntity(TodoListEntity, DaynestEntity):
 
         Supports due chore completion and planned item updates.
         """
-        kind, raw_id = self._parse_item_id(item_id)
+        kind, raw_id = self._parse_item_id(item_id, {"due", "planned"})
         client = self.coordinator.config_entry.runtime_data.client
 
         if kind == "due":
@@ -153,113 +291,13 @@ class DaynestTodoListEntity(TodoListEntity, DaynestEntity):
         """
         client = self.coordinator.config_entry.runtime_data.client
         for item_id in item_ids:
-            kind, raw_id = self._parse_item_id(item_id)
+            kind, raw_id = self._parse_item_id(item_id, {"due", "planned"})
             if kind == "due":
                 await client.async_skip_task(raw_id)
             else:
                 await client.async_delete_planned_item(raw_id)
 
         await self.coordinator.async_request_refresh()
-
-    def _build_items(self, source: Any, *, id_key: str, kind: str) -> list[TodoItem]:
-        """Build Home Assistant todo items from a payload list."""
-        if not isinstance(source, list):
-            return []
-
-        items: list[TodoItem] = []
-        for item in source:
-            if not isinstance(item, dict):
-                continue
-
-            item_id = self._format_item_id(kind, item.get(id_key))
-            if item_id is None:
-                continue
-            status = self._status_from_item(item)
-            summary = str(item.get("title") or "Task")
-            due_value = item.get("scheduled_date") or item.get("planned_for")
-            due = self._parse_due(due_value)
-
-            kwargs: dict[str, Any] = {
-                "summary": summary,
-                "status": status,
-            }
-            notes = item.get("notes")
-            if isinstance(notes, str) and notes.strip():
-                kwargs["description"] = notes
-            if due is not None:
-                kwargs["due"] = due
-
-            try:
-                items.append(TodoItem(item_id=item_id, **kwargs))
-            except TypeError:
-                items.append(TodoItem(uid=item_id, **kwargs))
-
-        return items
-
-    def _format_item_id(self, kind: str, raw_id: Any) -> str | None:
-        """Build a stable item ID string from Daynest IDs."""
-        try:
-            parsed_id = int(raw_id)
-        except (TypeError, ValueError):
-            return None
-        if parsed_id <= 0:
-            return None
-        return f"{kind}:{parsed_id}"
-
-    def _parse_item_id(self, item_id: str) -> tuple[str, int]:
-        """Parse item IDs encoded as '<kind>:<id>'."""
-        kind, separator, raw_id = item_id.partition(":")
-        if not separator or kind not in {"due", "planned"}:
-            raise HomeAssistantError(
-                translation_domain=DOMAIN,
-                translation_key="todo_invalid_item_id",
-                translation_placeholders={"item_id": item_id},
-            )
-        try:
-            parsed_id = int(raw_id)
-        except ValueError as err:
-            raise HomeAssistantError(
-                translation_domain=DOMAIN,
-                translation_key="todo_invalid_item_id",
-                translation_placeholders={"item_id": item_id},
-            ) from err
-        if parsed_id <= 0:
-            raise HomeAssistantError(
-                translation_domain=DOMAIN,
-                translation_key="todo_invalid_item_id",
-                translation_placeholders={"item_id": item_id},
-            )
-        return kind, parsed_id
-
-    def _is_complete_status(self, status: Any) -> bool:
-        """Return true when status maps to a completed todo item."""
-        if status == COMPLETE_STATUS:
-            return True
-        if isinstance(status, str) and status.lower() in {"completed", "complete"}:
-            return True
-        return False
-
-    def _format_due_for_payload(self, value: Any) -> str:
-        """Serialize due values into YYYY-MM-DD for planned-item write calls."""
-        if isinstance(value, datetime):
-            return value.date().isoformat()
-        if isinstance(value, date):
-            return value.isoformat()
-        if isinstance(value, str):
-            try:
-                return datetime.fromisoformat(value).date().isoformat()
-            except ValueError:
-                try:
-                    return date.fromisoformat(value).isoformat()
-                except ValueError:
-                    pass
-        fallback = self.coordinator.data.get("for_date") if isinstance(self.coordinator.data, dict) else None
-        if isinstance(fallback, str):
-            try:
-                return date.fromisoformat(fallback).isoformat()
-            except ValueError:
-                pass
-        return date.today().isoformat()
 
     def _find_planned_item(self, planned_item_id: int) -> dict[str, Any] | None:
         """Find a planned item by ID in the current coordinator payload."""
@@ -275,20 +313,106 @@ class DaynestTodoListEntity(TodoListEntity, DaynestEntity):
                 return item
         return None
 
-    def _status_from_item(self, item: dict[str, Any]) -> TodoItemStatus:
-        """Convert Daynest item status to Home Assistant to-do status."""
-        raw_status = item.get("status")
-        if isinstance(raw_status, str) and raw_status.lower() in {"completed", "complete", "done", "skipped", "taken"}:
-            return COMPLETE_STATUS
-        if item.get("is_done") is True:
-            return COMPLETE_STATUS
-        return TodoItemStatus.NEEDS_ACTION
 
-    def _parse_due(self, value: Any) -> datetime | None:
-        """Parse due date values from coordinator data into datetime objects."""
-        if not isinstance(value, str):
+class DaynestShoppingListTodoEntity(DaynestTodoBaseEntity):
+    """Expose one active Daynest shopping list as a Home Assistant to-do list."""
+
+    def __init__(
+        self,
+        coordinator: DaynestDataUpdateCoordinator,
+        shopping_list_id: int,
+        shopping_list_name: str,
+    ) -> None:
+        """Initialize the shopping-list to-do entity."""
+        self.shopping_list_id = shopping_list_id
+        entity_description = EntityDescription(
+            key=f"shopping_list_{shopping_list_id}",
+            translation_key="shopping_list",
+        )
+        super().__init__(coordinator, entity_description)
+        self._attr_translation_placeholders = {"name": shopping_list_name}
+
+    @property
+    def todo_items(self) -> list[TodoItem]:
+        """Return current shopping-list items from the coordinator payload."""
+        if not isinstance(self.coordinator.data, dict):
+            return []
+        shopping_items = self.coordinator.data.get("shopping_items")
+        if not isinstance(shopping_items, dict):
+            return []
+        return self._build_items(shopping_items.get(self.shopping_list_id), id_key="id", kind="shopping")
+
+    async def async_create_todo_item(self, item: TodoItem) -> None:
+        """Create a shopping list item from Home Assistant."""
+        summary = str(item.summary or "").strip()
+        if not summary:
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="todo_summary_required",
+            )
+
+        await self.coordinator.config_entry.runtime_data.client.async_create_shopping_item(
+            self.shopping_list_id,
+            title=summary,
+            planned_for=self._format_due_for_payload(item.due),
+            notes=item.description,
+        )
+        await self.coordinator.async_request_refresh()
+
+    async def async_update_todo_item(self, item_id: str, changes: dict[str, Any]) -> None:
+        """Update a shopping list item from Home Assistant."""
+        _, raw_id = self._parse_item_id(item_id, {"shopping"})
+        shopping_item = self._find_shopping_item(raw_id)
+        if shopping_item is None:
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="todo_shopping_item_not_found",
+                translation_placeholders={"item_id": str(raw_id)},
+            )
+
+        status = changes.get("status")
+        if status is None:
+            status = COMPLETE_STATUS if shopping_item.get("is_done") else TodoItemStatus.NEEDS_ACTION
+        summary = str(changes.get("summary", shopping_item.get("title") or "Task")).strip()
+        if not summary:
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="todo_title_empty",
+            )
+
+        await self.coordinator.config_entry.runtime_data.client.async_update_shopping_item(
+            self.shopping_list_id,
+            raw_id,
+            title=summary,
+            planned_for=self._format_due_for_payload(changes.get("due", shopping_item.get("planned_for"))),
+            is_done=self._is_complete_status(status),
+            notes=changes.get("description", shopping_item.get("notes")),
+            tags=shopping_item.get("tags") if isinstance(shopping_item.get("tags"), list) else [],
+            priority=str(shopping_item.get("priority") or "normal"),
+            recurrence_hint=shopping_item.get("recurrence_hint") if isinstance(shopping_item.get("recurrence_hint"), str) else None,
+            rrule=shopping_item.get("rrule") if isinstance(shopping_item.get("rrule"), str) else None,
+        )
+        await self.coordinator.async_request_refresh()
+
+    async def async_delete_todo_items(self, item_ids: list[str]) -> None:
+        """Delete shopping list items from Home Assistant."""
+        client = self.coordinator.config_entry.runtime_data.client
+        for item_id in item_ids:
+            _, raw_id = self._parse_item_id(item_id, {"shopping"})
+            await client.async_delete_shopping_item(self.shopping_list_id, raw_id)
+
+        await self.coordinator.async_request_refresh()
+
+    def _find_shopping_item(self, shopping_item_id: int) -> dict[str, Any] | None:
+        """Find a shopping item by ID in the current coordinator payload."""
+        if not isinstance(self.coordinator.data, dict):
             return None
-        try:
-            return datetime.fromisoformat(value)
-        except ValueError:
+        shopping_items = self.coordinator.data.get("shopping_items")
+        if not isinstance(shopping_items, dict):
             return None
+        for item in shopping_items.get(self.shopping_list_id, []):
+            if not isinstance(item, dict):
+                continue
+            if self._format_item_id("shopping", item.get("id")) == f"shopping:{shopping_item_id}":
+                return item
+        return None

--- a/custom_components/daynest/translations/en.json
+++ b/custom_components/daynest/translations/en.json
@@ -72,6 +72,9 @@
     },
     "todo_invalid_item_id": {
       "message": "Unsupported Daynest to-do item id: {item_id}."
+    },
+    "todo_shopping_item_not_found": {
+      "message": "Unable to locate shopping list item {item_id}."
     }
   },
   "entity": {
@@ -137,6 +140,9 @@
     "todo": {
       "tasks_due_today": {
         "name": "Today"
+      },
+      "shopping_list": {
+        "name": "Shopping List: {name}"
       }
     }
   },
@@ -165,7 +171,7 @@
         },
         "days": {
           "name": "Days",
-          "description": "Number of days to snooze the task (1–30). Defaults to 1."
+          "description": "Number of days to snooze the task (1\u201330). Defaults to 1."
         }
       }
     },

--- a/custom_components/tests/test_coordinator.py
+++ b/custom_components/tests/test_coordinator.py
@@ -213,6 +213,12 @@ class TestAsyncUpdateData:
             "default_snooze_days": 4,
             "medication_reminder_minutes": 20,
         }
+        client.async_list_shopping_lists.return_value = [
+            {"id": 10, "name": "Groceries", "status": "active"},
+        ]
+        client.async_list_shopping_items.return_value = [
+            {"id": 20, "title": "Milk", "is_done": False},
+        ]
         coordinator = _make_coordinator(client)
         result = await coordinator._async_update_data()
         assert result["due_today_count"] == 3
@@ -220,6 +226,10 @@ class TestAsyncUpdateData:
         assert result["integration_contract"] == CONTRACT_VALID
         assert result["default_snooze_days"] == 4
         assert result["medication_reminder_minutes"] == 20
+        assert result["shopping_lists"] == [{"id": 10, "name": "Groceries", "status": "active"}]
+        assert result["shopping_items"] == {10: [{"id": 20, "title": "Milk", "is_done": False}]}
+        client.async_list_shopping_lists.assert_awaited_once_with(status="active")
+        client.async_list_shopping_items.assert_awaited_once_with(10)
 
     async def test_authentication_error_raises_config_entry_auth_failed(self) -> None:
         client = AsyncMock()

--- a/custom_components/tests/test_todo.py
+++ b/custom_components/tests/test_todo.py
@@ -6,7 +6,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from custom_components.daynest.todo import ENTITY_DESCRIPTION, DaynestTodoListEntity
+from custom_components.daynest.todo import ENTITY_DESCRIPTION, DaynestShoppingListTodoEntity, DaynestTodoListEntity
 from homeassistant.components.todo import TodoItem, TodoItemStatus
 from homeassistant.exceptions import HomeAssistantError
 
@@ -250,3 +250,110 @@ class TestDaynestTodoListEntity:
         with pytest.raises(HomeAssistantError) as exc_info:
             await entity.async_create_todo_item(TodoItem(summary="", status=TodoItemStatus.NEEDS_ACTION))
         assert exc_info.value.translation_key == "todo_summary_required"
+
+
+SHOPPING_COORDINATOR_DATA = {
+    **COORDINATOR_DATA,
+    "shopping_lists": [
+        {"id": 301, "name": "Groceries", "status": "active"},
+    ],
+    "shopping_items": {
+        301: [
+            {
+                "id": 401,
+                "title": "Milk",
+                "planned_for": "2026-01-15",
+                "notes": "2 liters",
+                "is_done": False,
+                "tags": ["Dairy"],
+            },
+            {
+                "id": 402,
+                "title": "Bread",
+                "planned_for": "2026-01-15",
+                "is_done": True,
+            },
+        ],
+    },
+}
+
+
+@pytest.mark.unit
+class TestDaynestShoppingListTodoEntity:
+    """Tests for DaynestShoppingListTodoEntity."""
+
+    def test_shopping_list_items_map_to_todo_items(self) -> None:
+
+        entity = DaynestShoppingListTodoEntity(
+            coordinator=_make_coordinator(data=SHOPPING_COORDINATOR_DATA),
+            shopping_list_id=301,
+            shopping_list_name="Groceries",
+        )
+
+        items = entity.todo_items
+
+        assert [item.summary for item in items] == ["Milk", "Bread"]
+        assert [_item_id(item) for item in items] == ["shopping:401", "shopping:402"]
+        assert [item.status for item in items] == [TodoItemStatus.NEEDS_ACTION, COMPLETE_STATUS]
+
+    async def test_create_shopping_item_calls_client(self) -> None:
+
+        coordinator = _make_coordinator(data=SHOPPING_COORDINATOR_DATA)
+        entity = DaynestShoppingListTodoEntity(
+            coordinator=coordinator,
+            shopping_list_id=301,
+            shopping_list_name="Groceries",
+        )
+
+        await entity.async_create_todo_item(
+            TodoItem(
+                summary="Eggs",
+                due=entity._parse_due("2026-01-16"),
+                status=TodoItemStatus.NEEDS_ACTION,
+            )
+        )
+
+        coordinator.config_entry.runtime_data.client.async_create_shopping_item.assert_awaited_once_with(
+            301,
+            title="Eggs",
+            planned_for="2026-01-16",
+            notes=None,
+        )
+        coordinator.async_request_refresh.assert_awaited_once()
+
+    async def test_update_shopping_item_calls_client(self) -> None:
+
+        coordinator = _make_coordinator(data=SHOPPING_COORDINATOR_DATA)
+        entity = DaynestShoppingListTodoEntity(
+            coordinator=coordinator,
+            shopping_list_id=301,
+            shopping_list_name="Groceries",
+        )
+
+        await entity.async_update_todo_item(
+            "shopping:401",
+            {"summary": "Whole milk", "status": COMPLETE_STATUS},
+        )
+
+        coordinator.config_entry.runtime_data.client.async_update_shopping_item.assert_awaited_once()
+        args = coordinator.config_entry.runtime_data.client.async_update_shopping_item.await_args.args
+        kwargs = coordinator.config_entry.runtime_data.client.async_update_shopping_item.await_args.kwargs
+        assert args == (301, 401)
+        assert kwargs["title"] == "Whole milk"
+        assert kwargs["is_done"] is True
+        assert kwargs["tags"] == ["Dairy"]
+        coordinator.async_request_refresh.assert_awaited_once()
+
+    async def test_delete_shopping_item_calls_client(self) -> None:
+
+        coordinator = _make_coordinator(data=SHOPPING_COORDINATOR_DATA)
+        entity = DaynestShoppingListTodoEntity(
+            coordinator=coordinator,
+            shopping_list_id=301,
+            shopping_list_name="Groceries",
+        )
+
+        await entity.async_delete_todo_items(["shopping:401"])
+
+        coordinator.config_entry.runtime_data.client.async_delete_shopping_item.assert_awaited_once_with(301, 401)
+        coordinator.async_request_refresh.assert_awaited_once()

--- a/custom_components/uv.lock
+++ b/custom_components/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.14.2"
 
 [options]
@@ -931,7 +931,9 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/94/5e/a70f31e3e8d961c4ce589c15b28e4225d63704e431a23932a3808cbcc867/greenlet-3.5.0-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:f35807464c4c58c55f0d31dfa83c541a5615d825c2fe3d2b95360cf7c4e3c0a8", size = 285564, upload-time = "2026-04-27T12:23:08.555Z" },
     { url = "https://files.pythonhosted.org/packages/af/a6/046c0a28e21833e4086918218cfb3d8bed51c075a1b700f20b9d7861c0f4/greenlet-3.5.0-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:55fa7ea52771be44af0de27d8b80c02cd18c2c3cddde6c847ecebdf72418b6a1", size = 651166, upload-time = "2026-04-27T12:52:43.644Z" },
     { url = "https://files.pythonhosted.org/packages/47/f8/4af27f71c5ff32a7fbc516adb46370d9c4ae2bc7bd3dc7d066ac542b4b15/greenlet-3.5.0-cp314-cp314-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a97e4821aa710603f94de0da25f25096454d78ffdace5dc77f3a006bc01abba3", size = 663792, upload-time = "2026-04-27T12:59:44.93Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/89/2dadb89793c37ee8b4c237857188293e9060dc085f19845c292e00f8e091/greenlet-3.5.0-cp314-cp314-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:bf2d8a80bec89ab46221ae45c5373d5ba0bd36c19aa8508e85c6cd7e5106cd37", size = 668086, upload-time = "2026-04-27T13:02:42.314Z" },
     { url = "https://files.pythonhosted.org/packages/a3/59/1bd6d7428d6ed9106efbb8c52310c60fd04f6672490f452aeaa3829aa436/greenlet-3.5.0-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8f52a464e4ed91780bdfbbdd2b97197f3accaa629b98c200f4dffada759f3ae7", size = 660933, upload-time = "2026-04-27T12:25:33.276Z" },
+    { url = "https://files.pythonhosted.org/packages/82/35/75722be7e26a2af4cbd2dc35b0ed382dacf9394b7e75551f76ed1abe87f2/greenlet-3.5.0-cp314-cp314-manylinux_2_39_riscv64.whl", hash = "sha256:1bae92a1dd94c5f9d9493c3a212dd874c202442047cf96446412c862feca83a2", size = 470799, upload-time = "2026-04-27T13:05:17.094Z" },
     { url = "https://files.pythonhosted.org/packages/83/e4/b903e5a5fae1e8a28cdd32a0cfbfd560b668c25b692f67768822ddc5f40f/greenlet-3.5.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:762612baf1161ccb8437c0161c668a688223cba28e1bf038f4eb47b13e39ccdf", size = 1618401, upload-time = "2026-04-27T12:53:31.062Z" },
     { url = "https://files.pythonhosted.org/packages/0e/e3/5ec408a329acb854fb607a122e1ee5fb3ff649f9a97952948a90803c0d8e/greenlet-3.5.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:57a43c6079a89713522bc4bcb9f75070ecf5d3dbad7792bfe42239362cbf2a16", size = 1682038, upload-time = "2026-04-27T12:25:31.838Z" },
     { url = "https://files.pythonhosted.org/packages/91/20/6b165108058767ee643c55c5c4904d591a830ee2b3c7dbd359828fbc829f/greenlet-3.5.0-cp314-cp314-win_amd64.whl", hash = "sha256:3bc59be3945ae9750b9e7d45067d01ae3fe90ea5f9ade99239dabdd6e28a5033", size = 239835, upload-time = "2026-04-27T12:24:54.136Z" },
@@ -939,7 +941,9 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/78/a8/4522939255bb5409af4e87132f915446bf3622c2c292d14d3c38d128ae82/greenlet-3.5.0-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:a10a732421ab4fec934783ce3e54763470d0181db6e3468f9103a275c3ed1853", size = 293614, upload-time = "2026-04-27T12:24:12.874Z" },
     { url = "https://files.pythonhosted.org/packages/15/5e/8744c52e2c027b5a8772a01561934c8835f869733e101f62075c60430340/greenlet-3.5.0-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7fc391b1566f2907d17aaebe78f8855dc45675159a775fcf9e61f8ee0078e87f", size = 650723, upload-time = "2026-04-27T12:52:45.412Z" },
     { url = "https://files.pythonhosted.org/packages/00/ef/7b4c39c03cf46ceca512c5d3f914afd85aa30b2cc9a93015b0dd73e4be6c/greenlet-3.5.0-cp314-cp314t-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:680bd0e7ad5e8daa8a4aa89f68fd6adc834b8a8036dc256533f7e08f4a4b01f7", size = 656529, upload-time = "2026-04-27T12:59:46.295Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/5c/0602239503b124b70e39355cbdb39361ecfe65b87a5f2f63752c32f5286f/greenlet-3.5.0-cp314-cp314t-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:1aa4ce8debcd4ea7fb2e150f3036588c41493d1d52c43538924ae1819003f4ce", size = 657015, upload-time = "2026-04-27T13:02:43.973Z" },
     { url = "https://files.pythonhosted.org/packages/0b/b5/c7768f352f5c010f92064d0063f987e7dc0cd290a6d92a34109015ce4aa1/greenlet-3.5.0-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ddb36c7d6c9c0a65f18c7258634e0c416c6ab59caac8c987b96f80c2ebda0112", size = 654364, upload-time = "2026-04-27T12:25:35.64Z" },
+    { url = "https://files.pythonhosted.org/packages/38/51/8699f865f125dc952384cb432b0f7138aa4d8f2969a7d12d0df5b94d054d/greenlet-3.5.0-cp314-cp314t-manylinux_2_39_riscv64.whl", hash = "sha256:728a73687e39ae9ca34e4694cbf2f049d3fbc7174639468d0f67200a97d8f9e2", size = 488275, upload-time = "2026-04-27T13:05:18.28Z" },
     { url = "https://files.pythonhosted.org/packages/ef/d0/079ebe12e4b1fc758857ce5be1a5e73f06870f2101e52611d1e71925ce54/greenlet-3.5.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e5ddf316ced87539144621453c3aef229575825fe60c604e62bedc4003f372b2", size = 1614204, upload-time = "2026-04-27T12:53:32.618Z" },
     { url = "https://files.pythonhosted.org/packages/6d/89/6c2fb63df3596552d20e58fb4d96669243388cf680cff222758812c7bfaa/greenlet-3.5.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:4a448128607be0de65342dc9b31be7f948ef4cc0bc8832069350abefd310a8f2", size = 1675480, upload-time = "2026-04-27T12:25:34.168Z" },
     { url = "https://files.pythonhosted.org/packages/15/32/77ee8a6c1564fc345a491a4e85b3bf360e4cf26eac98c4532d2fdb96e01f/greenlet-3.5.0-cp314-cp314t-win_amd64.whl", hash = "sha256:d60097128cb0a1cab9ea541186ea13cd7b847b8449a7787c2e2350da0cb82d86", size = 245324, upload-time = "2026-04-27T12:24:40.295Z" },
@@ -2007,7 +2011,7 @@ wheels = [
 
 [[package]]
 name = "python-daynest"
-version = "0.1.0"
+version = "0.1.10"
 source = { editable = "../python-daynest" }
 dependencies = [
     { name = "aiohttp" },

--- a/python-daynest/pyproject.toml
+++ b/python-daynest/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "python-daynest"
-version = "0.1.9"
+version = "0.1.10"
 description = "Python client library for the Daynest API"
 requires-python = ">=3.12"
 license = { text = "MIT" }

--- a/python-daynest/src/daynest/client.py
+++ b/python-daynest/src/daynest/client.py
@@ -400,7 +400,6 @@ class DaynestClient:
         payload = await self._cached_call(
             "async_list_shopping_items",
             lambda: self._request_list("/api/planned-items"),
-            shopping_list_id,
         )
         return [
             item

--- a/python-daynest/src/daynest/client.py
+++ b/python-daynest/src/daynest/client.py
@@ -385,6 +385,85 @@ class DaynestClient:
             path += f"?scope={scope}"
         await self._send_no_content_action("delete", path=path)
 
+
+    async def async_list_shopping_lists(self, status: str = "active") -> list[dict[str, Any]]:
+        """List shopping lists for the authenticated user."""
+        query = urlencode({"status": status})
+        return await self._cached_call(
+            "async_list_shopping_lists",
+            lambda: self._request_list(f"/api/shopping-lists?{query}"),
+            status,
+        )
+
+    async def async_list_shopping_items(self, shopping_list_id: int) -> list[dict[str, Any]]:
+        """List planned items linked to a shopping list."""
+        payload = await self._cached_call(
+            "async_list_shopping_items",
+            lambda: self._request_list("/api/planned-items"),
+            shopping_list_id,
+        )
+        return [
+            item
+            for item in payload
+            if item.get("module_key") == "shopping_list" and item.get("linked_ref") == str(shopping_list_id)
+        ]
+
+    async def async_create_shopping_item(
+        self,
+        shopping_list_id: int,
+        *,
+        title: str,
+        planned_for: date | str,
+        notes: str | None = None,
+        tags: list[str] | None = None,
+    ) -> dict[str, Any]:
+        """Create an item linked to a shopping list."""
+        payload = {
+            "title": title,
+            "planned_for": planned_for.isoformat() if isinstance(planned_for, date) else planned_for,
+            "notes": notes,
+            "module_key": "shopping_list",
+            "linked_source": "shopping_list",
+            "linked_ref": str(shopping_list_id),
+            "priority": "normal",
+            "tags": tags or [],
+        }
+        return await self._send_action("post", path="/api/planned-items", payload=payload)
+
+    async def async_update_shopping_item(
+        self,
+        shopping_list_id: int,
+        item_id: int,
+        *,
+        title: str,
+        planned_for: date | str,
+        is_done: bool,
+        notes: str | None = None,
+        tags: list[str] | None = None,
+        priority: str = "normal",
+        recurrence_hint: str | None = None,
+        rrule: str | None = None,
+    ) -> dict[str, Any]:
+        """Update an item linked to a shopping list."""
+        payload = {
+            "title": title,
+            "planned_for": planned_for.isoformat() if isinstance(planned_for, date) else planned_for,
+            "notes": notes,
+            "module_key": "shopping_list",
+            "recurrence_hint": recurrence_hint,
+            "rrule": rrule,
+            "linked_source": "shopping_list",
+            "linked_ref": str(shopping_list_id),
+            "priority": priority,
+            "tags": tags or [],
+            "is_done": is_done,
+        }
+        return await self._send_action("put", path=f"/api/planned-items/{item_id}", payload=payload)
+
+    async def async_delete_shopping_item(self, shopping_list_id: int, item_id: int) -> None:
+        """Delete an item linked to a shopping list."""
+        await self._send_no_content_action("delete", path=f"/api/planned-items/{item_id}")
+
     async def async_get_calendar(
         self,
         start: date,

--- a/python-daynest/tests/test_client.py
+++ b/python-daynest/tests/test_client.py
@@ -918,3 +918,78 @@ class TestDaynestClientCacheAndSSE:
 
         session.get.assert_not_called()
         callback.assert_not_awaited()
+
+
+@pytest.mark.unit
+class TestDaynestClientShoppingLists:
+    """Tests for shopping-list helpers."""
+
+    async def test_list_shopping_lists_requests_active_lists(self) -> None:
+        response = _make_mock_response(200, [{"id": 1, "name": "Groceries", "status": "active"}])
+        client = _make_client(response)
+
+        result = await client.async_list_shopping_lists(status="active")
+
+        assert result == [{"id": 1, "name": "Groceries", "status": "active"}]
+        client._session.get.assert_called_once()
+        url = client._session.get.call_args.args[0]
+        assert url == "https://api.daynest.example/api/shopping-lists?status=active"
+
+    async def test_list_shopping_items_filters_linked_planned_items(self) -> None:
+        response = _make_mock_response(
+            200,
+            [
+                {"id": 1, "title": "Milk", "module_key": "shopping_list", "linked_ref": "7"},
+                {"id": 2, "title": "Other", "module_key": "shopping_list", "linked_ref": "8"},
+                {"id": 3, "title": "Task", "module_key": None, "linked_ref": None},
+            ],
+        )
+        client = _make_client(response)
+
+        result = await client.async_list_shopping_items(7)
+
+        assert result == [{"id": 1, "title": "Milk", "module_key": "shopping_list", "linked_ref": "7"}]
+
+    async def test_create_shopping_item_posts_linked_planned_item(self) -> None:
+        response = _make_mock_response(200, {"id": 1, "title": "Milk"})
+        session = MagicMock(spec=aiohttp.ClientSession)
+        session.post = MagicMock(return_value=response)
+        client = DaynestClient(base_url="https://api.daynest.example", integration_key="key", session=session)
+
+        result = await client.async_create_shopping_item(7, title="Milk", planned_for="2026-01-15", notes="2L")
+
+        assert result == {"id": 1, "title": "Milk"}
+        payload = session.post.call_args.kwargs["json"]
+        assert payload["module_key"] == "shopping_list"
+        assert payload["linked_ref"] == "7"
+        assert payload["title"] == "Milk"
+
+    async def test_update_shopping_item_puts_linked_planned_item(self) -> None:
+        response = _make_mock_response(200, {"id": 1, "title": "Milk"})
+        session = MagicMock(spec=aiohttp.ClientSession)
+        session.put = MagicMock(return_value=response)
+        client = DaynestClient(base_url="https://api.daynest.example", integration_key="key", session=session)
+
+        result = await client.async_update_shopping_item(
+            7,
+            1,
+            title="Milk",
+            planned_for="2026-01-15",
+            is_done=True,
+        )
+
+        assert result == {"id": 1, "title": "Milk"}
+        assert session.put.call_args.args[0] == "https://api.daynest.example/api/planned-items/1"
+        payload = session.put.call_args.kwargs["json"]
+        assert payload["linked_ref"] == "7"
+        assert payload["is_done"] is True
+
+    async def test_delete_shopping_item_deletes_planned_item(self) -> None:
+        response = _make_mock_response(204, None)
+        session = MagicMock(spec=aiohttp.ClientSession)
+        session.delete = MagicMock(return_value=response)
+        client = DaynestClient(base_url="https://api.daynest.example", integration_key="key", session=session)
+
+        await client.async_delete_shopping_item(7, 1)
+
+        assert session.delete.call_args.args[0] == "https://api.daynest.example/api/planned-items/1"

--- a/python-daynest/uv.lock
+++ b/python-daynest/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.12"
 
 [[package]]
@@ -507,7 +507,7 @@ wheels = [
 
 [[package]]
 name = "python-daynest"
-version = "0.1.0"
+version = "0.1.10"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
### Motivation
- Surface Daynest shopping lists and their items inside Home Assistant so users can view and manage shopping list items from the HA to‑do UI.
- Provide write-back support for shopping items (create/update/delete) via the existing Daynest client abstractions.

### Description
- Coordinator now fetches active shopping lists and linked planned items and exposes them on the coordinator payload under `shopping_lists` and `shopping_items` so entities can consume them.
- Added a new `DaynestShoppingListTodoEntity` and refactored the to‑do module into a base `DaynestTodoBaseEntity` so the existing "Today" to‑do entity remains and one to‑do entity per active shopping list is created at setup.
- Extended the python-daynest client with `async_list_shopping_lists`, `async_list_shopping_items`, `async_create_shopping_item`, `async_update_shopping_item`, and `async_delete_shopping_item` to support the shopping-list workflows and bumped the package/integration version to `0.1.10`.
- Added translations for shopping-list todo labels and an error message, and added unit tests covering coordinator shopping data, shopping todo entity behavior, and python-daynest shopping helpers.

### Testing
- Ran linting and static checks with `ruff` and `pyright` where applicable and addressed reported issues; `pyright` on the client package returned no errors in this environment.
- Unit tests in the Home Assistant custom component ran with: `cd custom_components && uv run --group test --with pytest==8.4.2 --with pytest-asyncio==1.4.0 pytest tests/test_todo.py tests/test_coordinator.py` and passed (`55 passed`).
- Unit tests for the python-daynest client ran with: `cd python-daynest && uv run pytest tests/test_client.py` and passed (`74 passed`).
- Note: attempting `pyright` against the custom_components tree in this environment hit the repository-local pyright venv configuration (points to a missing `.local/ha-venv`) so Home Assistant imports could not be resolved there, but `pyright` was run successfully for the client module.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a23f8342878832e868a01ef97e2ef85)