### PR TITLE
feat(android): add meal planner screen

### DIFF
--- a/android/app/src/main/java/com/daynest/android/app/DaynestApp.kt
+++ b/android/app/src/main/java/com/daynest/android/app/DaynestApp.kt
@@ -17,6 +17,7 @@ import com.daynest.android.app.session.SessionGateRoute
 import com.daynest.android.feature.auth.AuthRoute
 import com.daynest.android.feature.calendar.CalendarRoute
 import com.daynest.android.feature.home.HomeRoute
+import com.daynest.android.feature.mealplan.MealPlannerRoute
 import com.daynest.android.feature.medication.MedicationRoute
 import com.daynest.android.feature.settings.SettingsRoute
 import com.daynest.android.feature.shopping.ShoppingListDetailRoute
@@ -79,6 +80,9 @@ private fun NavGraphBuilder.daynestDestinations(navController: NavHostController
         TemplatesRoute(onNavigate = navController::navigateTopLevel)
     }
     shoppingDestinations(navController)
+    composable(route = DaynestDestination.MEAL_PLAN) {
+        MealPlannerRoute(onNavigate = navController::navigateTopLevel)
+    }
     composable(route = DaynestDestination.SETTINGS) {
         SettingsRoute(
             onNavigate = navController::navigateTopLevel,

--- a/android/app/src/main/java/com/daynest/android/app/navigation/DaynestDestination.kt
+++ b/android/app/src/main/java/com/daynest/android/app/navigation/DaynestDestination.kt
@@ -11,6 +11,7 @@ object DaynestDestination {
     const val MEDICATION = "medication"
     const val TEMPLATES = "templates"
     const val SHOPPING = "shopping"
+    const val MEAL_PLAN = "meal-plan"
     const val SHOPPING_DETAIL = "shopping/{listId}"
     const val SETTINGS = "settings"
 }
@@ -27,5 +28,6 @@ val daynestTopLevelDestinations =
         DaynestTopLevelDestination(DaynestDestination.MEDICATION, R.string.medication_title),
         DaynestTopLevelDestination(DaynestDestination.TEMPLATES, R.string.templates_title),
         DaynestTopLevelDestination(DaynestDestination.SHOPPING, R.string.shopping_title),
+        DaynestTopLevelDestination(DaynestDestination.MEAL_PLAN, R.string.meal_plan_title),
         DaynestTopLevelDestination(DaynestDestination.SETTINGS, R.string.settings_title),
     )

--- a/android/app/src/main/java/com/daynest/android/core/di/NetworkApiDiModule.kt
+++ b/android/app/src/main/java/com/daynest/android/core/di/NetworkApiDiModule.kt
@@ -1,6 +1,7 @@
 package com.daynest.android.core.di
 
 import com.daynest.android.data.calendar.CalendarApi
+import com.daynest.android.data.mealplan.MealPlanApi
 import com.daynest.android.data.medication.MedicationApi
 import com.daynest.android.data.push.PushApi
 import com.daynest.android.data.settings.SettingsApi
@@ -54,4 +55,8 @@ object NetworkApiDiModule {
     @Provides
     @Singleton
     fun provideShoppingListApi(retrofit: Retrofit): ShoppingListApi = retrofit.create(ShoppingListApi::class.java)
+
+    @Provides
+    @Singleton
+    fun provideMealPlanApi(retrofit: Retrofit): MealPlanApi = retrofit.create(MealPlanApi::class.java)
 }

--- a/android/app/src/main/java/com/daynest/android/data/mealplan/MealPlanApi.kt
+++ b/android/app/src/main/java/com/daynest/android/data/mealplan/MealPlanApi.kt
@@ -1,0 +1,108 @@
+package com.daynest.android.data.mealplan
+
+import com.daynest.android.data.shopping.ShoppingListDto
+import com.daynest.android.data.today.PlannedTodayItemDto
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import retrofit2.http.Body
+import retrofit2.http.GET
+import retrofit2.http.POST
+import retrofit2.http.PUT
+import retrofit2.http.Path
+
+interface MealPlanApi {
+    @GET("api/meal-plans")
+    suspend fun listMealPlans(): List<MealPlanDto>
+
+    @POST("api/meal-plans")
+    suspend fun createMealPlan(
+        @Body request: MealPlanCreateDto,
+    ): MealPlanDto
+
+    @GET("api/meal-plans/{mealPlanId}/slots")
+    suspend fun getWeekPlan(
+        @Path("mealPlanId") mealPlanId: Int,
+    ): WeekGridDto
+
+    @PUT("api/meal-plans/{mealPlanId}/slots/{slotId}")
+    suspend fun updateSlot(
+        @Path("mealPlanId") mealPlanId: Int,
+        @Path("slotId") slotId: Int,
+        @Body request: MealSlotUpdateDto,
+    ): MealSlotDto
+
+    @POST("api/meal-plans/{mealPlanId}/generate-shopping-list")
+    suspend fun generateShoppingList(
+        @Path("mealPlanId") mealPlanId: Int,
+    ): GenerateShoppingListDto
+}
+
+@Serializable
+data class MealPlanDto(
+    val id: Int,
+    @SerialName("user_id")
+    val userId: Int = 0,
+    val name: String,
+    @SerialName("week_start")
+    val weekStart: String,
+    val notes: String? = null,
+    @SerialName("created_at")
+    val createdAt: String = "",
+)
+
+@Serializable
+data class MealPlanCreateDto(
+    val name: String,
+    @SerialName("week_start")
+    val weekStart: String,
+    val notes: String? = null,
+)
+
+@Serializable
+data class MealSlotDto(
+    val id: Int,
+    @SerialName("meal_plan_id")
+    val mealPlanId: Int,
+    @SerialName("slot_date")
+    val slotDate: String,
+    @SerialName("slot_type")
+    val slotType: String,
+    val title: String = "",
+    @SerialName("recipe_url")
+    val recipeUrl: String? = null,
+    @SerialName("ingredients_json")
+    val ingredients: List<String> = emptyList(),
+    @SerialName("planned_item_id")
+    val plannedItemId: Int? = null,
+)
+
+@Serializable
+data class MealSlotUpdateDto(
+    val title: String? = null,
+    @SerialName("recipe_url")
+    val recipeUrl: String? = null,
+    @SerialName("ingredients_json")
+    val ingredients: List<String>? = null,
+    @SerialName("planned_item_id")
+    val plannedItemId: Int? = null,
+)
+
+@Serializable
+data class WeekDayDto(
+    val date: String,
+    val slots: Map<String, MealSlotDto> = emptyMap(),
+)
+
+@Serializable
+data class WeekGridDto(
+    @SerialName("meal_plan")
+    val mealPlan: MealPlanDto,
+    val days: List<WeekDayDto> = emptyList(),
+)
+
+@Serializable
+data class GenerateShoppingListDto(
+    @SerialName("shopping_list")
+    val shoppingList: ShoppingListDto,
+    val items: List<PlannedTodayItemDto> = emptyList(),
+)

--- a/android/app/src/main/java/com/daynest/android/data/mealplan/MealPlanRepository.kt
+++ b/android/app/src/main/java/com/daynest/android/data/mealplan/MealPlanRepository.kt
@@ -73,7 +73,10 @@ class MealPlanRepository
             } ?: emptyList()
 
         private suspend fun upsertCachedMealPlan(plan: MealPlanDto) {
-            cacheMealPlans((cachedMealPlans().filterNot { it.id == plan.id } + plan).sortedByDescending { it.weekStart })
+            val updated =
+                (cachedMealPlans().filterNot { it.id == plan.id } + plan)
+                    .sortedByDescending { it.weekStart }
+            cacheMealPlans(updated)
         }
 
         private suspend fun upsertCachedSlot(

--- a/android/app/src/main/java/com/daynest/android/data/mealplan/MealPlanRepository.kt
+++ b/android/app/src/main/java/com/daynest/android/data/mealplan/MealPlanRepository.kt
@@ -1,0 +1,109 @@
+package com.daynest.android.data.mealplan
+
+import com.daynest.android.core.database.sync.CacheEntryDao
+import com.daynest.android.core.database.sync.CacheEntryEntity
+import com.daynest.android.core.network.JsonSerializer
+import com.daynest.android.data.recoverOffline
+import com.daynest.android.data.safeApiCall
+import com.daynest.android.data.sync.SyncCacheKeys
+import kotlinx.serialization.builtins.ListSerializer
+import kotlinx.serialization.encodeToString
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class MealPlanRepository
+    @Inject
+    constructor(
+        private val mealPlanApi: MealPlanApi,
+        private val cacheEntryDao: CacheEntryDao,
+    ) {
+        suspend fun listMealPlans(): Result<List<MealPlanDto>> =
+            safeApiCall { mealPlanApi.listMealPlans() }
+                .onSuccess { plans -> cacheMealPlans(plans) }
+                .recoverOffline { cachedMealPlans() }
+
+        suspend fun createMealPlan(request: MealPlanCreateDto): Result<MealPlanDto> =
+            safeApiCall { mealPlanApi.createMealPlan(request) }
+                .onSuccess { plan -> upsertCachedMealPlan(plan) }
+
+        suspend fun getWeekPlan(mealPlanId: Int): Result<WeekGridDto> {
+            val cacheKey = weekCacheKey(mealPlanId)
+            return safeApiCall { mealPlanApi.getWeekPlan(mealPlanId) }
+                .onSuccess { week ->
+                    cacheEntryDao.upsert(
+                        CacheEntryEntity(
+                            cacheKey = cacheKey,
+                            payload = JsonSerializer.config.encodeToString(WeekGridDto.serializer(), week),
+                            updatedAtEpochMillis = System.currentTimeMillis(),
+                        ),
+                    )
+                    upsertCachedMealPlan(week.mealPlan)
+                }.recoverOffline {
+                    cacheEntryDao.get(cacheKey)?.payload?.let { payload ->
+                        JsonSerializer.config.decodeFromString(WeekGridDto.serializer(), payload)
+                    } ?: error("Meal plan week $mealPlanId not found in cache")
+                }
+        }
+
+        suspend fun updateSlot(
+            mealPlanId: Int,
+            slotId: Int,
+            request: MealSlotUpdateDto,
+        ): Result<MealSlotDto> =
+            safeApiCall { mealPlanApi.updateSlot(mealPlanId, slotId, request) }
+                .onSuccess { slot -> upsertCachedSlot(mealPlanId, slot) }
+
+        suspend fun generateShoppingList(mealPlanId: Int): Result<GenerateShoppingListDto> =
+            safeApiCall { mealPlanApi.generateShoppingList(mealPlanId) }
+
+        private suspend fun cacheMealPlans(plans: List<MealPlanDto>) {
+            cacheEntryDao.upsert(
+                CacheEntryEntity(
+                    cacheKey = SyncCacheKeys.MEAL_PLANS,
+                    payload = JsonSerializer.config.encodeToString(ListSerializer(MealPlanDto.serializer()), plans),
+                    updatedAtEpochMillis = System.currentTimeMillis(),
+                ),
+            )
+        }
+
+        private suspend fun cachedMealPlans(): List<MealPlanDto> =
+            cacheEntryDao.get(SyncCacheKeys.MEAL_PLANS)?.payload?.let { payload ->
+                JsonSerializer.config.decodeFromString(ListSerializer(MealPlanDto.serializer()), payload)
+            } ?: emptyList()
+
+        private suspend fun upsertCachedMealPlan(plan: MealPlanDto) {
+            cacheMealPlans((cachedMealPlans().filterNot { it.id == plan.id } + plan).sortedByDescending { it.weekStart })
+        }
+
+        private suspend fun upsertCachedSlot(
+            mealPlanId: Int,
+            slot: MealSlotDto,
+        ) {
+            val cacheKey = weekCacheKey(mealPlanId)
+            val cachedWeek =
+                cacheEntryDao.get(cacheKey)?.payload?.let { payload ->
+                    JsonSerializer.config.decodeFromString(WeekGridDto.serializer(), payload)
+                } ?: return
+            val updatedWeek =
+                cachedWeek.copy(
+                    days =
+                        cachedWeek.days.map { day ->
+                            if (day.date == slot.slotDate) {
+                                day.copy(slots = day.slots + (slot.slotType to slot))
+                            } else {
+                                day
+                            }
+                        },
+                )
+            cacheEntryDao.upsert(
+                CacheEntryEntity(
+                    cacheKey = cacheKey,
+                    payload = JsonSerializer.config.encodeToString(WeekGridDto.serializer(), updatedWeek),
+                    updatedAtEpochMillis = System.currentTimeMillis(),
+                ),
+            )
+        }
+
+        private fun weekCacheKey(mealPlanId: Int): String = "${SyncCacheKeys.MEAL_SLOTS}:$mealPlanId"
+    }

--- a/android/app/src/main/java/com/daynest/android/data/sync/SyncCacheKeys.kt
+++ b/android/app/src/main/java/com/daynest/android/data/sync/SyncCacheKeys.kt
@@ -6,4 +6,6 @@ object SyncCacheKeys {
     const val ROUTINE_TEMPLATES = "routine_templates"
     const val CHORE_TEMPLATES = "chore_templates"
     const val SHOPPING_LISTS = "shopping_lists"
+    const val MEAL_PLANS = "meal_plans"
+    const val MEAL_SLOTS = "meal_slots"
 }

--- a/android/app/src/main/java/com/daynest/android/feature/mealplan/MealPlannerScreen.kt
+++ b/android/app/src/main/java/com/daynest/android/feature/mealplan/MealPlannerScreen.kt
@@ -1,0 +1,241 @@
+@file:Suppress("ktlint:standard:function-naming", "FunctionNaming")
+
+package com.daynest.android.feature.mealplan
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.foundation.lazy.grid.items
+import androidx.compose.material3.Card
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.FloatingActionButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.daynest.android.R
+import com.daynest.android.app.navigation.DaynestDestination
+import com.daynest.android.app.navigation.DaynestNavigationScaffold
+import com.daynest.android.data.mealplan.MealSlotDto
+import com.daynest.android.data.mealplan.WeekDayDto
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
+import java.time.format.TextStyle
+import java.util.Locale
+
+@Composable
+fun MealPlannerRoute(
+    onNavigate: (String) -> Unit = {},
+    viewModel: MealPlannerViewModel = hiltViewModel(),
+) {
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    val snackbarHostState = remember { SnackbarHostState() }
+
+    LaunchedEffect(viewModel) {
+        viewModel.effects.collect { snackbarHostState.showSnackbar(it) }
+    }
+
+    MealPlannerScreen(
+        uiState = uiState,
+        onNavigate = onNavigate,
+        onPreviousWeek = viewModel::previousWeek,
+        onNextWeek = viewModel::nextWeek,
+        onRefresh = viewModel::loadWeek,
+        onEditSlot = viewModel::editSlot,
+        onDismissEditor = viewModel::dismissEditor,
+        onDraftChange = viewModel::updateDraft,
+        onSaveSlot = viewModel::saveSlot,
+        onGenerateShoppingList = viewModel::generateShoppingList,
+        snackbarHostState = snackbarHostState,
+    )
+}
+
+@Composable
+internal fun MealPlannerScreen(
+    uiState: MealPlannerUiState,
+    onNavigate: (String) -> Unit,
+    onPreviousWeek: () -> Unit,
+    onNextWeek: () -> Unit,
+    onRefresh: () -> Unit,
+    onEditSlot: (MealSlotDto) -> Unit,
+    onDismissEditor: () -> Unit,
+    onDraftChange: (MealSlotDraft) -> Unit,
+    onSaveSlot: () -> Unit,
+    onGenerateShoppingList: () -> Unit,
+    snackbarHostState: SnackbarHostState,
+) {
+    DaynestNavigationScaffold(
+        currentRoute = DaynestDestination.MEAL_PLAN,
+        onNavigate = onNavigate,
+        snackbarHostState = snackbarHostState,
+        floatingActionButton = {
+            FloatingActionButton(onClick = onGenerateShoppingList) {
+                Text(text = stringResource(id = R.string.meal_plan_generate_shopping_list_short))
+            }
+        },
+    ) { innerPadding ->
+        MealPlannerContent(
+            uiState = uiState,
+            onPreviousWeek = onPreviousWeek,
+            onNextWeek = onNextWeek,
+            onRefresh = onRefresh,
+            onEditSlot = onEditSlot,
+            modifier = Modifier.padding(innerPadding),
+        )
+    }
+
+    if (uiState.editingSlot != null) {
+        MealSlotBottomSheet(
+            draft = uiState.draft,
+            onDraftChange = onDraftChange,
+            onDismiss = onDismissEditor,
+            onSave = onSaveSlot,
+        )
+    }
+}
+
+@Composable
+private fun MealPlannerContent(
+    uiState: MealPlannerUiState,
+    onPreviousWeek: () -> Unit,
+    onNextWeek: () -> Unit,
+    onRefresh: () -> Unit,
+    onEditSlot: (MealSlotDto) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier.fillMaxSize().padding(16.dp),
+        verticalArrangement = Arrangement.spacedBy(12.dp),
+    ) {
+        Text(text = stringResource(id = R.string.meal_plan_title), style = MaterialTheme.typography.headlineSmall)
+        Text(text = stringResource(id = R.string.meal_plan_subtitle), style = MaterialTheme.typography.bodyMedium)
+        WeekNavigation(
+            weekStart = uiState.weekStart,
+            onPreviousWeek = onPreviousWeek,
+            onNextWeek = onNextWeek,
+        )
+        uiState.error?.let { error ->
+            Text(text = error, color = MaterialTheme.colorScheme.error)
+            TextButton(onClick = onRefresh) { Text(text = stringResource(id = R.string.action_refresh)) }
+        }
+        if (uiState.isLoading) {
+            Box(modifier = Modifier.fillMaxWidth(), contentAlignment = Alignment.Center) {
+                CircularProgressIndicator()
+            }
+        }
+        uiState.weekGrid?.let { week ->
+            MealWeekGrid(
+                days = mealGridSlots(week.days),
+                onEditSlot = onEditSlot,
+            )
+        }
+    }
+}
+
+@Composable
+private fun WeekNavigation(
+    weekStart: LocalDate,
+    onPreviousWeek: () -> Unit,
+    onNextWeek: () -> Unit,
+) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        TextButton(onClick = onPreviousWeek) { Text(text = "‹") }
+        Text(
+            text = stringResource(
+                id = R.string.meal_plan_week_range,
+                weekStart.format(DateTimeFormatter.ISO_DATE),
+                weekStart.plusDays(6).format(DateTimeFormatter.ISO_DATE),
+            ),
+            fontWeight = FontWeight.Bold,
+        )
+        TextButton(onClick = onNextWeek) { Text(text = "›") }
+    }
+}
+
+@Composable
+private fun MealWeekGrid(
+    days: List<MealSlotDto>,
+    onEditSlot: (MealSlotDto) -> Unit,
+) {
+    LazyVerticalGrid(
+        columns = GridCells.Fixed(7),
+        contentPadding = PaddingValues(bottom = 88.dp),
+        horizontalArrangement = Arrangement.spacedBy(6.dp),
+        verticalArrangement = Arrangement.spacedBy(6.dp),
+    ) {
+        items(days, key = { it.id }) { slot ->
+            MealSlotCard(slot = slot, onEditSlot = onEditSlot)
+        }
+    }
+}
+
+@Composable
+private fun MealSlotCard(
+    slot: MealSlotDto,
+    onEditSlot: (MealSlotDto) -> Unit,
+) {
+    val date = LocalDate.parse(slot.slotDate)
+    Card(
+        modifier =
+            Modifier
+                .fillMaxWidth()
+                .height(132.dp)
+                .clickable { onEditSlot(slot) },
+    ) {
+        Column(
+            modifier = Modifier.padding(8.dp),
+            verticalArrangement = Arrangement.spacedBy(4.dp),
+        ) {
+            Text(
+                text = date.dayOfWeek.getDisplayName(TextStyle.SHORT, Locale.getDefault()),
+                style = MaterialTheme.typography.labelMedium,
+                fontWeight = FontWeight.Bold,
+            )
+            Text(text = slot.slotType.replaceFirstChar { it.uppercase() }, style = MaterialTheme.typography.labelSmall)
+            Spacer(modifier = Modifier.height(2.dp))
+            Text(
+                text = slot.title.ifBlank { stringResource(id = R.string.meal_plan_empty_slot) },
+                style = MaterialTheme.typography.bodySmall,
+                maxLines = 2,
+                overflow = TextOverflow.Ellipsis,
+            )
+            if (slot.ingredients.isNotEmpty()) {
+                Text(
+                    text = stringResource(id = R.string.meal_plan_ingredient_count, slot.ingredients.size),
+                    style = MaterialTheme.typography.labelSmall,
+                )
+            }
+        }
+    }
+}
+
+private fun mealGridSlots(days: List<WeekDayDto>): List<MealSlotDto> =
+    listOf("breakfast", "lunch", "dinner", "snack").flatMap { slotType ->
+        days.mapNotNull { day -> day.slots[slotType] }
+    }

--- a/android/app/src/main/java/com/daynest/android/feature/mealplan/MealPlannerScreen.kt
+++ b/android/app/src/main/java/com/daynest/android/feature/mealplan/MealPlannerScreen.kt
@@ -29,6 +29,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
@@ -43,7 +44,6 @@ import com.daynest.android.data.mealplan.WeekDayDto
 import java.time.LocalDate
 import java.time.format.DateTimeFormatter
 import java.time.format.TextStyle
-import java.util.Locale
 
 @Composable
 fun MealPlannerRoute(
@@ -203,6 +203,7 @@ private fun MealSlotCard(
     onEditSlot: (MealSlotDto) -> Unit,
 ) {
     val date = remember(slot.slotDate) { LocalDate.parse(slot.slotDate) }
+    val locale = LocalConfiguration.current.locales[0]
     val slotTypeLabel =
         when (slot.slotType.lowercase()) {
             "breakfast" -> stringResource(id = R.string.meal_slot_breakfast)
@@ -223,7 +224,7 @@ private fun MealSlotCard(
             verticalArrangement = Arrangement.spacedBy(4.dp),
         ) {
             Text(
-                text = date.dayOfWeek.getDisplayName(TextStyle.SHORT, Locale.getDefault()),
+                text = date.dayOfWeek.getDisplayName(TextStyle.SHORT, locale),
                 style = MaterialTheme.typography.labelMedium,
                 fontWeight = FontWeight.Bold,
             )

--- a/android/app/src/main/java/com/daynest/android/feature/mealplan/MealPlannerScreen.kt
+++ b/android/app/src/main/java/com/daynest/android/feature/mealplan/MealPlannerScreen.kt
@@ -146,8 +146,9 @@ private fun MealPlannerContent(
             }
         }
         uiState.weekGrid?.let { week ->
+            val slots = remember(week.days) { mealGridSlots(week.days) }
             MealWeekGrid(
-                days = mealGridSlots(week.days),
+                days = slots,
                 onEditSlot = onEditSlot,
             )
         }
@@ -167,11 +168,12 @@ private fun WeekNavigation(
     ) {
         TextButton(onClick = onPreviousWeek) { Text(text = "‹") }
         Text(
-            text = stringResource(
-                id = R.string.meal_plan_week_range,
-                weekStart.format(DateTimeFormatter.ISO_DATE),
-                weekStart.plusDays(6).format(DateTimeFormatter.ISO_DATE),
-            ),
+            text =
+                stringResource(
+                    id = R.string.meal_plan_week_range,
+                    weekStart.format(DateTimeFormatter.ISO_DATE),
+                    weekStart.plusDays(WEEK_END_DAY_OFFSET).format(DateTimeFormatter.ISO_DATE),
+                ),
             fontWeight = FontWeight.Bold,
         )
         TextButton(onClick = onNextWeek) { Text(text = "›") }
@@ -184,7 +186,7 @@ private fun MealWeekGrid(
     onEditSlot: (MealSlotDto) -> Unit,
 ) {
     LazyVerticalGrid(
-        columns = GridCells.Fixed(7),
+        columns = GridCells.Fixed(DAYS_PER_WEEK),
         contentPadding = PaddingValues(bottom = 88.dp),
         horizontalArrangement = Arrangement.spacedBy(6.dp),
         verticalArrangement = Arrangement.spacedBy(6.dp),
@@ -200,7 +202,15 @@ private fun MealSlotCard(
     slot: MealSlotDto,
     onEditSlot: (MealSlotDto) -> Unit,
 ) {
-    val date = LocalDate.parse(slot.slotDate)
+    val date = remember(slot.slotDate) { LocalDate.parse(slot.slotDate) }
+    val slotTypeLabel =
+        when (slot.slotType.lowercase()) {
+            "breakfast" -> stringResource(id = R.string.meal_slot_breakfast)
+            "lunch" -> stringResource(id = R.string.meal_slot_lunch)
+            "dinner" -> stringResource(id = R.string.meal_slot_dinner)
+            "snack" -> stringResource(id = R.string.meal_slot_snack)
+            else -> slot.slotType.replaceFirstChar { it.uppercase() }
+        }
     Card(
         modifier =
             Modifier
@@ -217,7 +227,7 @@ private fun MealSlotCard(
                 style = MaterialTheme.typography.labelMedium,
                 fontWeight = FontWeight.Bold,
             )
-            Text(text = slot.slotType.replaceFirstChar { it.uppercase() }, style = MaterialTheme.typography.labelSmall)
+            Text(text = slotTypeLabel, style = MaterialTheme.typography.labelSmall)
             Spacer(modifier = Modifier.height(2.dp))
             Text(
                 text = slot.title.ifBlank { stringResource(id = R.string.meal_plan_empty_slot) },
@@ -234,6 +244,9 @@ private fun MealSlotCard(
         }
     }
 }
+
+private const val DAYS_PER_WEEK = 7
+private const val WEEK_END_DAY_OFFSET = 6L
 
 private fun mealGridSlots(days: List<WeekDayDto>): List<MealSlotDto> =
     listOf("breakfast", "lunch", "dinner", "snack").flatMap { slotType ->

--- a/android/app/src/main/java/com/daynest/android/feature/mealplan/MealPlannerViewModel.kt
+++ b/android/app/src/main/java/com/daynest/android/feature/mealplan/MealPlannerViewModel.kt
@@ -12,6 +12,7 @@ import com.daynest.android.data.mealplan.MealSlotDto
 import com.daynest.android.data.mealplan.MealSlotUpdateDto
 import com.daynest.android.data.mealplan.WeekGridDto
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow
@@ -39,30 +40,34 @@ class MealPlannerViewModel
         private val _effects = MutableSharedFlow<String>()
         val effects: SharedFlow<String> = _effects.asSharedFlow()
 
+        private var loadJob: Job? = null
+
         init {
             loadWeek()
         }
 
         fun loadWeek() {
             val weekStart = _uiState.value.weekStart
-            viewModelScope.launch {
-                _uiState.update { it.copy(isLoading = true, error = null) }
-                mealPlanRepository
-                    .listMealPlans()
-                    .fold(
-                        onSuccess = { plans ->
-                            val plan = plans.firstOrNull { it.weekStart == weekStart.toString() }
-                            if (plan == null) {
-                                createWeekPlan(weekStart)
-                            } else {
-                                loadGrid(plan)
-                            }
-                        },
-                        onFailure = { failure ->
-                            _uiState.update { it.copy(isLoading = false, error = failure.message) }
-                        },
-                    )
-            }
+            loadJob?.cancel()
+            loadJob =
+                viewModelScope.launch {
+                    _uiState.update { it.copy(isLoading = true, error = null) }
+                    mealPlanRepository
+                        .listMealPlans()
+                        .fold(
+                            onSuccess = { plans ->
+                                val plan = plans.firstOrNull { it.weekStart == weekStart.toString() }
+                                if (plan == null) {
+                                    createWeekPlan(weekStart)
+                                } else {
+                                    loadGrid(plan)
+                                }
+                            },
+                            onFailure = { failure ->
+                                _uiState.update { it.copy(isLoading = false, error = failure.message) }
+                            },
+                        )
+                }
         }
 
         fun previousWeek() {
@@ -101,7 +106,11 @@ class MealPlannerViewModel
                             MealSlotUpdateDto(
                                 title = draft.title.trim().ifBlank { null },
                                 recipeUrl = draft.recipeUrl.trim().ifBlank { null },
-                                ingredients = draft.ingredients.lines().map { it.trim() }.filter { it.isNotBlank() },
+                                ingredients =
+                                    draft.ingredients
+                                        .lines()
+                                        .map { it.trim() }
+                                        .filter { it.isNotBlank() },
                                 plannedItemId = slot.plannedItemId,
                             ),
                     ).onSuccess { updatedSlot ->
@@ -118,7 +127,10 @@ class MealPlannerViewModel
         }
 
         fun generateShoppingList() {
-            val planId = _uiState.value.weekGrid?.mealPlan?.id ?: return
+            val planId =
+                _uiState.value.weekGrid
+                    ?.mealPlan
+                    ?.id ?: return
             viewModelScope.launch {
                 mealPlanRepository
                     .generateShoppingList(planId)
@@ -132,7 +144,9 @@ class MealPlannerViewModel
                                     response.items.size,
                                 ),
                         )
-                    }.onFailure { _effects.emit(it.message ?: getString(R.string.meal_plan_error_generate_shopping_list)) }
+                    }.onFailure { error ->
+                        _effects.emit(error.message ?: getString(R.string.meal_plan_error_generate_shopping_list))
+                    }
             }
         }
 
@@ -140,10 +154,11 @@ class MealPlannerViewModel
             mealPlanRepository
                 .createMealPlan(
                     MealPlanCreateDto(
-                        name = getApplication<Application>().getString(
-                            R.string.meal_plan_default_name,
-                            weekStart.format(DateTimeFormatter.ISO_DATE),
-                        ),
+                        name =
+                            getApplication<Application>().getString(
+                                R.string.meal_plan_default_name,
+                                weekStart.format(DateTimeFormatter.ISO_DATE),
+                            ),
                         weekStart = weekStart.toString(),
                     ),
                 ).fold(
@@ -156,7 +171,9 @@ class MealPlannerViewModel
             mealPlanRepository
                 .getWeekPlan(plan.id)
                 .fold(
-                    onSuccess = { week -> _uiState.update { it.copy(weekGrid = week, isLoading = false, error = null) } },
+                    onSuccess = { week ->
+                        _uiState.update { it.copy(weekGrid = week, isLoading = false, error = null) }
+                    },
                     onFailure = { failure -> _uiState.update { it.copy(isLoading = false, error = failure.message) } },
                 )
         }
@@ -190,8 +207,7 @@ data class MealSlotDraft(
     }
 }
 
-private fun currentWeekStart(): LocalDate =
-    LocalDate.now().with(TemporalAdjusters.previousOrSame(DayOfWeek.MONDAY))
+private fun currentWeekStart(): LocalDate = LocalDate.now().with(TemporalAdjusters.previousOrSame(DayOfWeek.MONDAY))
 
 private fun WeekGridDto.replaceSlot(slot: MealSlotDto): WeekGridDto =
     copy(

--- a/android/app/src/main/java/com/daynest/android/feature/mealplan/MealPlannerViewModel.kt
+++ b/android/app/src/main/java/com/daynest/android/feature/mealplan/MealPlannerViewModel.kt
@@ -1,0 +1,206 @@
+package com.daynest.android.feature.mealplan
+
+import android.app.Application
+import androidx.annotation.StringRes
+import androidx.lifecycle.AndroidViewModel
+import androidx.lifecycle.viewModelScope
+import com.daynest.android.R
+import com.daynest.android.data.mealplan.MealPlanCreateDto
+import com.daynest.android.data.mealplan.MealPlanDto
+import com.daynest.android.data.mealplan.MealPlanRepository
+import com.daynest.android.data.mealplan.MealSlotDto
+import com.daynest.android.data.mealplan.MealSlotUpdateDto
+import com.daynest.android.data.mealplan.WeekGridDto
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import java.time.DayOfWeek
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
+import java.time.temporal.TemporalAdjusters
+import javax.inject.Inject
+
+@HiltViewModel
+class MealPlannerViewModel
+    @Inject
+    constructor(
+        application: Application,
+        private val mealPlanRepository: MealPlanRepository,
+    ) : AndroidViewModel(application) {
+        private val _uiState = MutableStateFlow(MealPlannerUiState(weekStart = currentWeekStart()))
+        val uiState: StateFlow<MealPlannerUiState> = _uiState.asStateFlow()
+
+        private val _effects = MutableSharedFlow<String>()
+        val effects: SharedFlow<String> = _effects.asSharedFlow()
+
+        init {
+            loadWeek()
+        }
+
+        fun loadWeek() {
+            val weekStart = _uiState.value.weekStart
+            viewModelScope.launch {
+                _uiState.update { it.copy(isLoading = true, error = null) }
+                mealPlanRepository
+                    .listMealPlans()
+                    .fold(
+                        onSuccess = { plans ->
+                            val plan = plans.firstOrNull { it.weekStart == weekStart.toString() }
+                            if (plan == null) {
+                                createWeekPlan(weekStart)
+                            } else {
+                                loadGrid(plan)
+                            }
+                        },
+                        onFailure = { failure ->
+                            _uiState.update { it.copy(isLoading = false, error = failure.message) }
+                        },
+                    )
+            }
+        }
+
+        fun previousWeek() {
+            _uiState.update { it.copy(weekStart = it.weekStart.minusWeeks(1), weekGrid = null) }
+            loadWeek()
+        }
+
+        fun nextWeek() {
+            _uiState.update { it.copy(weekStart = it.weekStart.plusWeeks(1), weekGrid = null) }
+            loadWeek()
+        }
+
+        fun editSlot(slot: MealSlotDto) {
+            _uiState.update { it.copy(editingSlot = slot, draft = MealSlotDraft.from(slot)) }
+        }
+
+        fun dismissEditor() {
+            _uiState.update { it.copy(editingSlot = null, draft = MealSlotDraft()) }
+        }
+
+        fun updateDraft(draft: MealSlotDraft) {
+            _uiState.update { it.copy(draft = draft) }
+        }
+
+        fun saveSlot() {
+            val state = _uiState.value
+            val planId = state.weekGrid?.mealPlan?.id ?: return
+            val slot = state.editingSlot ?: return
+            val draft = state.draft
+            viewModelScope.launch {
+                mealPlanRepository
+                    .updateSlot(
+                        mealPlanId = planId,
+                        slotId = slot.id,
+                        request =
+                            MealSlotUpdateDto(
+                                title = draft.title.trim().ifBlank { null },
+                                recipeUrl = draft.recipeUrl.trim().ifBlank { null },
+                                ingredients = draft.ingredients.lines().map { it.trim() }.filter { it.isNotBlank() },
+                                plannedItemId = slot.plannedItemId,
+                            ),
+                    ).onSuccess { updatedSlot ->
+                        _uiState.update { current ->
+                            current.copy(
+                                editingSlot = null,
+                                draft = MealSlotDraft(),
+                                weekGrid = current.weekGrid?.replaceSlot(updatedSlot),
+                            )
+                        }
+                        _effects.emit(getString(R.string.meal_plan_slot_saved))
+                    }.onFailure { _effects.emit(it.message ?: getString(R.string.meal_plan_error_save_slot)) }
+            }
+        }
+
+        fun generateShoppingList() {
+            val planId = _uiState.value.weekGrid?.mealPlan?.id ?: return
+            viewModelScope.launch {
+                mealPlanRepository
+                    .generateShoppingList(planId)
+                    .onSuccess { response ->
+                        _effects.emit(
+                            getApplication<Application>()
+                                .resources
+                                .getQuantityString(
+                                    R.plurals.meal_plan_shopping_list_generated,
+                                    response.items.size,
+                                    response.items.size,
+                                ),
+                        )
+                    }.onFailure { _effects.emit(it.message ?: getString(R.string.meal_plan_error_generate_shopping_list)) }
+            }
+        }
+
+        private suspend fun createWeekPlan(weekStart: LocalDate) {
+            mealPlanRepository
+                .createMealPlan(
+                    MealPlanCreateDto(
+                        name = getApplication<Application>().getString(
+                            R.string.meal_plan_default_name,
+                            weekStart.format(DateTimeFormatter.ISO_DATE),
+                        ),
+                        weekStart = weekStart.toString(),
+                    ),
+                ).fold(
+                    onSuccess = { loadGrid(it) },
+                    onFailure = { failure -> _uiState.update { it.copy(isLoading = false, error = failure.message) } },
+                )
+        }
+
+        private suspend fun loadGrid(plan: MealPlanDto) {
+            mealPlanRepository
+                .getWeekPlan(plan.id)
+                .fold(
+                    onSuccess = { week -> _uiState.update { it.copy(weekGrid = week, isLoading = false, error = null) } },
+                    onFailure = { failure -> _uiState.update { it.copy(isLoading = false, error = failure.message) } },
+                )
+        }
+
+        private fun getString(
+            @StringRes resId: Int,
+        ): String = getApplication<Application>().getString(resId)
+    }
+
+data class MealPlannerUiState(
+    val weekStart: LocalDate,
+    val weekGrid: WeekGridDto? = null,
+    val isLoading: Boolean = false,
+    val error: String? = null,
+    val editingSlot: MealSlotDto? = null,
+    val draft: MealSlotDraft = MealSlotDraft(),
+)
+
+data class MealSlotDraft(
+    val title: String = "",
+    val recipeUrl: String = "",
+    val ingredients: String = "",
+) {
+    companion object {
+        fun from(slot: MealSlotDto): MealSlotDraft =
+            MealSlotDraft(
+                title = slot.title,
+                recipeUrl = slot.recipeUrl.orEmpty(),
+                ingredients = slot.ingredients.joinToString("\n"),
+            )
+    }
+}
+
+private fun currentWeekStart(): LocalDate =
+    LocalDate.now().with(TemporalAdjusters.previousOrSame(DayOfWeek.MONDAY))
+
+private fun WeekGridDto.replaceSlot(slot: MealSlotDto): WeekGridDto =
+    copy(
+        days =
+            days.map { day ->
+                if (day.date == slot.slotDate) {
+                    day.copy(slots = day.slots + (slot.slotType to slot))
+                } else {
+                    day
+                }
+            },
+    )

--- a/android/app/src/main/java/com/daynest/android/feature/mealplan/MealSlotBottomSheet.kt
+++ b/android/app/src/main/java/com/daynest/android/feature/mealplan/MealSlotBottomSheet.kt
@@ -1,0 +1,71 @@
+@file:Suppress("ktlint:standard:function-naming", "FunctionNaming")
+
+package com.daynest.android.feature.mealplan
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import com.daynest.android.R
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun MealSlotBottomSheet(
+    draft: MealSlotDraft,
+    onDraftChange: (MealSlotDraft) -> Unit,
+    onDismiss: () -> Unit,
+    onSave: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    ModalBottomSheet(onDismissRequest = onDismiss) {
+        Column(
+            modifier = modifier.padding(24.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            Text(text = stringResource(id = R.string.meal_plan_edit_slot_title))
+            OutlinedTextField(
+                value = draft.title,
+                onValueChange = { onDraftChange(draft.copy(title = it)) },
+                modifier = Modifier.fillMaxWidth(),
+                label = { Text(text = stringResource(id = R.string.meal_plan_slot_title_label)) },
+                singleLine = true,
+            )
+            OutlinedTextField(
+                value = draft.recipeUrl,
+                onValueChange = { onDraftChange(draft.copy(recipeUrl = it)) },
+                modifier = Modifier.fillMaxWidth(),
+                label = { Text(text = stringResource(id = R.string.meal_plan_recipe_url_label)) },
+                singleLine = true,
+            )
+            OutlinedTextField(
+                value = draft.ingredients,
+                onValueChange = { onDraftChange(draft.copy(ingredients = it)) },
+                modifier = Modifier.fillMaxWidth(),
+                label = { Text(text = stringResource(id = R.string.meal_plan_ingredients_label)) },
+                minLines = 4,
+            )
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.End,
+            ) {
+                TextButton(onClick = onDismiss) {
+                    Text(text = stringResource(id = R.string.action_cancel))
+                }
+                Button(onClick = onSave) {
+                    Text(text = stringResource(id = R.string.action_save))
+                }
+            }
+        }
+    }
+}

--- a/android/app/src/main/java/com/daynest/android/feature/mealplan/MealSlotBottomSheet.kt
+++ b/android/app/src/main/java/com/daynest/android/feature/mealplan/MealSlotBottomSheet.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material3.Button
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ModalBottomSheet
@@ -16,6 +17,7 @@ import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
 import com.daynest.android.R
 
@@ -47,6 +49,7 @@ fun MealSlotBottomSheet(
                 modifier = Modifier.fillMaxWidth(),
                 label = { Text(text = stringResource(id = R.string.meal_plan_recipe_url_label)) },
                 singleLine = true,
+                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Uri),
             )
             OutlinedTextField(
                 value = draft.ingredients,

--- a/android/app/src/main/res/values-nl/strings.xml
+++ b/android/app/src/main/res/values-nl/strings.xml
@@ -236,6 +236,30 @@
 
     <string name="parity_more_coming">Native bewerkingsbediening blijft groeien vanuit dezelfde gedeelde API-contracten.</string>
 
+    <!-- Maaltijdplanner -->
+    <string name="meal_plan_title">Maaltijden</string>
+    <string name="meal_plan_subtitle">Plan maaltijden per week en maak automatisch een boodschappenlijst.</string>
+    <string name="meal_plan_default_name">Week van %1$s</string>
+    <string name="meal_plan_week_range">%1$s – %2$s</string>
+    <string name="meal_plan_empty_slot">Nog geen maaltijd</string>
+    <string name="meal_plan_ingredient_count">%1$d ingrediënten</string>
+    <string name="meal_plan_edit_slot_title">Maaltijdslot bewerken</string>
+    <string name="meal_plan_slot_title_label">Titel</string>
+    <string name="meal_plan_recipe_url_label">Recept-URL</string>
+    <string name="meal_plan_ingredients_label">Ingrediënten (één per regel)</string>
+    <string name="meal_plan_generate_shopping_list_short">Lijst</string>
+    <string name="meal_plan_slot_saved">Maaltijdslot opgeslagen</string>
+    <string name="meal_plan_error_save_slot">Kan maaltijdslot niet opslaan</string>
+    <string name="meal_plan_error_generate_shopping_list">Kan boodschappenlijst niet maken</string>
+    <plurals name="meal_plan_shopping_list_generated">
+        <item quantity="one">Boodschappenlijst gemaakt met %1$d item.</item>
+        <item quantity="other">Boodschappenlijst gemaakt met %1$d items.</item>
+    </plurals>
+    <string name="meal_slot_breakfast">Ontbijt</string>
+    <string name="meal_slot_lunch">Lunch</string>
+    <string name="meal_slot_dinner">Diner</string>
+    <string name="meal_slot_snack">Tussendoortje</string>
+
     <!-- Startscherm-widgets -->
     <string name="widget_small_label">Daynest (klein)</string>
     <string name="widget_medium_label">Daynest (middel)</string>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -264,4 +264,24 @@
         <item quantity="one">%1$d item failed</item>
         <item quantity="other">%1$d items failed</item>
     </plurals>
+    <!-- Meal planning -->
+    <string name="meal_plan_title">Maaltijden</string>
+    <string name="meal_plan_subtitle">Plan maaltijden per week en maak automatisch een boodschappenlijst.</string>
+    <string name="meal_plan_default_name">Week van %1$s</string>
+    <string name="meal_plan_week_range">%1$s – %2$s</string>
+    <string name="meal_plan_empty_slot">Nog geen maaltijd</string>
+    <string name="meal_plan_ingredient_count">%1$d ingrediënten</string>
+    <string name="meal_plan_edit_slot_title">Maaltijdslot bewerken</string>
+    <string name="meal_plan_slot_title_label">Titel</string>
+    <string name="meal_plan_recipe_url_label">Recept-URL</string>
+    <string name="meal_plan_ingredients_label">Ingrediënten (één per regel)</string>
+    <string name="meal_plan_generate_shopping_list_short">Lijst</string>
+    <string name="meal_plan_slot_saved">Maaltijdslot opgeslagen</string>
+    <string name="meal_plan_error_save_slot">Kan maaltijdslot niet opslaan</string>
+    <string name="meal_plan_error_generate_shopping_list">Kan boodschappenlijst niet maken</string>
+    <plurals name="meal_plan_shopping_list_generated">
+        <item quantity="one">Boodschappenlijst gemaakt met %1$d item.</item>
+        <item quantity="other">Boodschappenlijst gemaakt met %1$d items.</item>
+    </plurals>
+
 </resources>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -283,5 +283,9 @@
         <item quantity="one">Boodschappenlijst gemaakt met %1$d item.</item>
         <item quantity="other">Boodschappenlijst gemaakt met %1$d items.</item>
     </plurals>
+    <string name="meal_slot_breakfast">Ontbijt</string>
+    <string name="meal_slot_lunch">Lunch</string>
+    <string name="meal_slot_dinner">Diner</string>
+    <string name="meal_slot_snack">Tussendoortje</string>
 
 </resources>

--- a/android/app/src/test/java/com/daynest/android/app/navigation/DaynestDestinationTest.kt
+++ b/android/app/src/test/java/com/daynest/android/app/navigation/DaynestDestinationTest.kt
@@ -16,6 +16,7 @@ class DaynestDestinationTest {
                 DaynestDestination.MEDICATION,
                 DaynestDestination.TEMPLATES,
                 DaynestDestination.SHOPPING,
+                DaynestDestination.MEAL_PLAN,
                 DaynestDestination.SETTINGS,
             ),
             routes,

--- a/custom_components/daynest/calendar.py
+++ b/custom_components/daynest/calendar.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import UTC, date, datetime
+from datetime import UTC, date, datetime, time, timedelta
 from typing import TYPE_CHECKING
 
 from daynest import DaynestError
@@ -12,6 +12,7 @@ from homeassistant.components.calendar import (
     CalendarEntityFeature,
     CalendarEvent,
 )
+from homeassistant.util import dt as dt_util
 
 from .const import LOGGER
 from .entity import DaynestEntity
@@ -37,6 +38,18 @@ PLANNED_ENTITY_DESCRIPTION = CalendarEntityDescription(
     key="daynest_planned_calendar",
     translation_key="daynest_planned_calendar",
 )
+MEAL_PLAN_ENTITY_DESCRIPTION = CalendarEntityDescription(
+    key="daynest_meal_plan_calendar",
+    translation_key="daynest_meal_plan_calendar",
+)
+
+MEAL_SLOT_START_TIMES = {
+    "breakfast": time(8, 0),
+    "lunch": time(12, 0),
+    "dinner": time(18, 0),
+    "snack": time(15, 0),
+}
+MEAL_SLOT_DURATION = timedelta(hours=1)
 
 
 async def async_setup_entry(
@@ -58,7 +71,11 @@ async def async_setup_entry(
             DaynestPlannedCalendar(
                 coordinator=entry.runtime_data.coordinator,
                 entity_description=PLANNED_ENTITY_DESCRIPTION,
-            )
+            ),
+            DaynestMealPlanCalendarEntity(
+                coordinator=entry.runtime_data.coordinator,
+                entity_description=MEAL_PLAN_ENTITY_DESCRIPTION,
+            ),
         ]
     )
 
@@ -171,3 +188,79 @@ class DaynestPlannedCalendar(DaynestCalendarEntity):
     """Calendar view for planned items."""
 
     _event_type = "planned_items"
+
+
+def _parse_iso_date(value: object) -> date | None:
+    """Parse an ISO date object for meal slot mapping."""
+    if isinstance(value, date) and not isinstance(value, datetime):
+        return value
+    if isinstance(value, str):
+        try:
+            return date.fromisoformat(value)
+        except ValueError:
+            return None
+    return None
+
+
+class DaynestMealPlanCalendarEntity(CalendarEntity, DaynestEntity):
+    """Calendar view for meal plan slots."""
+
+    _attr_supported_features = CalendarEntityFeature(0)
+
+    def __init__(
+        self,
+        coordinator: DaynestDataUpdateCoordinator,
+        entity_description: CalendarEntityDescription,
+    ) -> None:
+        """Initialize the meal plan calendar entity."""
+        super().__init__(coordinator, entity_description)
+
+    @property
+    def event(self) -> CalendarEvent | None:
+        """Return the next upcoming meal event if available."""
+        now = datetime.now(UTC)
+        future_events = [event for event in self._meal_slot_events(now, now + timedelta(days=14)) if event.start >= now]
+        return min(future_events, key=lambda event: event.start) if future_events else None
+
+    async def async_get_events(
+        self,
+        hass: HomeAssistant,
+        start_datetime: datetime,
+        end_datetime: datetime,
+    ) -> list[CalendarEvent]:
+        """Return meal slot events from coordinator data in the requested range."""
+        return self._meal_slot_events(start_datetime, end_datetime)
+
+    def _meal_slot_events(self, start_datetime: datetime, end_datetime: datetime) -> list[CalendarEvent]:
+        local_tz = dt_util.get_time_zone(self.hass.config.time_zone) or UTC
+        range_start = start_datetime if start_datetime.tzinfo is not None else start_datetime.replace(tzinfo=local_tz)
+        range_end = end_datetime if end_datetime.tzinfo is not None else end_datetime.replace(tzinfo=local_tz)
+        events: list[CalendarEvent] = []
+        for slot in self.coordinator.data.get("meal_slots", []):
+            if not isinstance(slot, dict):
+                continue
+            title = str(slot.get("title") or "").strip()
+            if not title:
+                continue
+            slot_date = _parse_iso_date(slot.get("slot_date"))
+            if slot_date is None:
+                continue
+            slot_type = str(slot.get("slot_type") or "").lower()
+            start_time = MEAL_SLOT_START_TIMES.get(slot_type)
+            if start_time is None:
+                continue
+            event_start = datetime.combine(slot_date, start_time, tzinfo=local_tz)
+            event_end = event_start + MEAL_SLOT_DURATION
+            if event_end <= range_start or event_start >= range_end:
+                continue
+            slot_id = slot.get("id")
+            events.append(
+                CalendarEvent(
+                    summary=title,
+                    start=event_start,
+                    end=event_end,
+                    uid=f"meal-slot-{slot_id}" if slot_id is not None else None,
+                    description=slot.get("recipe_url") if isinstance(slot.get("recipe_url"), str) else None,
+                )
+            )
+        return events

--- a/custom_components/daynest/coordinator.py
+++ b/custom_components/daynest/coordinator.py
@@ -18,6 +18,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed
 from homeassistant.helpers.issue_registry import IssueSeverity, async_create_issue, async_delete_issue
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
+from homeassistant.util import dt as dt_util
 
 from .const import DOMAIN, LOGGER, SUPPORTED_INTEGRATION_CONTRACT_VERSIONS, parse_integration_contract_version
 from .data import DaynestConfigEntry
@@ -60,6 +61,29 @@ def _safe_date(value: Any) -> date | None:
         return date.fromisoformat(value)
     except ValueError:
         return None
+
+
+def _current_and_next_week_window(today: date | None = None) -> tuple[date, date]:
+    """Return Monday week starts for the current and next week."""
+    reference_date = today if today is not None else dt_util.now().date()
+    current_week_start = reference_date - timedelta(days=reference_date.weekday())
+    return current_week_start, current_week_start + timedelta(days=7)
+
+
+def _model_to_dict(value: Any) -> dict[str, Any]:
+    """Convert simple typed client models to dictionaries for coordinator data."""
+    if isinstance(value, dict):
+        return value
+    result: dict[str, Any] = {}
+    for key in getattr(value, "__dataclass_fields__", {}):
+        item = getattr(value, key)
+        if isinstance(item, date):
+            result[key] = item.isoformat()
+        elif isinstance(item, tuple):
+            result[key] = list(item)
+        else:
+            result[key] = item
+    return result
 
 
 class DaynestDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
@@ -242,6 +266,33 @@ class DaynestDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             raise UpdateFailed(f"Malformed shopping list response: {err}") from err
         except DaynestError as err:
             raise UpdateFailed(f"Unexpected API error while updating shopping lists: {err}") from err
+
+        try:
+            current_week_start, next_week_start = _current_and_next_week_window()
+            meal_plans = await self._client.async_list_meal_plans(
+                week_start_from=current_week_start,
+                week_start_to=next_week_start,
+            )
+            normalized["meal_plans"] = [_model_to_dict(plan) for plan in meal_plans]
+            valid_meal_plan_ids = [
+                _safe_int(plan.get("id"), default=0)
+                for plan in normalized["meal_plans"]
+                if _safe_int(plan.get("id"), default=0) > 0
+            ]
+            meal_slots: list[dict[str, Any]] = []
+            if valid_meal_plan_ids:
+                slot_results = await asyncio.gather(
+                    *(self._client.async_get_meal_plan_slots(plan_id) for plan_id in valid_meal_plan_ids)
+                )
+                for slots in slot_results:
+                    meal_slots.extend(_model_to_dict(slot) for slot in slots)
+            normalized["meal_slots"] = meal_slots
+        except DaynestCommunicationError as err:
+            raise UpdateFailed(f"Temporary communication failure while updating meal plans: {err}") from err
+        except DaynestMalformedResponseError as err:
+            raise UpdateFailed(f"Malformed meal plan response: {err}") from err
+        except DaynestError as err:
+            raise UpdateFailed(f"Unexpected API error while updating meal plans: {err}") from err
 
         if self._last_dashboard_data is not None:
             self._fire_transition_events(self._last_dashboard_data, normalized)

--- a/custom_components/daynest/translations/en.json
+++ b/custom_components/daynest/translations/en.json
@@ -87,6 +87,9 @@
       },
       "daynest_planned_calendar": {
         "name": "Daynest Planned"
+      },
+      "daynest_meal_plan_calendar": {
+        "name": "Daynest Meal Plan"
       }
     },
     "binary_sensor": {

--- a/custom_components/tests/test_calendar.py
+++ b/custom_components/tests/test_calendar.py
@@ -9,9 +9,11 @@ import pytest
 
 from custom_components.daynest.calendar import (
     DaynestChoresCalendar,
+    DaynestMealPlanCalendarEntity,
     DaynestMedicationsCalendar,
     DaynestPlannedCalendar,
     _parse_event,
+    async_setup_entry,
 )
 from daynest import DaynestError
 from homeassistant.components.calendar import CalendarEvent
@@ -20,7 +22,7 @@ from homeassistant.helpers.entity import EntityDescription
 
 def _make_coordinator(client: MagicMock | None = None) -> MagicMock:
     coordinator = MagicMock()
-    coordinator.data = {"model": "Unknown"}
+    coordinator.data = {"model": "Unknown", "meal_slots": []}
     coordinator.config_entry.entry_id = "test_entry_id"
     coordinator.config_entry.domain = "daynest"
     coordinator.config_entry.title = "Daynest Test"
@@ -37,6 +39,7 @@ def _make_entity(
         DaynestChoresCalendar: "daynest_chores_calendar",
         DaynestMedicationsCalendar: "daynest_medications_calendar",
         DaynestPlannedCalendar: "daynest_planned_calendar",
+        DaynestMealPlanCalendarEntity: "daynest_meal_plan_calendar",
     }[entity_cls]
     description = EntityDescription(key=key, translation_key=key)
     return entity_cls(coordinator=coordinator, entity_description=description)
@@ -223,6 +226,95 @@ class TestDaynestCalendarEntityGetEvents:
         hass = MagicMock()
         await entity.async_get_events(hass, datetime(2026, 5, 1, 0, 0), datetime(2026, 5, 31, 23, 59))
         client.async_get_calendar.assert_called_once_with(date(2026, 5, 1), date(2026, 5, 31), event_type="planned_items")
+
+
+@pytest.mark.unit
+class TestAsyncSetupEntry:
+    """Tests for calendar platform setup."""
+
+    async def test_registers_meal_plan_calendar(self) -> None:
+        entry = MagicMock()
+        entry.runtime_data.coordinator = _make_coordinator()
+        async_add_entities = MagicMock()
+
+        await async_setup_entry(MagicMock(), entry, async_add_entities)
+
+        entities = async_add_entities.call_args.args[0]
+        assert any(isinstance(entity, DaynestMealPlanCalendarEntity) for entity in entities)
+
+
+@pytest.mark.unit
+class TestDaynestMealPlanCalendarEntity:
+    """Tests for meal plan calendar events."""
+
+    async def test_returns_meal_slot_events_from_coordinator_data(self) -> None:
+        coordinator = _make_coordinator()
+        coordinator.data["meal_slots"] = [
+            {
+                "id": 5,
+                "meal_plan_id": 1,
+                "slot_date": "2026-06-08",
+                "slot_type": "breakfast",
+                "title": "Overnight oats",
+                "recipe_url": "https://recipes.example/oats",
+            },
+            {
+                "id": 6,
+                "meal_plan_id": 1,
+                "slot_date": "2026-06-08",
+                "slot_type": "dinner",
+                "title": "Pasta",
+                "recipe_url": None,
+            },
+        ]
+        entity = DaynestMealPlanCalendarEntity(
+            coordinator=coordinator,
+            entity_description=EntityDescription(
+                key="daynest_meal_plan_calendar",
+                translation_key="daynest_meal_plan_calendar",
+            ),
+        )
+        entity.hass = MagicMock()
+        entity.hass.config.time_zone = "UTC"
+
+        events = await entity.async_get_events(
+            MagicMock(),
+            datetime(2026, 6, 8, 0, 0, tzinfo=UTC),
+            datetime(2026, 6, 9, 0, 0, tzinfo=UTC),
+        )
+
+        assert [event.summary for event in events] == ["Overnight oats", "Pasta"]
+        assert events[0].start == datetime(2026, 6, 8, 8, 0, tzinfo=UTC)
+        assert events[0].end == datetime(2026, 6, 8, 9, 0, tzinfo=UTC)
+        assert events[0].uid == "meal-slot-5"
+        assert events[0].description == "https://recipes.example/oats"
+        assert events[1].start == datetime(2026, 6, 8, 18, 0, tzinfo=UTC)
+
+    async def test_skips_empty_or_out_of_range_slots(self) -> None:
+        coordinator = _make_coordinator()
+        coordinator.data["meal_slots"] = [
+            {"id": 1, "slot_date": "2026-06-08", "slot_type": "lunch", "title": ""},
+            {"id": 2, "slot_date": "bad", "slot_type": "lunch", "title": "Bad date"},
+            {"id": 3, "slot_date": "2026-06-09", "slot_type": "unknown", "title": "Unknown"},
+            {"id": 4, "slot_date": "2026-06-10", "slot_type": "snack", "title": "Fruit"},
+        ]
+        entity = DaynestMealPlanCalendarEntity(
+            coordinator=coordinator,
+            entity_description=EntityDescription(
+                key="daynest_meal_plan_calendar",
+                translation_key="daynest_meal_plan_calendar",
+            ),
+        )
+        entity.hass = MagicMock()
+        entity.hass.config.time_zone = "UTC"
+
+        events = await entity.async_get_events(
+            MagicMock(),
+            datetime(2026, 6, 8, 0, 0, tzinfo=UTC),
+            datetime(2026, 6, 9, 0, 0, tzinfo=UTC),
+        )
+
+        assert events == []
 
 
 @pytest.mark.unit

--- a/custom_components/tests/test_coordinator.py
+++ b/custom_components/tests/test_coordinator.py
@@ -2,12 +2,18 @@
 
 from __future__ import annotations
 
-from unittest.mock import AsyncMock, MagicMock
+from datetime import date
+from unittest.mock import DEFAULT, AsyncMock, MagicMock
 
-from daynest.models import DaynestDashboard
+from daynest.models import DaynestDashboard, MealPlan, MealSlot
 import pytest
 
-from custom_components.daynest.coordinator import DaynestDataUpdateCoordinator, _safe_float, _safe_int
+from custom_components.daynest.coordinator import (
+    DaynestDataUpdateCoordinator,
+    _current_and_next_week_window,
+    _safe_float,
+    _safe_int,
+)
 from daynest import DaynestAuthError, DaynestCommunicationError, DaynestError, DaynestMalformedResponseError
 from homeassistant.exceptions import ConfigEntryAuthFailed
 from homeassistant.helpers.update_coordinator import UpdateFailed
@@ -49,6 +55,16 @@ def _make_coordinator(client: AsyncMock | None = None) -> DaynestDataUpdateCoord
     config_entry.domain = "daynest"
     if client is None:
         client = AsyncMock()
+    for method_name, default_value in {
+        "async_get_user_settings": {},
+        "async_list_shopping_lists": [],
+        "async_list_shopping_items": [],
+        "async_list_meal_plans": [],
+        "async_get_meal_plan_slots": [],
+    }.items():
+        method = getattr(client, method_name, None)
+        if isinstance(method, AsyncMock) and method.side_effect is None and method._mock_return_value is DEFAULT:
+            method.return_value = default_value
     return DaynestDataUpdateCoordinator(hass=hass, config_entry=config_entry, client=client)
 
 
@@ -102,6 +118,17 @@ class TestSafeFloat:
 
     def test_empty_string_returns_default(self) -> None:
         assert _safe_float("") == 0.0
+
+
+@pytest.mark.unit
+class TestMealPlanWindow:
+    """Tests for meal plan week window calculation."""
+
+    def test_current_and_next_week_window_uses_monday_starts(self) -> None:
+        current, next_week = _current_and_next_week_window(date(2026, 6, 6))
+
+        assert current == date(2026, 6, 1)
+        assert next_week == date(2026, 6, 8)
 
 
 @pytest.mark.unit
@@ -219,6 +246,28 @@ class TestAsyncUpdateData:
         client.async_list_shopping_items.return_value = [
             {"id": 20, "title": "Milk", "is_done": False},
         ]
+        client.async_list_meal_plans.return_value = [
+            MealPlan(
+                id=30,
+                user_id=1,
+                name="Current week",
+                week_start=date(2026, 6, 1),
+                notes=None,
+                created_at=date(2026, 6, 1),
+            ),
+        ]
+        client.async_get_meal_plan_slots.return_value = [
+            MealSlot(
+                id=40,
+                meal_plan_id=30,
+                slot_date=date(2026, 6, 1),
+                slot_type="dinner",
+                title="Pasta",
+                recipe_url="https://recipes.example/pasta",
+                ingredients_json=("pasta",),
+                planned_item_id=None,
+            ),
+        ]
         coordinator = _make_coordinator(client)
         result = await coordinator._async_update_data()
         assert result["due_today_count"] == 3
@@ -228,8 +277,31 @@ class TestAsyncUpdateData:
         assert result["medication_reminder_minutes"] == 20
         assert result["shopping_lists"] == [{"id": 10, "name": "Groceries", "status": "active"}]
         assert result["shopping_items"] == {10: [{"id": 20, "title": "Milk", "is_done": False}]}
+        assert result["meal_plans"] == [
+            {
+                "id": 30,
+                "user_id": 1,
+                "name": "Current week",
+                "week_start": "2026-06-01",
+                "notes": None,
+                "created_at": "2026-06-01",
+            }
+        ]
+        assert result["meal_slots"] == [
+            {
+                "id": 40,
+                "meal_plan_id": 30,
+                "slot_date": "2026-06-01",
+                "slot_type": "dinner",
+                "title": "Pasta",
+                "recipe_url": "https://recipes.example/pasta",
+                "ingredients_json": ["pasta"],
+                "planned_item_id": None,
+            }
+        ]
         client.async_list_shopping_lists.assert_awaited_once_with(status="active")
         client.async_list_shopping_items.assert_awaited_once_with(10)
+        client.async_get_meal_plan_slots.assert_awaited_once_with(30)
 
     async def test_authentication_error_raises_config_entry_auth_failed(self) -> None:
         client = AsyncMock()
@@ -326,6 +398,16 @@ class TestAsyncUpdateData:
         client.async_list_shopping_lists.side_effect = DaynestCommunicationError("timeout")
         coordinator = _make_coordinator(client)
         with pytest.raises(UpdateFailed, match="Temporary communication failure while updating shopping lists"):
+            await coordinator._async_update_data()
+
+    async def test_meal_plan_communication_error_raises_update_failed(self) -> None:
+        client = AsyncMock()
+        client.async_get_dashboard.return_value = _make_dashboard_response()
+        client.async_get_user_settings.return_value = {}
+        client.async_list_shopping_lists.return_value = []
+        client.async_list_meal_plans.side_effect = DaynestCommunicationError("timeout")
+        coordinator = _make_coordinator(client)
+        with pytest.raises(UpdateFailed, match="Temporary communication failure while updating meal plans"):
             await coordinator._async_update_data()
 
     async def test_empty_shopping_lists_returns_empty_shopping_items(self) -> None:

--- a/python-daynest/src/daynest/__init__.py
+++ b/python-daynest/src/daynest/__init__.py
@@ -17,6 +17,8 @@ from daynest.models import (
     DaynestApiResponse,
     DaynestDashboard,
     DaynestSummary,
+    MealPlan,
+    MealSlot,
     PlannedItem,
     RoutineTemplate,
 )
@@ -33,6 +35,8 @@ __all__ = [
     "DaynestApiResponse",
     "DaynestSummary",
     "DaynestDashboard",
+    "MealPlan",
+    "MealSlot",
     "PlannedItem",
     "RoutineTemplate",
     "ChoreTemplate",

--- a/python-daynest/src/daynest/client.py
+++ b/python-daynest/src/daynest/client.py
@@ -31,6 +31,8 @@ from daynest.models import (
     DaynestApiResponse,
     DaynestDashboard,
     DaynestSummary,
+    MealPlan,
+    MealSlot,
     PlannedItem,
     RoutineTemplate,
 )
@@ -385,6 +387,43 @@ class DaynestClient:
             path += f"?scope={scope}"
         await self._send_no_content_action("delete", path=path)
 
+    async def async_list_meal_plans(
+        self,
+        *,
+        week_start_from: date | None = None,
+        week_start_to: date | None = None,
+    ) -> list[MealPlan]:
+        """List meal plans, optionally filtered by week_start client-side."""
+        payload = await self._cached_call("async_list_meal_plans", lambda: self._request_list("/api/meal-plans"))
+        plans = [MealPlan.from_dict(item) for item in payload]
+        if week_start_from is not None:
+            plans = [plan for plan in plans if plan.week_start >= week_start_from]
+        if week_start_to is not None:
+            plans = [plan for plan in plans if plan.week_start <= week_start_to]
+        return plans
+
+    async def async_get_meal_plan_slots(self, meal_plan_id: int) -> list[MealSlot]:
+        """Fetch and flatten slots for a meal plan week grid."""
+        payload = await self._cached_call(
+            "async_get_meal_plan_slots",
+            lambda: self._request_dict(f"/api/meal-plans/{meal_plan_id}/slots"),
+            meal_plan_id,
+        )
+        days = payload.get("days")
+        if not isinstance(days, list):
+            msg = "Malformed meal plan slots payload: expected days array"
+            raise DaynestMalformedResponseError(msg)
+        slots: list[MealSlot] = []
+        for day in days:
+            if not isinstance(day, dict):
+                continue
+            raw_slots = day.get("slots")
+            if not isinstance(raw_slots, dict):
+                continue
+            for raw_slot in raw_slots.values():
+                if isinstance(raw_slot, dict):
+                    slots.append(MealSlot.from_dict(raw_slot))
+        return slots
 
     async def async_list_shopping_lists(self, status: str = "active") -> list[dict[str, Any]]:
         """List shopping lists for the authenticated user."""

--- a/python-daynest/src/daynest/models.py
+++ b/python-daynest/src/daynest/models.py
@@ -179,6 +179,65 @@ class PlannedItem:
 
 
 @dataclass(slots=True, frozen=True)
+class MealPlan:
+    """Typed model for a meal plan."""
+
+    id: int
+    user_id: int
+    name: str
+    week_start: date
+    notes: str | None
+    created_at: datetime
+
+    @classmethod
+    def from_dict(cls, payload: dict[str, Any]) -> MealPlan:
+        if not isinstance(payload, dict):
+            msg = "Malformed meal plan payload: expected JSON object"
+            raise DaynestMalformedResponseError(msg)
+        return cls(
+            id=int(_require(payload, "id", context="meal plan")),
+            user_id=int(_require(payload, "user_id", context="meal plan")),
+            name=str(_require(payload, "name", context="meal plan")),
+            week_start=_parse_date(_require(payload, "week_start", context="meal plan"), field="week_start"),
+            notes=payload.get("notes") if isinstance(payload.get("notes"), str) else None,
+            created_at=_parse_datetime(_require(payload, "created_at", context="meal plan"), field="created_at"),
+        )
+
+
+@dataclass(slots=True, frozen=True)
+class MealSlot:
+    """Typed model for a meal plan slot."""
+
+    id: int
+    meal_plan_id: int
+    slot_date: date
+    slot_type: str
+    title: str
+    recipe_url: str | None
+    ingredients_json: tuple[str, ...]
+    planned_item_id: int | None
+
+    @classmethod
+    def from_dict(cls, payload: dict[str, Any]) -> MealSlot:
+        if not isinstance(payload, dict):
+            msg = "Malformed meal slot payload: expected JSON object"
+            raise DaynestMalformedResponseError(msg)
+        ingredients = payload.get("ingredients_json")
+        ingredient_values = tuple(str(item) for item in ingredients) if isinstance(ingredients, list) else ()
+        planned_item_id = payload.get("planned_item_id")
+        return cls(
+            id=int(_require(payload, "id", context="meal slot")),
+            meal_plan_id=int(_require(payload, "meal_plan_id", context="meal slot")),
+            slot_date=_parse_date(_require(payload, "slot_date", context="meal slot"), field="slot_date"),
+            slot_type=str(_require(payload, "slot_type", context="meal slot")),
+            title=str(payload.get("title", "")),
+            recipe_url=payload.get("recipe_url") if isinstance(payload.get("recipe_url"), str) else None,
+            ingredients_json=ingredient_values,
+            planned_item_id=int(planned_item_id) if planned_item_id is not None else None,
+        )
+
+
+@dataclass(slots=True, frozen=True)
 class RoutineTemplate:
     """Typed model for a routine template."""
 

--- a/python-daynest/tests/test_client.py
+++ b/python-daynest/tests/test_client.py
@@ -16,7 +16,7 @@ from daynest.exceptions import (
     DaynestServerUnavailableError,
     DaynestTimeoutError,
 )
-from daynest.models import CalendarDay, CalendarEvent, ChoreTemplate, DaynestDashboard, DaynestSummary, PlannedItem, RoutineTemplate
+from daynest.models import CalendarDay, CalendarEvent, ChoreTemplate, DaynestDashboard, DaynestSummary, MealPlan, MealSlot, PlannedItem, RoutineTemplate
 
 VALID_SUMMARY_PAYLOAD = {
     "sensor_daynest_chores_due": 2,
@@ -918,6 +918,111 @@ class TestDaynestClientCacheAndSSE:
 
         session.get.assert_not_called()
         callback.assert_not_awaited()
+
+
+@pytest.mark.unit
+class TestDaynestClientMealPlanMethods:
+    """Tests for meal plan client helpers."""
+
+    async def test_list_meal_plans_filters_by_week_start(self) -> None:
+        response = _make_mock_response(
+            200,
+            [
+                {
+                    "id": 1,
+                    "user_id": 2,
+                    "name": "Past",
+                    "week_start": "2026-05-25",
+                    "notes": None,
+                    "created_at": "2026-05-01T00:00:00",
+                },
+                {
+                    "id": 2,
+                    "user_id": 2,
+                    "name": "Current",
+                    "week_start": "2026-06-01",
+                    "notes": "Notes",
+                    "created_at": "2026-05-01T00:00:00",
+                },
+                {
+                    "id": 3,
+                    "user_id": 2,
+                    "name": "Next",
+                    "week_start": "2026-06-08",
+                    "notes": None,
+                    "created_at": "2026-05-01T00:00:00",
+                },
+            ],
+        )
+        client = _make_list_client(response)
+
+        plans = await client.async_list_meal_plans(
+            week_start_from=date(2026, 6, 1),
+            week_start_to=date(2026, 6, 8),
+        )
+
+        assert [plan.id for plan in plans] == [2, 3]
+        assert all(isinstance(plan, MealPlan) for plan in plans)
+        client._session.get.assert_called_once()
+        assert client._session.get.call_args.args[0] == "https://api.daynest.example/api/meal-plans"
+
+    async def test_get_meal_plan_slots_flattens_week_grid(self) -> None:
+        response = _make_mock_response(
+            200,
+            {
+                "meal_plan": {
+                    "id": 2,
+                    "user_id": 2,
+                    "name": "Current",
+                    "week_start": "2026-06-01",
+                    "notes": None,
+                    "created_at": "2026-05-01T00:00:00",
+                },
+                "days": [
+                    {
+                        "date": "2026-06-01",
+                        "slots": {
+                            "breakfast": {
+                                "id": 10,
+                                "meal_plan_id": 2,
+                                "slot_date": "2026-06-01",
+                                "slot_type": "breakfast",
+                                "title": "Oats",
+                                "recipe_url": "https://recipes.example/oats",
+                                "ingredients_json": ["oats"],
+                                "planned_item_id": None,
+                            },
+                            "dinner": {
+                                "id": 11,
+                                "meal_plan_id": 2,
+                                "slot_date": "2026-06-01",
+                                "slot_type": "dinner",
+                                "title": "Pasta",
+                                "recipe_url": None,
+                                "ingredients_json": [],
+                                "planned_item_id": 50,
+                            },
+                        },
+                    },
+                ],
+            },
+        )
+        client = _make_list_client(response)
+
+        slots = await client.async_get_meal_plan_slots(2)
+
+        assert [slot.title for slot in slots] == ["Oats", "Pasta"]
+        assert all(isinstance(slot, MealSlot) for slot in slots)
+        assert slots[0].ingredients_json == ("oats",)
+        assert slots[1].planned_item_id == 50
+        assert client._session.get.call_args.args[0] == "https://api.daynest.example/api/meal-plans/2/slots"
+
+    async def test_get_meal_plan_slots_rejects_missing_days_array(self) -> None:
+        response = _make_mock_response(200, {"meal_plan": {}, "days": "bad"})
+        client = _make_list_client(response)
+
+        with pytest.raises(DaynestMalformedResponseError, match="expected days array"):
+            await client.async_get_meal_plan_slots(2)
 
 
 @pytest.mark.unit


### PR DESCRIPTION
### Motivation
- Add a meal-planning feature to the Android app so users can create weekly meal plans, edit day/slot content, and generate shopping lists from a plan.

### Description
- Add Retrofit API and DTOs in `android/.../data/mealplan/MealPlanApi.kt` for listing/creating meal plans, loading week grids, updating slots, and generating shopping lists.
- Add `MealPlanRepository` in `android/.../data/mealplan/MealPlanRepository.kt` with cached reads/writes using new cache keys `SyncCacheKeys.MEAL_PLANS` and `SyncCacheKeys.MEAL_SLOTS`, and offline-safe `safeApiCall`/`recoverOffline` usage.
- Register the meal-plan API with Hilt by adding a provider in `android/.../core/di/NetworkApiDiModule.kt` and add cache constants to `android/.../data/sync/SyncCacheKeys.kt`.
- Add Compose UI and viewmodel for the planner under `android/.../feature/mealplan/` including `MealPlannerScreen.kt`, `MealPlannerViewModel.kt`, `MealSlotBottomSheet.kt`, and integrate a top-level destination in `DaynestDestination.kt` and `DaynestApp.kt`, plus localized strings in `res/values/strings.xml`.

### Testing
- Ran `git diff --check` which passed.
- Attempted to run `./gradlew :app:compileDebugKotlin` but the Gradle invocation failed due to an unresolved plugin dependency `org.gradle.toolchains.foojay-resolver-convention:1.0.0` from configured plugin repositories, so the Android compile could not be completed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2492e6ce88832eafc80a5a39e4aac7)