### PR TITLE
feat(ha): add meal plan calendar and meal-plan client support

### DIFF
--- a/custom_components/daynest/calendar.py
+++ b/custom_components/daynest/calendar.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import UTC, date, datetime
+from datetime import UTC, date, datetime, time, timedelta
 from typing import TYPE_CHECKING
 
 from daynest import DaynestError
@@ -37,6 +37,18 @@ PLANNED_ENTITY_DESCRIPTION = CalendarEntityDescription(
     key="daynest_planned_calendar",
     translation_key="daynest_planned_calendar",
 )
+MEAL_PLAN_ENTITY_DESCRIPTION = CalendarEntityDescription(
+    key="daynest_meal_plan_calendar",
+    translation_key="daynest_meal_plan_calendar",
+)
+
+MEAL_SLOT_START_TIMES = {
+    "breakfast": time(8, 0),
+    "lunch": time(12, 0),
+    "dinner": time(18, 0),
+    "snack": time(15, 0),
+}
+MEAL_SLOT_DURATION = timedelta(hours=1)
 
 
 async def async_setup_entry(
@@ -58,7 +70,11 @@ async def async_setup_entry(
             DaynestPlannedCalendar(
                 coordinator=entry.runtime_data.coordinator,
                 entity_description=PLANNED_ENTITY_DESCRIPTION,
-            )
+            ),
+            DaynestMealPlanCalendarEntity(
+                coordinator=entry.runtime_data.coordinator,
+                entity_description=MEAL_PLAN_ENTITY_DESCRIPTION,
+            ),
         ]
     )
 
@@ -171,3 +187,79 @@ class DaynestPlannedCalendar(DaynestCalendarEntity):
     """Calendar view for planned items."""
 
     _event_type = "planned_items"
+
+
+def _parse_iso_date(value: object) -> date | None:
+    """Parse an ISO date object for meal slot mapping."""
+    if isinstance(value, date) and not isinstance(value, datetime):
+        return value
+    if isinstance(value, str):
+        try:
+            return date.fromisoformat(value)
+        except ValueError:
+            return None
+    return None
+
+
+class DaynestMealPlanCalendarEntity(CalendarEntity, DaynestEntity):
+    """Calendar view for meal plan slots."""
+
+    _attr_supported_features = CalendarEntityFeature(0)
+
+    def __init__(
+        self,
+        coordinator: DaynestDataUpdateCoordinator,
+        entity_description: CalendarEntityDescription,
+    ) -> None:
+        """Initialize the meal plan calendar entity."""
+        super().__init__(coordinator, entity_description)
+
+    @property
+    def event(self) -> CalendarEvent | None:
+        """Return the next upcoming meal event if available."""
+        now = datetime.now(UTC)
+        future_events = [event for event in self._meal_slot_events(now, now + timedelta(days=14)) if event.start >= now]
+        return min(future_events, key=lambda event: event.start) if future_events else None
+
+    async def async_get_events(
+        self,
+        hass: HomeAssistant,
+        start_datetime: datetime,
+        end_datetime: datetime,
+    ) -> list[CalendarEvent]:
+        """Return meal slot events from coordinator data in the requested range."""
+        return self._meal_slot_events(start_datetime, end_datetime)
+
+    def _meal_slot_events(self, start_datetime: datetime, end_datetime: datetime) -> list[CalendarEvent]:
+        timezone = start_datetime.tzinfo or UTC
+        range_start = start_datetime if start_datetime.tzinfo is not None else start_datetime.replace(tzinfo=timezone)
+        range_end = end_datetime if end_datetime.tzinfo is not None else end_datetime.replace(tzinfo=timezone)
+        events: list[CalendarEvent] = []
+        for slot in self.coordinator.data.get("meal_slots", []):
+            if not isinstance(slot, dict):
+                continue
+            title = str(slot.get("title") or "").strip()
+            if not title:
+                continue
+            slot_date = _parse_iso_date(slot.get("slot_date"))
+            if slot_date is None:
+                continue
+            slot_type = str(slot.get("slot_type") or "").lower()
+            start_time = MEAL_SLOT_START_TIMES.get(slot_type)
+            if start_time is None:
+                continue
+            event_start = datetime.combine(slot_date, start_time, tzinfo=timezone)
+            event_end = event_start + MEAL_SLOT_DURATION
+            if event_end <= range_start or event_start >= range_end:
+                continue
+            slot_id = slot.get("id")
+            events.append(
+                CalendarEvent(
+                    summary=title,
+                    start=event_start,
+                    end=event_end,
+                    uid=f"meal-slot-{slot_id}" if slot_id is not None else None,
+                    description=slot.get("recipe_url") if isinstance(slot.get("recipe_url"), str) else None,
+                )
+            )
+        return events

--- a/custom_components/daynest/calendar.py
+++ b/custom_components/daynest/calendar.py
@@ -12,6 +12,7 @@ from homeassistant.components.calendar import (
     CalendarEntityFeature,
     CalendarEvent,
 )
+from homeassistant.util import dt as dt_util
 
 from .const import LOGGER
 from .entity import DaynestEntity
@@ -231,9 +232,9 @@ class DaynestMealPlanCalendarEntity(CalendarEntity, DaynestEntity):
         return self._meal_slot_events(start_datetime, end_datetime)
 
     def _meal_slot_events(self, start_datetime: datetime, end_datetime: datetime) -> list[CalendarEvent]:
-        timezone = start_datetime.tzinfo or UTC
-        range_start = start_datetime if start_datetime.tzinfo is not None else start_datetime.replace(tzinfo=timezone)
-        range_end = end_datetime if end_datetime.tzinfo is not None else end_datetime.replace(tzinfo=timezone)
+        local_tz = dt_util.get_time_zone(self.hass.config.time_zone) or UTC
+        range_start = start_datetime if start_datetime.tzinfo is not None else start_datetime.replace(tzinfo=local_tz)
+        range_end = end_datetime if end_datetime.tzinfo is not None else end_datetime.replace(tzinfo=local_tz)
         events: list[CalendarEvent] = []
         for slot in self.coordinator.data.get("meal_slots", []):
             if not isinstance(slot, dict):
@@ -248,7 +249,7 @@ class DaynestMealPlanCalendarEntity(CalendarEntity, DaynestEntity):
             start_time = MEAL_SLOT_START_TIMES.get(slot_type)
             if start_time is None:
                 continue
-            event_start = datetime.combine(slot_date, start_time, tzinfo=timezone)
+            event_start = datetime.combine(slot_date, start_time, tzinfo=local_tz)
             event_end = event_start + MEAL_SLOT_DURATION
             if event_end <= range_start or event_start >= range_end:
                 continue

--- a/custom_components/daynest/coordinator.py
+++ b/custom_components/daynest/coordinator.py
@@ -18,6 +18,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed
 from homeassistant.helpers.issue_registry import IssueSeverity, async_create_issue, async_delete_issue
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
+from homeassistant.util import dt as dt_util
 
 from .const import DOMAIN, LOGGER, SUPPORTED_INTEGRATION_CONTRACT_VERSIONS, parse_integration_contract_version
 from .data import DaynestConfigEntry
@@ -64,7 +65,7 @@ def _safe_date(value: Any) -> date | None:
 
 def _current_and_next_week_window(today: date | None = None) -> tuple[date, date]:
     """Return Monday week starts for the current and next week."""
-    reference_date = today or date.today()
+    reference_date = today if today is not None else dt_util.now().date()
     current_week_start = reference_date - timedelta(days=reference_date.weekday())
     return current_week_start, current_week_start + timedelta(days=7)
 

--- a/custom_components/daynest/coordinator.py
+++ b/custom_components/daynest/coordinator.py
@@ -62,6 +62,29 @@ def _safe_date(value: Any) -> date | None:
         return None
 
 
+def _current_and_next_week_window(today: date | None = None) -> tuple[date, date]:
+    """Return Monday week starts for the current and next week."""
+    reference_date = today or date.today()
+    current_week_start = reference_date - timedelta(days=reference_date.weekday())
+    return current_week_start, current_week_start + timedelta(days=7)
+
+
+def _model_to_dict(value: Any) -> dict[str, Any]:
+    """Convert simple typed client models to dictionaries for coordinator data."""
+    if isinstance(value, dict):
+        return value
+    result: dict[str, Any] = {}
+    for key in getattr(value, "__dataclass_fields__", {}):
+        item = getattr(value, key)
+        if isinstance(item, date):
+            result[key] = item.isoformat()
+        elif isinstance(item, tuple):
+            result[key] = list(item)
+        else:
+            result[key] = item
+    return result
+
+
 class DaynestDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
     """Coordinator that fetches and normalizes Daynest dashboard data."""
 
@@ -242,6 +265,33 @@ class DaynestDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             raise UpdateFailed(f"Malformed shopping list response: {err}") from err
         except DaynestError as err:
             raise UpdateFailed(f"Unexpected API error while updating shopping lists: {err}") from err
+
+        try:
+            current_week_start, next_week_start = _current_and_next_week_window()
+            meal_plans = await self._client.async_list_meal_plans(
+                week_start_from=current_week_start,
+                week_start_to=next_week_start,
+            )
+            normalized["meal_plans"] = [_model_to_dict(plan) for plan in meal_plans]
+            valid_meal_plan_ids = [
+                _safe_int(plan.get("id"), default=0)
+                for plan in normalized["meal_plans"]
+                if _safe_int(plan.get("id"), default=0) > 0
+            ]
+            meal_slots: list[dict[str, Any]] = []
+            if valid_meal_plan_ids:
+                slot_results = await asyncio.gather(
+                    *(self._client.async_get_meal_plan_slots(plan_id) for plan_id in valid_meal_plan_ids)
+                )
+                for slots in slot_results:
+                    meal_slots.extend(_model_to_dict(slot) for slot in slots)
+            normalized["meal_slots"] = meal_slots
+        except DaynestCommunicationError as err:
+            raise UpdateFailed(f"Temporary communication failure while updating meal plans: {err}") from err
+        except DaynestMalformedResponseError as err:
+            raise UpdateFailed(f"Malformed meal plan response: {err}") from err
+        except DaynestError as err:
+            raise UpdateFailed(f"Unexpected API error while updating meal plans: {err}") from err
 
         if self._last_dashboard_data is not None:
             self._fire_transition_events(self._last_dashboard_data, normalized)

--- a/custom_components/daynest/translations/en.json
+++ b/custom_components/daynest/translations/en.json
@@ -87,6 +87,9 @@
       },
       "daynest_planned_calendar": {
         "name": "Daynest Planned"
+      },
+      "daynest_meal_plan_calendar": {
+        "name": "Daynest Meal Plan"
       }
     },
     "binary_sensor": {

--- a/custom_components/tests/test_calendar.py
+++ b/custom_components/tests/test_calendar.py
@@ -9,9 +9,11 @@ import pytest
 
 from custom_components.daynest.calendar import (
     DaynestChoresCalendar,
+    DaynestMealPlanCalendarEntity,
     DaynestMedicationsCalendar,
     DaynestPlannedCalendar,
     _parse_event,
+    async_setup_entry,
 )
 from daynest import DaynestError
 from homeassistant.components.calendar import CalendarEvent
@@ -20,7 +22,7 @@ from homeassistant.helpers.entity import EntityDescription
 
 def _make_coordinator(client: MagicMock | None = None) -> MagicMock:
     coordinator = MagicMock()
-    coordinator.data = {"model": "Unknown"}
+    coordinator.data = {"model": "Unknown", "meal_slots": []}
     coordinator.config_entry.entry_id = "test_entry_id"
     coordinator.config_entry.domain = "daynest"
     coordinator.config_entry.title = "Daynest Test"
@@ -37,6 +39,7 @@ def _make_entity(
         DaynestChoresCalendar: "daynest_chores_calendar",
         DaynestMedicationsCalendar: "daynest_medications_calendar",
         DaynestPlannedCalendar: "daynest_planned_calendar",
+        DaynestMealPlanCalendarEntity: "daynest_meal_plan_calendar",
     }[entity_cls]
     description = EntityDescription(key=key, translation_key=key)
     return entity_cls(coordinator=coordinator, entity_description=description)
@@ -223,6 +226,91 @@ class TestDaynestCalendarEntityGetEvents:
         hass = MagicMock()
         await entity.async_get_events(hass, datetime(2026, 5, 1, 0, 0), datetime(2026, 5, 31, 23, 59))
         client.async_get_calendar.assert_called_once_with(date(2026, 5, 1), date(2026, 5, 31), event_type="planned_items")
+
+
+@pytest.mark.unit
+class TestAsyncSetupEntry:
+    """Tests for calendar platform setup."""
+
+    async def test_registers_meal_plan_calendar(self) -> None:
+        entry = MagicMock()
+        entry.runtime_data.coordinator = _make_coordinator()
+        async_add_entities = MagicMock()
+
+        await async_setup_entry(MagicMock(), entry, async_add_entities)
+
+        entities = async_add_entities.call_args.args[0]
+        assert any(isinstance(entity, DaynestMealPlanCalendarEntity) for entity in entities)
+
+
+@pytest.mark.unit
+class TestDaynestMealPlanCalendarEntity:
+    """Tests for meal plan calendar events."""
+
+    async def test_returns_meal_slot_events_from_coordinator_data(self) -> None:
+        coordinator = _make_coordinator()
+        coordinator.data["meal_slots"] = [
+            {
+                "id": 5,
+                "meal_plan_id": 1,
+                "slot_date": "2026-06-08",
+                "slot_type": "breakfast",
+                "title": "Overnight oats",
+                "recipe_url": "https://recipes.example/oats",
+            },
+            {
+                "id": 6,
+                "meal_plan_id": 1,
+                "slot_date": "2026-06-08",
+                "slot_type": "dinner",
+                "title": "Pasta",
+                "recipe_url": None,
+            },
+        ]
+        entity = DaynestMealPlanCalendarEntity(
+            coordinator=coordinator,
+            entity_description=EntityDescription(
+                key="daynest_meal_plan_calendar",
+                translation_key="daynest_meal_plan_calendar",
+            ),
+        )
+
+        events = await entity.async_get_events(
+            MagicMock(),
+            datetime(2026, 6, 8, 0, 0, tzinfo=UTC),
+            datetime(2026, 6, 9, 0, 0, tzinfo=UTC),
+        )
+
+        assert [event.summary for event in events] == ["Overnight oats", "Pasta"]
+        assert events[0].start == datetime(2026, 6, 8, 8, 0, tzinfo=UTC)
+        assert events[0].end == datetime(2026, 6, 8, 9, 0, tzinfo=UTC)
+        assert events[0].uid == "meal-slot-5"
+        assert events[0].description == "https://recipes.example/oats"
+        assert events[1].start == datetime(2026, 6, 8, 18, 0, tzinfo=UTC)
+
+    async def test_skips_empty_or_out_of_range_slots(self) -> None:
+        coordinator = _make_coordinator()
+        coordinator.data["meal_slots"] = [
+            {"id": 1, "slot_date": "2026-06-08", "slot_type": "lunch", "title": ""},
+            {"id": 2, "slot_date": "bad", "slot_type": "lunch", "title": "Bad date"},
+            {"id": 3, "slot_date": "2026-06-09", "slot_type": "unknown", "title": "Unknown"},
+            {"id": 4, "slot_date": "2026-06-10", "slot_type": "snack", "title": "Fruit"},
+        ]
+        entity = DaynestMealPlanCalendarEntity(
+            coordinator=coordinator,
+            entity_description=EntityDescription(
+                key="daynest_meal_plan_calendar",
+                translation_key="daynest_meal_plan_calendar",
+            ),
+        )
+
+        events = await entity.async_get_events(
+            MagicMock(),
+            datetime(2026, 6, 8, 0, 0, tzinfo=UTC),
+            datetime(2026, 6, 9, 0, 0, tzinfo=UTC),
+        )
+
+        assert events == []
 
 
 @pytest.mark.unit

--- a/custom_components/tests/test_calendar.py
+++ b/custom_components/tests/test_calendar.py
@@ -274,6 +274,8 @@ class TestDaynestMealPlanCalendarEntity:
                 translation_key="daynest_meal_plan_calendar",
             ),
         )
+        entity.hass = MagicMock()
+        entity.hass.config.time_zone = "UTC"
 
         events = await entity.async_get_events(
             MagicMock(),
@@ -303,6 +305,8 @@ class TestDaynestMealPlanCalendarEntity:
                 translation_key="daynest_meal_plan_calendar",
             ),
         )
+        entity.hass = MagicMock()
+        entity.hass.config.time_zone = "UTC"
 
         events = await entity.async_get_events(
             MagicMock(),

--- a/custom_components/tests/test_coordinator.py
+++ b/custom_components/tests/test_coordinator.py
@@ -2,12 +2,18 @@
 
 from __future__ import annotations
 
-from unittest.mock import AsyncMock, MagicMock
+from datetime import date
+from unittest.mock import DEFAULT, AsyncMock, MagicMock
 
-from daynest.models import DaynestDashboard
+from daynest.models import DaynestDashboard, MealPlan, MealSlot
 import pytest
 
-from custom_components.daynest.coordinator import DaynestDataUpdateCoordinator, _safe_float, _safe_int
+from custom_components.daynest.coordinator import (
+    DaynestDataUpdateCoordinator,
+    _current_and_next_week_window,
+    _safe_float,
+    _safe_int,
+)
 from daynest import DaynestAuthError, DaynestCommunicationError, DaynestError, DaynestMalformedResponseError
 from homeassistant.exceptions import ConfigEntryAuthFailed
 from homeassistant.helpers.update_coordinator import UpdateFailed
@@ -49,6 +55,16 @@ def _make_coordinator(client: AsyncMock | None = None) -> DaynestDataUpdateCoord
     config_entry.domain = "daynest"
     if client is None:
         client = AsyncMock()
+    for method_name, default_value in {
+        "async_get_user_settings": {},
+        "async_list_shopping_lists": [],
+        "async_list_shopping_items": [],
+        "async_list_meal_plans": [],
+        "async_get_meal_plan_slots": [],
+    }.items():
+        method = getattr(client, method_name, None)
+        if isinstance(method, AsyncMock) and method.side_effect is None and method._mock_return_value is DEFAULT:
+            method.return_value = default_value
     return DaynestDataUpdateCoordinator(hass=hass, config_entry=config_entry, client=client)
 
 
@@ -102,6 +118,17 @@ class TestSafeFloat:
 
     def test_empty_string_returns_default(self) -> None:
         assert _safe_float("") == 0.0
+
+
+@pytest.mark.unit
+class TestMealPlanWindow:
+    """Tests for meal plan week window calculation."""
+
+    def test_current_and_next_week_window_uses_monday_starts(self) -> None:
+        current, next_week = _current_and_next_week_window(date(2026, 6, 6))
+
+        assert current == date(2026, 6, 1)
+        assert next_week == date(2026, 6, 8)
 
 
 @pytest.mark.unit
@@ -219,6 +246,28 @@ class TestAsyncUpdateData:
         client.async_list_shopping_items.return_value = [
             {"id": 20, "title": "Milk", "is_done": False},
         ]
+        client.async_list_meal_plans.return_value = [
+            MealPlan(
+                id=30,
+                user_id=1,
+                name="Current week",
+                week_start=date(2026, 6, 1),
+                notes=None,
+                created_at=date(2026, 6, 1),
+            ),
+        ]
+        client.async_get_meal_plan_slots.return_value = [
+            MealSlot(
+                id=40,
+                meal_plan_id=30,
+                slot_date=date(2026, 6, 1),
+                slot_type="dinner",
+                title="Pasta",
+                recipe_url="https://recipes.example/pasta",
+                ingredients_json=("pasta",),
+                planned_item_id=None,
+            ),
+        ]
         coordinator = _make_coordinator(client)
         result = await coordinator._async_update_data()
         assert result["due_today_count"] == 3
@@ -228,8 +277,31 @@ class TestAsyncUpdateData:
         assert result["medication_reminder_minutes"] == 20
         assert result["shopping_lists"] == [{"id": 10, "name": "Groceries", "status": "active"}]
         assert result["shopping_items"] == {10: [{"id": 20, "title": "Milk", "is_done": False}]}
+        assert result["meal_plans"] == [
+            {
+                "id": 30,
+                "user_id": 1,
+                "name": "Current week",
+                "week_start": "2026-06-01",
+                "notes": None,
+                "created_at": "2026-06-01",
+            }
+        ]
+        assert result["meal_slots"] == [
+            {
+                "id": 40,
+                "meal_plan_id": 30,
+                "slot_date": "2026-06-01",
+                "slot_type": "dinner",
+                "title": "Pasta",
+                "recipe_url": "https://recipes.example/pasta",
+                "ingredients_json": ["pasta"],
+                "planned_item_id": None,
+            }
+        ]
         client.async_list_shopping_lists.assert_awaited_once_with(status="active")
         client.async_list_shopping_items.assert_awaited_once_with(10)
+        client.async_get_meal_plan_slots.assert_awaited_once_with(30)
 
     async def test_authentication_error_raises_config_entry_auth_failed(self) -> None:
         client = AsyncMock()
@@ -326,6 +398,16 @@ class TestAsyncUpdateData:
         client.async_list_shopping_lists.side_effect = DaynestCommunicationError("timeout")
         coordinator = _make_coordinator(client)
         with pytest.raises(UpdateFailed, match="Temporary communication failure while updating shopping lists"):
+            await coordinator._async_update_data()
+
+    async def test_meal_plan_communication_error_raises_update_failed(self) -> None:
+        client = AsyncMock()
+        client.async_get_dashboard.return_value = _make_dashboard_response()
+        client.async_get_user_settings.return_value = {}
+        client.async_list_shopping_lists.return_value = []
+        client.async_list_meal_plans.side_effect = DaynestCommunicationError("timeout")
+        coordinator = _make_coordinator(client)
+        with pytest.raises(UpdateFailed, match="Temporary communication failure while updating meal plans"):
             await coordinator._async_update_data()
 
     async def test_empty_shopping_lists_returns_empty_shopping_items(self) -> None:

--- a/python-daynest/src/daynest/__init__.py
+++ b/python-daynest/src/daynest/__init__.py
@@ -17,6 +17,8 @@ from daynest.models import (
     DaynestApiResponse,
     DaynestDashboard,
     DaynestSummary,
+    MealPlan,
+    MealSlot,
     PlannedItem,
     RoutineTemplate,
 )
@@ -33,6 +35,8 @@ __all__ = [
     "DaynestApiResponse",
     "DaynestSummary",
     "DaynestDashboard",
+    "MealPlan",
+    "MealSlot",
     "PlannedItem",
     "RoutineTemplate",
     "ChoreTemplate",

--- a/python-daynest/src/daynest/client.py
+++ b/python-daynest/src/daynest/client.py
@@ -31,6 +31,8 @@ from daynest.models import (
     DaynestApiResponse,
     DaynestDashboard,
     DaynestSummary,
+    MealPlan,
+    MealSlot,
     PlannedItem,
     RoutineTemplate,
 )
@@ -385,6 +387,43 @@ class DaynestClient:
             path += f"?scope={scope}"
         await self._send_no_content_action("delete", path=path)
 
+    async def async_list_meal_plans(
+        self,
+        *,
+        week_start_from: date | None = None,
+        week_start_to: date | None = None,
+    ) -> list[MealPlan]:
+        """List meal plans, optionally filtered by week_start client-side."""
+        payload = await self._cached_call("async_list_meal_plans", lambda: self._request_list("/api/meal-plans"))
+        plans = [MealPlan.from_dict(item) for item in payload]
+        if week_start_from is not None:
+            plans = [plan for plan in plans if plan.week_start >= week_start_from]
+        if week_start_to is not None:
+            plans = [plan for plan in plans if plan.week_start <= week_start_to]
+        return plans
+
+    async def async_get_meal_plan_slots(self, meal_plan_id: int) -> list[MealSlot]:
+        """Fetch and flatten slots for a meal plan week grid."""
+        payload = await self._cached_call(
+            "async_get_meal_plan_slots",
+            lambda: self._request_dict(f"/api/meal-plans/{meal_plan_id}/slots"),
+            meal_plan_id,
+        )
+        days = payload.get("days")
+        if not isinstance(days, list):
+            msg = "Malformed meal plan slots payload: expected days array"
+            raise DaynestMalformedResponseError(msg)
+        slots: list[MealSlot] = []
+        for day in days:
+            if not isinstance(day, dict):
+                continue
+            raw_slots = day.get("slots")
+            if not isinstance(raw_slots, dict):
+                continue
+            for raw_slot in raw_slots.values():
+                if isinstance(raw_slot, dict):
+                    slots.append(MealSlot.from_dict(raw_slot))
+        return slots
 
     async def async_list_shopping_lists(self, status: str = "active") -> list[dict[str, Any]]:
         """List shopping lists for the authenticated user."""

--- a/python-daynest/src/daynest/models.py
+++ b/python-daynest/src/daynest/models.py
@@ -179,6 +179,65 @@ class PlannedItem:
 
 
 @dataclass(slots=True, frozen=True)
+class MealPlan:
+    """Typed model for a meal plan."""
+
+    id: int
+    user_id: int
+    name: str
+    week_start: date
+    notes: str | None
+    created_at: datetime
+
+    @classmethod
+    def from_dict(cls, payload: dict[str, Any]) -> MealPlan:
+        if not isinstance(payload, dict):
+            msg = "Malformed meal plan payload: expected JSON object"
+            raise DaynestMalformedResponseError(msg)
+        return cls(
+            id=int(_require(payload, "id", context="meal plan")),
+            user_id=int(_require(payload, "user_id", context="meal plan")),
+            name=str(_require(payload, "name", context="meal plan")),
+            week_start=_parse_date(_require(payload, "week_start", context="meal plan"), field="week_start"),
+            notes=payload.get("notes") if isinstance(payload.get("notes"), str) else None,
+            created_at=_parse_datetime(_require(payload, "created_at", context="meal plan"), field="created_at"),
+        )
+
+
+@dataclass(slots=True, frozen=True)
+class MealSlot:
+    """Typed model for a meal plan slot."""
+
+    id: int
+    meal_plan_id: int
+    slot_date: date
+    slot_type: str
+    title: str
+    recipe_url: str | None
+    ingredients_json: tuple[str, ...]
+    planned_item_id: int | None
+
+    @classmethod
+    def from_dict(cls, payload: dict[str, Any]) -> MealSlot:
+        if not isinstance(payload, dict):
+            msg = "Malformed meal slot payload: expected JSON object"
+            raise DaynestMalformedResponseError(msg)
+        ingredients = payload.get("ingredients_json")
+        ingredient_values = tuple(str(item) for item in ingredients) if isinstance(ingredients, list) else ()
+        planned_item_id = payload.get("planned_item_id")
+        return cls(
+            id=int(_require(payload, "id", context="meal slot")),
+            meal_plan_id=int(_require(payload, "meal_plan_id", context="meal slot")),
+            slot_date=_parse_date(_require(payload, "slot_date", context="meal slot"), field="slot_date"),
+            slot_type=str(_require(payload, "slot_type", context="meal slot")),
+            title=str(payload.get("title", "")),
+            recipe_url=payload.get("recipe_url") if isinstance(payload.get("recipe_url"), str) else None,
+            ingredients_json=ingredient_values,
+            planned_item_id=int(planned_item_id) if planned_item_id is not None else None,
+        )
+
+
+@dataclass(slots=True, frozen=True)
 class RoutineTemplate:
     """Typed model for a routine template."""
 

--- a/python-daynest/tests/test_client.py
+++ b/python-daynest/tests/test_client.py
@@ -16,7 +16,7 @@ from daynest.exceptions import (
     DaynestServerUnavailableError,
     DaynestTimeoutError,
 )
-from daynest.models import CalendarDay, CalendarEvent, ChoreTemplate, DaynestDashboard, DaynestSummary, PlannedItem, RoutineTemplate
+from daynest.models import CalendarDay, CalendarEvent, ChoreTemplate, DaynestDashboard, DaynestSummary, MealPlan, MealSlot, PlannedItem, RoutineTemplate
 
 VALID_SUMMARY_PAYLOAD = {
     "sensor_daynest_chores_due": 2,
@@ -918,6 +918,111 @@ class TestDaynestClientCacheAndSSE:
 
         session.get.assert_not_called()
         callback.assert_not_awaited()
+
+
+@pytest.mark.unit
+class TestDaynestClientMealPlanMethods:
+    """Tests for meal plan client helpers."""
+
+    async def test_list_meal_plans_filters_by_week_start(self) -> None:
+        response = _make_mock_response(
+            200,
+            [
+                {
+                    "id": 1,
+                    "user_id": 2,
+                    "name": "Past",
+                    "week_start": "2026-05-25",
+                    "notes": None,
+                    "created_at": "2026-05-01T00:00:00",
+                },
+                {
+                    "id": 2,
+                    "user_id": 2,
+                    "name": "Current",
+                    "week_start": "2026-06-01",
+                    "notes": "Notes",
+                    "created_at": "2026-05-01T00:00:00",
+                },
+                {
+                    "id": 3,
+                    "user_id": 2,
+                    "name": "Next",
+                    "week_start": "2026-06-08",
+                    "notes": None,
+                    "created_at": "2026-05-01T00:00:00",
+                },
+            ],
+        )
+        client = _make_list_client(response)
+
+        plans = await client.async_list_meal_plans(
+            week_start_from=date(2026, 6, 1),
+            week_start_to=date(2026, 6, 8),
+        )
+
+        assert [plan.id for plan in plans] == [2, 3]
+        assert all(isinstance(plan, MealPlan) for plan in plans)
+        client._session.get.assert_called_once()
+        assert client._session.get.call_args.args[0] == "https://api.daynest.example/api/meal-plans"
+
+    async def test_get_meal_plan_slots_flattens_week_grid(self) -> None:
+        response = _make_mock_response(
+            200,
+            {
+                "meal_plan": {
+                    "id": 2,
+                    "user_id": 2,
+                    "name": "Current",
+                    "week_start": "2026-06-01",
+                    "notes": None,
+                    "created_at": "2026-05-01T00:00:00",
+                },
+                "days": [
+                    {
+                        "date": "2026-06-01",
+                        "slots": {
+                            "breakfast": {
+                                "id": 10,
+                                "meal_plan_id": 2,
+                                "slot_date": "2026-06-01",
+                                "slot_type": "breakfast",
+                                "title": "Oats",
+                                "recipe_url": "https://recipes.example/oats",
+                                "ingredients_json": ["oats"],
+                                "planned_item_id": None,
+                            },
+                            "dinner": {
+                                "id": 11,
+                                "meal_plan_id": 2,
+                                "slot_date": "2026-06-01",
+                                "slot_type": "dinner",
+                                "title": "Pasta",
+                                "recipe_url": None,
+                                "ingredients_json": [],
+                                "planned_item_id": 50,
+                            },
+                        },
+                    },
+                ],
+            },
+        )
+        client = _make_list_client(response)
+
+        slots = await client.async_get_meal_plan_slots(2)
+
+        assert [slot.title for slot in slots] == ["Oats", "Pasta"]
+        assert all(isinstance(slot, MealSlot) for slot in slots)
+        assert slots[0].ingredients_json == ("oats",)
+        assert slots[1].planned_item_id == 50
+        assert client._session.get.call_args.args[0] == "https://api.daynest.example/api/meal-plans/2/slots"
+
+    async def test_get_meal_plan_slots_rejects_missing_days_array(self) -> None:
+        response = _make_mock_response(200, {"meal_plan": {}, "days": "bad"})
+        client = _make_list_client(response)
+
+        with pytest.raises(DaynestMalformedResponseError, match="expected days array"):
+            await client.async_get_meal_plan_slots(2)
 
 
 @pytest.mark.unit


### PR DESCRIPTION
### Motivation
- Surface meal plans and per-day meal slots in the Home Assistant integration so users can view meal-plan slots as calendar events and the coordinator can include meal-plan data alongside existing dashboard/shopping-list data.

### Description
- Add typed `MealPlan` and `MealSlot` models to the `python-daynest` client and export them in the package `__all__` list.
- Add client helpers `async_list_meal_plans` and `async_get_meal_plan_slots` to `DaynestClient` to list meal plans and flatten week-slot grids into slot objects.
- Extend the HA coordinator with `_current_and_next_week_window`, `_model_to_dict`, and logic to fetch current/next-week meal plans and slots and expose them as `meal_plans` and `meal_slots` in the coordinator data while mapping client errors to `UpdateFailed`.
- Register a new `DaynestMealPlanCalendarEntity` in the calendar platform that converts `meal_slots` into `CalendarEvent` instances using default slot times (breakfast 08:00, lunch 12:00, dinner 18:00, snack 15:00), and add translation keys and unit tests covering the client, coordinator, and calendar behavior.

### Testing
- Ran style checks with `ruff` and auto-fixed import ordering with `ruff --fix`, and no lint issues remain; the checks passed.
- Ran component unit tests with `pytest` for the custom component (`custom_components` tests) and all tests passed (`141 passed`).
- Ran library tests with `pytest` for `python-daynest` and all tests passed (`190 passed`).
- Verified `git diff --check` and project checks reported no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2495b36904832eb518b21adcfa2106)