### PR TITLE
feat(calendar): add outbound iCal feed

### DIFF
--- a/backend/alembic/versions/20260606_0016_calendar_feed_token.py
+++ b/backend/alembic/versions/20260606_0016_calendar_feed_token.py
@@ -1,0 +1,26 @@
+"""add calendar feed token
+
+Revision ID: 20260606_0016
+Revises: 20260607_0015
+Create Date: 2026-06-06 00:16:00.000000
+"""
+
+from typing import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "20260606_0016"
+down_revision: str | None = "20260607_0015"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column("users", sa.Column("calendar_feed_token", sa.String(64), nullable=True))
+    op.create_index("ix_users_calendar_feed_token", "users", ["calendar_feed_token"], unique=True)
+
+
+def downgrade() -> None:
+    op.drop_index("ix_users_calendar_feed_token", table_name="users")
+    op.drop_column("users", "calendar_feed_token")

--- a/backend/app/api/routes/calendar.py
+++ b/backend/app/api/routes/calendar.py
@@ -2,15 +2,17 @@ from datetime import date, datetime, timedelta, timezone
 from secrets import token_urlsafe
 from zoneinfo import ZoneInfo
 
-from fastapi import APIRouter, Depends, HTTPException, Query, Response, status
+from fastapi import APIRouter, Depends, HTTPException, Query, Request, Response, status
+from icalendar import Calendar, Event
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 
 from app.api.dependencies.auth import get_current_user, get_current_user_optional
 from app.api.dependencies.today import get_today_service
 from app.db.session import get_db
+from app.models.planned_item import PlannedItem
 from app.models.user import User
-from app.schemas.calendar import CalendarTokenResponse
+from app.schemas.calendar import CalendarFeedResponse, CalendarTokenResponse
 from app.schemas.today import CalendarRangeResponse
 from app.services.today_service import TodayService
 
@@ -128,6 +130,131 @@ def revoke_calendar_token(
     db.commit()
     return Response(status_code=status.HTTP_204_NO_CONTENT)
 
+
+_FEED_PAST_DAYS = 7
+_FEED_FUTURE_DAYS = 90
+_DEFAULT_FEED_DURATION_MINUTES = 60
+
+
+def _new_calendar_feed_token(db: Session) -> str:
+    for _ in range(10):
+        token = token_urlsafe(32)
+        exists = db.scalar(select(User.id).where(User.calendar_feed_token == token))
+        if exists is None:
+            return token
+    raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Could not generate calendar feed token")
+
+
+def _calendar_feed_response(request: Request, user: User) -> CalendarFeedResponse:
+    token = user.calendar_feed_token
+    if token is None:
+        raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Calendar feed token missing")
+    return CalendarFeedResponse(
+        token=token,
+        feed_url=str(request.url_for("get_calendar_feed_ics", token=token)),
+    )
+
+
+@router.get("/calendar/feed", response_model=CalendarFeedResponse)
+def get_calendar_feed(
+    request: Request,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+) -> CalendarFeedResponse:
+    if current_user.calendar_feed_token is None:
+        current_user.calendar_feed_token = _new_calendar_feed_token(db)
+        db.commit()
+        db.refresh(current_user)
+    return _calendar_feed_response(request, current_user)
+
+
+@router.post("/calendar/feed/regenerate", response_model=CalendarFeedResponse)
+def regenerate_calendar_feed(
+    request: Request,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+) -> CalendarFeedResponse:
+    current_user.calendar_feed_token = _new_calendar_feed_token(db)
+    db.commit()
+    db.refresh(current_user)
+    return _calendar_feed_response(request, current_user)
+
+
+def _planned_item_start(item: PlannedItem, tz: ZoneInfo) -> date | datetime:
+    if item.time_of_day is None:
+        return item.planned_for
+    return datetime.combine(item.planned_for, item.time_of_day, tzinfo=tz)
+
+
+def _planned_item_end(item: PlannedItem, start: date | datetime) -> date | datetime:
+    if isinstance(start, datetime):
+        minutes = item.duration_minutes or _DEFAULT_FEED_DURATION_MINUTES
+        return start + timedelta(minutes=minutes)
+    return start + timedelta(days=1)
+
+
+def _build_planned_items_calendar(user: User, planned_items: list[PlannedItem]) -> bytes:
+    calendar = Calendar()
+    calendar.add("prodid", "-//Daynest//Planned Items//EN")
+    calendar.add("version", "2.0")
+    calendar.add("calscale", "GREGORIAN")
+    calendar.add("method", "PUBLISH")
+    calendar.add("x-wr-calname", "Daynest")
+
+    try:
+        tz = ZoneInfo(user.timezone)
+    except Exception:
+        tz = ZoneInfo("UTC")
+
+    dtstamp = datetime.now(timezone.utc)
+    for item in planned_items:
+        event = Event()
+        start = _planned_item_start(item, tz)
+        event.add("uid", f"daynest-{item.id}@daynest")
+        event.add("dtstamp", dtstamp)
+        event.add("dtstart", start)
+        event.add("dtend", _planned_item_end(item, start))
+        event.add("summary", item.title)
+        if item.notes:
+            event.add("description", item.notes)
+        calendar.add_component(event)
+
+    return calendar.to_ical()
+
+
+@router.get("/calendar/feed/{token}.ics", name="get_calendar_feed_ics")
+def get_calendar_feed_ics(token: str, db: Session = Depends(get_db)) -> Response:
+    user = db.scalar(select(User).where(User.calendar_feed_token == token).where(User.is_active.is_(True)))
+    if user is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Calendar feed not found")
+
+    try:
+        feed_tz = ZoneInfo(user.timezone)
+    except Exception:
+        feed_tz = ZoneInfo("UTC")
+    today = datetime.now(feed_tz).date()
+    start_date = today - timedelta(days=_FEED_PAST_DAYS)
+    end_date = today + timedelta(days=_FEED_FUTURE_DAYS)
+    planned_items = list(
+        db.scalars(
+            select(PlannedItem)
+            .where(PlannedItem.user_id == user.id)
+            .where(PlannedItem.planned_for >= start_date)
+            .where(PlannedItem.planned_for <= end_date)
+            .order_by(PlannedItem.planned_for, PlannedItem.time_of_day, PlannedItem.id)
+        )
+    )
+
+    return Response(
+        content=_build_planned_items_calendar(user, planned_items),
+        media_type="text/calendar; charset=utf-8",
+        headers={
+            "Content-Disposition": 'attachment; filename="daynest-planned-items.ics"',
+            "Cache-Control": "private, no-store",
+            "Pragma": "no-cache",
+            "Expires": "0",
+        },
+    )
 
 # --- Calendar range ---
 

--- a/backend/app/models/user.py
+++ b/backend/app/models/user.py
@@ -59,6 +59,7 @@ class User(Base):
         server_default=sa.text("true"),
     )
     calendar_token: Mapped[str | None] = mapped_column(String(64), nullable=True, unique=True, index=True)
+    calendar_feed_token: Mapped[str | None] = mapped_column(String(64), nullable=True, unique=True, index=True)
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False, server_default=func.now())
 
     routine_templates: Mapped[list["RoutineTemplate"]] = relationship(back_populates="user", cascade="all, delete-orphan")

--- a/backend/app/schemas/calendar.py
+++ b/backend/app/schemas/calendar.py
@@ -3,3 +3,8 @@ from pydantic import BaseModel
 
 class CalendarTokenResponse(BaseModel):
     token: str
+
+
+class CalendarFeedResponse(BaseModel):
+    token: str
+    feed_url: str

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -9,6 +9,7 @@ dependencies = [
     "fastapi==0.136.3",
     "google-auth==2.53.0",
     "httpx==0.28.1",
+    "icalendar==6.3.2",
     "fastmcp==3.4.2",
     "psycopg[binary]==3.3.4",
     "pydantic==2.13.4",

--- a/backend/tests/test_shopping_lists.py
+++ b/backend/tests/test_shopping_lists.py
@@ -1,6 +1,6 @@
 """Tests for shopping-list backend APIs and service behavior."""
 
-from datetime import date
+from datetime import date, timedelta
 
 import pytest
 from fastapi.testclient import TestClient
@@ -191,12 +191,14 @@ def test_import_recurring_groceries_route_links_upcoming_items(
         "/api/shopping-lists", json={"name": "Groceries"}
     ).json()["id"]
 
+    today = date.today()
+    next_week = today + timedelta(weeks=1)
     db_session.add(
         RecurrenceSeries(
             user_id=user.id,
             title="Eggs",
             rrule="FREQ=WEEKLY;COUNT=2",
-            start_date=date(2026, 6, 6),
+            start_date=today,
             module_key="recurring_grocery",
             recurrence_hint="weekly",
         )
@@ -207,7 +209,7 @@ def test_import_recurring_groceries_route_links_upcoming_items(
 
     assert response.status_code == 200
     payload = response.json()
-    assert [item["planned_for"] for item in payload] == ["2026-06-06", "2026-06-13"]
+    assert [item["planned_for"] for item in payload] == [today.isoformat(), next_week.isoformat()]
     assert {item["module_key"] for item in payload} == {"shopping_list"}
     assert {item["linked_ref"] for item in payload} == {str(shopping_list_id)}
 

--- a/backend/tests/test_today_route_integration.py
+++ b/backend/tests/test_today_route_integration.py
@@ -1,4 +1,4 @@
-from datetime import date, datetime, time, timezone
+from datetime import date, datetime, time, timedelta, timezone
 from unittest.mock import MagicMock
 
 from fastapi.testclient import TestClient
@@ -781,3 +781,78 @@ def test_routine_task_generation_and_mutation_endpoints(client: TestClient, db_s
         assert skip_resp.json()["status"] == "skipped"
     finally:
         _clear_auth()
+
+
+def test_calendar_feed_get_generates_subscription_url(client: TestClient, db_session: Session) -> None:
+    user = _create_user(db_session, email="calendar-feed-generate@example.com")
+    _auth_as(user)
+
+    try:
+        response = client.get("/api/calendar/feed")
+    finally:
+        _clear_auth()
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert len(payload["token"]) >= 32
+    assert payload["feed_url"] == f"http://localhost/api/calendar/feed/{payload['token']}.ics"
+    db_session.refresh(user)
+    assert user.calendar_feed_token == payload["token"]
+
+
+def test_calendar_feed_regenerate_rotates_token(client: TestClient, db_session: Session) -> None:
+    user = _create_user(db_session, email="calendar-feed-rotate@example.com")
+    user.calendar_feed_token = "old-feed-token"
+    db_session.commit()
+    _auth_as(user)
+
+    try:
+        response = client.post("/api/calendar/feed/regenerate")
+    finally:
+        _clear_auth()
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["token"] != "old-feed-token"
+    assert payload["feed_url"] == f"http://localhost/api/calendar/feed/{payload['token']}.ics"
+    db_session.refresh(user)
+    assert user.calendar_feed_token == payload["token"]
+
+
+def test_calendar_feed_ics_serializes_planned_items(client: TestClient, db_session: Session) -> None:
+    user = _create_user(db_session, email="calendar-feed-ics@example.com")
+    user.calendar_feed_token = "feed-token"
+    user.timezone = "UTC"
+    today = date.today()
+    included = PlannedItem(
+        user_id=user.id,
+        title="Plan menu, shop",
+        notes="Prep recipes\nBuy produce",
+        planned_for=today,
+        time_of_day=time(9, 30),
+        duration_minutes=45,
+    )
+    all_day = PlannedItem(user_id=user.id, title="All-day plan", planned_for=today + timedelta(days=1))
+    too_old = PlannedItem(user_id=user.id, title="Too old", planned_for=today - timedelta(days=8))
+    too_far = PlannedItem(user_id=user.id, title="Too far", planned_for=today + timedelta(days=91))
+    db_session.add_all([included, all_day, too_old, too_far])
+    db_session.commit()
+
+    response = client.get("/api/calendar/feed/feed-token.ics")
+
+    assert response.status_code == 200
+    assert response.headers["content-type"].startswith("text/calendar")
+    body = response.text
+    assert "BEGIN:VCALENDAR" in body
+    assert f"UID:daynest-{included.id}@daynest" in body
+    assert "SUMMARY:Plan menu\\, shop" in body
+    assert "DESCRIPTION:Prep recipes\\nBuy produce" in body
+    assert f"UID:daynest-{all_day.id}@daynest" in body
+    assert "SUMMARY:Too old" not in body
+    assert "SUMMARY:Too far" not in body
+
+
+def test_calendar_feed_unknown_token_returns_404(client: TestClient) -> None:
+    response = client.get("/api/calendar/feed/missing.ics")
+
+    assert response.status_code == 404

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.13"
 
 [[package]]
@@ -430,6 +430,7 @@ dependencies = [
     { name = "fastmcp" },
     { name = "google-auth" },
     { name = "httpx" },
+    { name = "icalendar" },
     { name = "psycopg", extra = ["binary"] },
     { name = "pydantic" },
     { name = "pydantic-settings" },
@@ -459,6 +460,7 @@ requires-dist = [
     { name = "fastmcp", specifier = "==3.4.2" },
     { name = "google-auth", specifier = "==2.53.0" },
     { name = "httpx", specifier = "==0.28.1" },
+    { name = "icalendar", specifier = "==6.3.2" },
     { name = "psycopg", extras = ["binary"], specifier = "==3.3.4" },
     { name = "pydantic", specifier = "==2.13.4" },
     { name = "pydantic-settings", specifier = "==2.14.1" },
@@ -692,7 +694,9 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/7a/75/7e9cd1126a1e1f0cd67b0eda02e5221b28488d352684704a78ed505bd719/greenlet-3.4.0-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:43748988b097f9c6f09364f260741aa73c80747f63389824435c7a50bfdfd5c1", size = 285856, upload-time = "2026-04-08T15:52:45.82Z" },
     { url = "https://files.pythonhosted.org/packages/9d/c4/3e2df392e5cb199527c4d9dbcaa75c14edcc394b45040f0189f649631e3c/greenlet-3.4.0-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5566e4e2cd7a880e8c27618e3eab20f3494452d12fd5129edef7b2f7aa9a36d1", size = 610208, upload-time = "2026-04-08T16:24:39.674Z" },
     { url = "https://files.pythonhosted.org/packages/da/af/750cdfda1d1bd30a6c28080245be8d0346e669a98fdbae7f4102aa95fff3/greenlet-3.4.0-cp313-cp313-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:1054c5a3c78e2ab599d452f23f7adafef55062a783a8e241d24f3b633ba6ff82", size = 621269, upload-time = "2026-04-08T16:30:59.767Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/93/c8c508d68ba93232784bbc1b5474d92371f2897dfc6bc281b419f2e0d492/greenlet-3.4.0-cp313-cp313-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:98eedd1803353daf1cd9ef23eef23eda5a4d22f99b1f998d273a8b78b70dd47f", size = 628455, upload-time = "2026-04-08T16:40:40.698Z" },
     { url = "https://files.pythonhosted.org/packages/54/78/0cbc693622cd54ebe25207efbb3a0eb07c2639cb8594f6e3aaaa0bb077a8/greenlet-3.4.0-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f82cb6cddc27dd81c96b1506f4aa7def15070c3b2a67d4e46fd19016aacce6cf", size = 617549, upload-time = "2026-04-08T15:56:34.893Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/46/cfaaa0ade435a60550fd83d07dfd5c41f873a01da17ede5c4cade0b9bab8/greenlet-3.4.0-cp313-cp313-manylinux_2_39_riscv64.whl", hash = "sha256:b7857e2202aae67bc5725e0c1f6403c20a8ff46094ece015e7d474f5f7020b55", size = 426238, upload-time = "2026-04-08T16:43:06.865Z" },
     { url = "https://files.pythonhosted.org/packages/ba/c0/8966767de01343c1ff47e8b855dc78e7d1a8ed2b7b9c83576a57e289f81d/greenlet-3.4.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:227a46251ecba4ff46ae742bc5ce95c91d5aceb4b02f885487aff269c127a729", size = 1575310, upload-time = "2026-04-08T16:26:21.671Z" },
     { url = "https://files.pythonhosted.org/packages/b8/38/bcdc71ba05e9a5fda87f63ffc2abcd1f15693b659346df994a48c968003d/greenlet-3.4.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:5b99e87be7eba788dd5b75ba1cde5639edffdec5f91fe0d734a249535ec3408c", size = 1640435, upload-time = "2026-04-08T15:57:32.572Z" },
     { url = "https://files.pythonhosted.org/packages/a1/c2/19b664b7173b9e4ef5f77e8cef9f14c20ec7fce7920dc1ccd7afd955d093/greenlet-3.4.0-cp313-cp313-win_amd64.whl", hash = "sha256:849f8bc17acd6295fcb5de8e46d55cc0e52381c56eaf50a2afd258e97bc65940", size = 238760, upload-time = "2026-04-08T17:04:03.878Z" },
@@ -700,7 +704,9 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/78/02/bde66806e8f169cf90b14d02c500c44cdbe02c8e224c9c67bafd1b8cadd1/greenlet-3.4.0-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:10a07aca6babdd18c16a3f4f8880acfffc2b88dfe431ad6aa5f5740759d7d75e", size = 286291, upload-time = "2026-04-08T17:09:34.307Z" },
     { url = "https://files.pythonhosted.org/packages/05/1f/39da1c336a87d47c58352fb8a78541ce63d63ae57c5b9dae1fe02801bbc2/greenlet-3.4.0-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:076e21040b3a917d3ce4ad68fb5c3c6b32f1405616c4a57aa83120979649bd3d", size = 656749, upload-time = "2026-04-08T16:24:41.721Z" },
     { url = "https://files.pythonhosted.org/packages/d3/6c/90ee29a4ee27af7aa2e2ec408799eeb69ee3fcc5abcecac6ddd07a5cd0f2/greenlet-3.4.0-cp314-cp314-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e82689eea4a237e530bb5cb41b180ef81fa2160e1f89422a67be7d90da67f615", size = 669084, upload-time = "2026-04-08T16:31:01.372Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/4a/74078d3936712cff6d3c91a930016f476ce4198d84e224fe6d81d3e02880/greenlet-3.4.0-cp314-cp314-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:06c2d3b89e0c62ba50bd7adf491b14f39da9e7e701647cb7b9ff4c99bee04b19", size = 673405, upload-time = "2026-04-08T16:40:42.527Z" },
     { url = "https://files.pythonhosted.org/packages/07/49/d4cad6e5381a50947bb973d2f6cf6592621451b09368b8c20d9b8af49c5b/greenlet-3.4.0-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4df3b0b2289ec686d3c821a5fee44259c05cfe824dd5e6e12c8e5f5df23085cf", size = 665621, upload-time = "2026-04-08T15:56:35.995Z" },
+    { url = "https://files.pythonhosted.org/packages/79/3e/df8a83ab894751bc31e1106fdfaa80ca9753222f106b04de93faaa55feb7/greenlet-3.4.0-cp314-cp314-manylinux_2_39_riscv64.whl", hash = "sha256:070b8bac2ff3b4d9e0ff36a0d19e42103331d9737e8504747cd1e659f76297bd", size = 471670, upload-time = "2026-04-08T16:43:08.512Z" },
     { url = "https://files.pythonhosted.org/packages/37/31/d1edd54f424761b5d47718822f506b435b6aab2f3f93b465441143ea5119/greenlet-3.4.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:8bff29d586ea415688f4cec96a591fcc3bf762d046a796cdadc1fdb6e7f2d5bf", size = 1622259, upload-time = "2026-04-08T16:26:23.201Z" },
     { url = "https://files.pythonhosted.org/packages/b0/c6/6d3f9cdcb21c4e12a79cb332579f1c6aa1af78eb68059c5a957c7812d95e/greenlet-3.4.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:8a569c2fb840c53c13a2b8967c63621fafbd1a0e015b9c82f408c33d626a2fda", size = 1686916, upload-time = "2026-04-08T15:57:34.282Z" },
     { url = "https://files.pythonhosted.org/packages/63/45/c1ca4a1ad975de4727e52d3ffe641ae23e1d7a8ffaa8ff7a0477e1827b92/greenlet-3.4.0-cp314-cp314-win_amd64.whl", hash = "sha256:207ba5b97ea8b0b60eb43ffcacf26969dd83726095161d676aac03ff913ee50d", size = 239821, upload-time = "2026-04-08T17:03:48.423Z" },
@@ -708,7 +714,9 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/d4/8f/18d72b629783f5e8d045a76f5325c1e938e659a9e4da79c7dcd10169a48d/greenlet-3.4.0-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:d70012e51df2dbbccfaf63a40aaf9b40c8bed37c3e3a38751c926301ce538ece", size = 294681, upload-time = "2026-04-08T15:52:35.778Z" },
     { url = "https://files.pythonhosted.org/packages/9e/ad/5fa86ec46769c4153820d58a04062285b3b9e10ba3d461ee257b68dcbf53/greenlet-3.4.0-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a58bec0751f43068cd40cff31bb3ca02ad6000b3a51ca81367af4eb5abc480c8", size = 658899, upload-time = "2026-04-08T16:24:43.32Z" },
     { url = "https://files.pythonhosted.org/packages/43/f0/4e8174ca0e87ae748c409f055a1ba161038c43cc0a5a6f1433a26ac2e5bf/greenlet-3.4.0-cp314-cp314t-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:05fa0803561028f4b2e3b490ee41216a842eaee11aed004cc343a996d9523aa2", size = 665284, upload-time = "2026-04-08T16:31:02.833Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/92/466b0d9afd44b8af623139a3599d651c7564fa4152f25f117e1ee5949ffb/greenlet-3.4.0-cp314-cp314t-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:c4cd56a9eb7a6444edbc19062f7b6fbc8f287c663b946e3171d899693b1c19fa", size = 665872, upload-time = "2026-04-08T16:40:43.912Z" },
     { url = "https://files.pythonhosted.org/packages/19/da/991cf7cd33662e2df92a1274b7eb4d61769294d38a1bba8a45f31364845e/greenlet-3.4.0-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e60d38719cb80b3ab5e85f9f1aed4960acfde09868af6762ccb27b260d68f4ed", size = 661861, upload-time = "2026-04-08T15:56:37.269Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/14/3395a7ef3e260de0325152ddfe19dffb3e49fe10873b94654352b53ad48e/greenlet-3.4.0-cp314-cp314t-manylinux_2_39_riscv64.whl", hash = "sha256:1f85f204c4d54134ae850d401fa435c89cd667d5ce9dc567571776b45941af72", size = 489237, upload-time = "2026-04-08T16:43:09.993Z" },
     { url = "https://files.pythonhosted.org/packages/36/c5/6c2c708e14db3d9caea4b459d8464f58c32047451142fe2cfd90e7458f41/greenlet-3.4.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:7f50c804733b43eded05ae694691c9aa68bca7d0a867d67d4a3f514742a2d53f", size = 1622182, upload-time = "2026-04-08T16:26:24.777Z" },
     { url = "https://files.pythonhosted.org/packages/7a/4c/50c5fed19378e11a29fabab1f6be39ea95358f4a0a07e115a51ca93385d8/greenlet-3.4.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:2d4f0635dc4aa638cda4b2f5a07ae9a2cff9280327b581a3fcb6f317b4fbc38a", size = 1685050, upload-time = "2026-04-08T15:57:36.453Z" },
     { url = "https://files.pythonhosted.org/packages/db/72/85ae954d734703ab48e622c59d4ce35d77ce840c265814af9c078cacc7aa/greenlet-3.4.0-cp314-cp314t-win_amd64.whl", hash = "sha256:1a4a48f24681300c640f143ba7c404270e1ebbbcf34331d7104a4ff40f8ea705", size = 245554, upload-time = "2026-04-08T17:03:50.044Z" },
@@ -805,6 +813,19 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/0f/4c/751061ffa58615a32c31b2d82e8482be8dd4a89154f003147acee90f2be9/httpx_sse-0.4.3.tar.gz", hash = "sha256:9b1ed0127459a66014aec3c56bebd93da3c1bc8bb6618c8082039a44889a755d", size = 15943, upload-time = "2025-10-10T21:48:22.271Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d2/fd/6668e5aec43ab844de6fc74927e155a3b37bf40d7c3790e49fc0406b6578/httpx_sse-0.4.3-py3-none-any.whl", hash = "sha256:0ac1c9fe3c0afad2e0ebb25a934a59f4c7823b60792691f779fad2c5568830fc", size = 8960, upload-time = "2025-10-10T21:48:21.158Z" },
+]
+
+[[package]]
+name = "icalendar"
+version = "6.3.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "python-dateutil" },
+    { name = "tzdata" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5d/70/458092b3e7c15783423fe64d07e63ea3311a597e723be6a1060513e3db93/icalendar-6.3.2.tar.gz", hash = "sha256:e0c10ecbfcebe958d33af7d491f6e6b7580d11d475f2eeb29532d0424f9110a1", size = 178422, upload-time = "2025-11-05T12:49:32.286Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/06/ee/2ff96bb5bd88fe03ab90aedf5180f96dc0f3ae4648ca264b473055bcaaff/icalendar-6.3.2-py3-none-any.whl", hash = "sha256:d400e9c9bb8c025e5a3c77c236941bb690494be52528a0b43cc7e8b7c9505064", size = 242403, upload-time = "2025-11-05T12:49:30.691Z" },
 ]
 
 [[package]]

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -398,5 +398,21 @@
   "meal_plan_generate_preview": "Review the unique ingredients that will be added to a new shopping list.",
   "meal_plan_generate_error": "Unable to generate shopping list.",
   "meal_plan_no_ingredients": "Add ingredients to at least one meal before generating a list.",
-  "meal_plan_shopping_list_created": "Created shopping list “{name}”."
+  "meal_plan_shopping_list_created": "Created shopping list “{name}”.",
+  "settings_calendar_subscription_header": "Calendar subscription",
+  "settings_calendar_subscription_description": "Add this URL to Google Calendar, Apple Calendar, or Outlook to see your Daynest items there.",
+  "settings_calendar_feed_label": "iCal feed URL",
+  "settings_calendar_feed_loading": "Loading calendar feed URL…",
+  "settings_calendar_feed_unavailable": "Calendar feed unavailable",
+  "settings_calendar_feed_copy": "Copy",
+  "settings_calendar_feed_copied": "Calendar feed URL copied.",
+  "settings_calendar_clipboard_error": "Clipboard copy failed.",
+  "settings_calendar_clipboard_unsupported": "Clipboard API not supported or blocked.",
+  "settings_calendar_regenerate": "Regenerate",
+  "settings_calendar_regenerating": "Regenerating…",
+  "settings_calendar_rotate_warning": "Rotating the URL invalidates existing subscriptions.",
+  "settings_calendar_regenerate_confirm": "Regenerating your calendar feed URL will immediately break existing calendar subscriptions. Continue?",
+  "settings_calendar_regenerated": "Calendar feed URL regenerated. Copy the new URL into your calendar app.",
+  "settings_calendar_regenerate_error": "Failed to regenerate calendar feed URL.",
+  "settings_calendar_load_error": "Failed to load calendar feed URL."
 }

--- a/frontend/messages/nl.json
+++ b/frontend/messages/nl.json
@@ -398,5 +398,21 @@
   "meal_plan_generate_preview": "Controleer de unieke ingrediënten die aan een nieuwe boodschappenlijst worden toegevoegd.",
   "meal_plan_generate_error": "Kan boodschappenlijst niet maken.",
   "meal_plan_no_ingredients": "Voeg ingrediënten toe aan minstens één maaltijd voordat je een lijst maakt.",
-  "meal_plan_shopping_list_created": "Boodschappenlijst “{name}” aangemaakt."
+  "meal_plan_shopping_list_created": "Boodschappenlijst “{name}” aangemaakt.",
+  "settings_calendar_subscription_header": "Kalenderabonnement",
+  "settings_calendar_subscription_description": "Voeg deze URL toe aan Google Agenda, Apple Agenda of Outlook om je Daynest-items daar te zien.",
+  "settings_calendar_feed_label": "iCal-feed-URL",
+  "settings_calendar_feed_loading": "Kalender-feed-URL laden…",
+  "settings_calendar_feed_unavailable": "Kalenderfeed niet beschikbaar",
+  "settings_calendar_feed_copy": "Kopiëren",
+  "settings_calendar_feed_copied": "Kalender-feed-URL gekopieerd.",
+  "settings_calendar_clipboard_error": "Klembord kopiëren mislukt.",
+  "settings_calendar_clipboard_unsupported": "Klembord-API niet ondersteund of geblokkeerd.",
+  "settings_calendar_regenerate": "Opnieuw genereren",
+  "settings_calendar_regenerating": "Opnieuw genereren…",
+  "settings_calendar_rotate_warning": "Het roteren van de URL maakt bestaande abonnementen ongeldig.",
+  "settings_calendar_regenerate_confirm": "Als je de kalender-feed-URL opnieuw genereert, worden bestaande kalenderabonnementen onmiddellijk verbroken. Doorgaan?",
+  "settings_calendar_regenerated": "Kalender-feed-URL opnieuw gegenereerd. Kopieer de nieuwe URL naar je kalenderapp.",
+  "settings_calendar_regenerate_error": "Kan de kalender-feed-URL niet opnieuw genereren.",
+  "settings_calendar_load_error": "Kan de kalender-feed-URL niet laden."
 }

--- a/frontend/src/features/settings/SettingsPage.tsx
+++ b/frontend/src/features/settings/SettingsPage.tsx
@@ -29,8 +29,10 @@ import {
 } from "@/lib/api/auth";
 import { getCustomServerUrl, setCustomServerUrl } from "@/lib/api/serverConfig";
 import {
+  useCalendarFeedQuery,
   useCreateIntegrationClientMutation,
   useIntegrationClientsQuery,
+  useRegenerateCalendarFeedMutation,
   useRevokeIntegrationClientMutation,
   useRotateIntegrationClientMutation,
   useUpdateUserSettingsMutation,
@@ -110,11 +112,15 @@ export function SettingsPage() {
   const [notificationPermission, setNotificationPermission] = useState(() =>
     typeof Notification === "undefined" ? "denied" : Notification.permission,
   );
+  const [calendarFeedCopyStatus, setCalendarFeedCopyStatus] = useState<string | null>(null);
+  const [calendarFeedError, setCalendarFeedError] = useState<string | null>(null);
   const clientsQuery = useIntegrationClientsQuery();
+  const calendarFeedQuery = useCalendarFeedQuery();
   const userSettingsQuery = useUserSettingsQuery();
   const createClientMutation = useCreateIntegrationClientMutation();
   const rotateClientMutation = useRotateIntegrationClientMutation();
   const revokeClientMutation = useRevokeIntegrationClientMutation();
+  const regenerateCalendarFeedMutation = useRegenerateCalendarFeedMutation();
   const updateUserSettingsMutation = useUpdateUserSettingsMutation();
   const clients = clientsQuery.data ?? [];
   const loading = clientsQuery.isPending;
@@ -400,6 +406,32 @@ export function SettingsPage() {
       setCopyStatus("Client secret copied.");
     } catch {
       setCopyStatus("Clipboard copy failed.");
+    }
+  };
+
+  const copyCalendarFeedUrl = async () => {
+    const feedUrl = calendarFeedQuery.data?.feed_url;
+    if (!feedUrl) return;
+    try {
+      await navigator.clipboard.writeText(feedUrl);
+      setCalendarFeedCopyStatus("Calendar feed URL copied.");
+    } catch {
+      setCalendarFeedCopyStatus("Clipboard copy failed.");
+    }
+  };
+
+  const onRegenerateCalendarFeed = async () => {
+    const confirmed = window.confirm(
+      "Regenerating your calendar feed URL will immediately break existing calendar subscriptions. Continue?",
+    );
+    if (!confirmed) return;
+    setCalendarFeedError(null);
+    setCalendarFeedCopyStatus(null);
+    try {
+      await regenerateCalendarFeedMutation.mutateAsync();
+      setCalendarFeedCopyStatus("Calendar feed URL regenerated. Copy the new URL into your calendar app.");
+    } catch (err) {
+      setCalendarFeedError(err instanceof Error ? err.message : "Failed to regenerate calendar feed URL.");
     }
   };
 
@@ -751,6 +783,55 @@ export function SettingsPage() {
                   {m.settings_enable_browser_notifications()}
                 </button>
               ) : null}
+            </div>
+          </div>
+
+          <div className="card mb-3">
+            <div className="card-header fw-semibold py-2">Calendar subscription</div>
+            <div className="card-body d-grid gap-2">
+              <p className="text-muted small mb-1">
+                Add this URL to Google Calendar, Apple Calendar, or Outlook to see your Daynest items there.
+              </p>
+              <label className="form-label small fw-semibold mb-0" htmlFor="calendarFeedUrl">
+                iCal feed URL
+              </label>
+              <div className="input-group input-group-sm">
+                <input
+                  id="calendarFeedUrl"
+                  className="form-control"
+                  readOnly
+                  value={calendarFeedQuery.data?.feed_url ?? ""}
+                  placeholder={calendarFeedQuery.isPending ? "Loading calendar feed URL…" : "Calendar feed unavailable"}
+                />
+                <button
+                  type="button"
+                  className="btn btn-outline-primary"
+                  disabled={!calendarFeedQuery.data?.feed_url}
+                  onClick={() => void copyCalendarFeedUrl()}
+                >
+                  Copy
+                </button>
+              </div>
+              <div className="d-flex gap-2 align-items-center flex-wrap">
+                <button
+                  type="button"
+                  className="btn btn-outline-danger btn-sm"
+                  disabled={regenerateCalendarFeedMutation.isPending}
+                  onClick={() => void onRegenerateCalendarFeed()}
+                >
+                  {regenerateCalendarFeedMutation.isPending ? "Regenerating…" : "Regenerate"}
+                </button>
+                <small className="text-muted">Rotating the URL invalidates existing subscriptions.</small>
+              </div>
+              {calendarFeedQuery.error ? (
+                <div className="text-danger small">
+                  {calendarFeedQuery.error instanceof Error
+                    ? calendarFeedQuery.error.message
+                    : "Failed to load calendar feed URL."}
+                </div>
+              ) : null}
+              {calendarFeedError ? <div className="text-danger small">{calendarFeedError}</div> : null}
+              {calendarFeedCopyStatus ? <div className="text-success small">{calendarFeedCopyStatus}</div> : null}
             </div>
           </div>
 

--- a/frontend/src/features/settings/SettingsPage.tsx
+++ b/frontend/src/features/settings/SettingsPage.tsx
@@ -413,25 +413,28 @@ export function SettingsPage() {
     const feedUrl = calendarFeedQuery.data?.feed_url;
     if (!feedUrl) return;
     try {
-      await navigator.clipboard.writeText(feedUrl);
-      setCalendarFeedCopyStatus("Calendar feed URL copied.");
+      if (navigator.clipboard?.writeText) {
+        await navigator.clipboard.writeText(feedUrl);
+        setCalendarFeedCopyStatus(m.settings_calendar_feed_copied());
+      } else {
+        setCalendarFeedCopyStatus(m.settings_calendar_clipboard_unsupported());
+      }
     } catch {
-      setCalendarFeedCopyStatus("Clipboard copy failed.");
+      setCalendarFeedCopyStatus(m.settings_calendar_clipboard_error());
     }
+    setTimeout(() => setCalendarFeedCopyStatus(null), 3000);
   };
 
   const onRegenerateCalendarFeed = async () => {
-    const confirmed = window.confirm(
-      "Regenerating your calendar feed URL will immediately break existing calendar subscriptions. Continue?",
-    );
+    const confirmed = window.confirm(m.settings_calendar_regenerate_confirm());
     if (!confirmed) return;
     setCalendarFeedError(null);
     setCalendarFeedCopyStatus(null);
     try {
       await regenerateCalendarFeedMutation.mutateAsync();
-      setCalendarFeedCopyStatus("Calendar feed URL regenerated. Copy the new URL into your calendar app.");
+      setCalendarFeedCopyStatus(m.settings_calendar_regenerated());
     } catch (err) {
-      setCalendarFeedError(err instanceof Error ? err.message : "Failed to regenerate calendar feed URL.");
+      setCalendarFeedError(err instanceof Error ? err.message : m.settings_calendar_regenerate_error());
     }
   };
 
@@ -787,13 +790,11 @@ export function SettingsPage() {
           </div>
 
           <div className="card mb-3">
-            <div className="card-header fw-semibold py-2">Calendar subscription</div>
+            <div className="card-header fw-semibold py-2">{m.settings_calendar_subscription_header()}</div>
             <div className="card-body d-grid gap-2">
-              <p className="text-muted small mb-1">
-                Add this URL to Google Calendar, Apple Calendar, or Outlook to see your Daynest items there.
-              </p>
+              <p className="text-muted small mb-1">{m.settings_calendar_subscription_description()}</p>
               <label className="form-label small fw-semibold mb-0" htmlFor="calendarFeedUrl">
-                iCal feed URL
+                {m.settings_calendar_feed_label()}
               </label>
               <div className="input-group input-group-sm">
                 <input
@@ -801,7 +802,11 @@ export function SettingsPage() {
                   className="form-control"
                   readOnly
                   value={calendarFeedQuery.data?.feed_url ?? ""}
-                  placeholder={calendarFeedQuery.isPending ? "Loading calendar feed URL…" : "Calendar feed unavailable"}
+                  placeholder={
+                    calendarFeedQuery.isPending
+                      ? m.settings_calendar_feed_loading()
+                      : m.settings_calendar_feed_unavailable()
+                  }
                 />
                 <button
                   type="button"
@@ -809,7 +814,7 @@ export function SettingsPage() {
                   disabled={!calendarFeedQuery.data?.feed_url}
                   onClick={() => void copyCalendarFeedUrl()}
                 >
-                  Copy
+                  {m.settings_calendar_feed_copy()}
                 </button>
               </div>
               <div className="d-flex gap-2 align-items-center flex-wrap">
@@ -819,15 +824,17 @@ export function SettingsPage() {
                   disabled={regenerateCalendarFeedMutation.isPending}
                   onClick={() => void onRegenerateCalendarFeed()}
                 >
-                  {regenerateCalendarFeedMutation.isPending ? "Regenerating…" : "Regenerate"}
+                  {regenerateCalendarFeedMutation.isPending
+                    ? m.settings_calendar_regenerating()
+                    : m.settings_calendar_regenerate()}
                 </button>
-                <small className="text-muted">Rotating the URL invalidates existing subscriptions.</small>
+                <small className="text-muted">{m.settings_calendar_rotate_warning()}</small>
               </div>
               {calendarFeedQuery.error ? (
                 <div className="text-danger small">
                   {calendarFeedQuery.error instanceof Error
                     ? calendarFeedQuery.error.message
-                    : "Failed to load calendar feed URL."}
+                    : m.settings_calendar_load_error()}
                 </div>
               ) : null}
               {calendarFeedError ? <div className="text-danger small">{calendarFeedError}</div> : null}

--- a/frontend/src/features/settings/useSettingsQueries.ts
+++ b/frontend/src/features/settings/useSettingsQueries.ts
@@ -1,8 +1,10 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import {
   createIntegrationClient,
+  fetchCalendarFeed,
   fetchUserSettings,
   listIntegrationClients,
+  regenerateCalendarFeed,
   revokeIntegrationClient,
   rotateIntegrationClient,
   updateUserSettings,
@@ -24,6 +26,13 @@ export function useIntegrationClientsQuery() {
   return useQuery({
     queryKey: queryKeys.settings.integrationClients(),
     queryFn: ({ signal }) => listIntegrationClients(signal),
+  });
+}
+
+export function useCalendarFeedQuery() {
+  return useQuery({
+    queryKey: queryKeys.settings.calendarFeed(),
+    queryFn: ({ signal }) => fetchCalendarFeed(signal),
   });
 }
 
@@ -55,6 +64,16 @@ export function useRevokeIntegrationClientMutation() {
   return useMutation({
     mutationFn: (clientId: number) => revokeIntegrationClient(clientId),
     onSuccess: invalidate,
+  });
+}
+
+export function useRegenerateCalendarFeedMutation() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: () => regenerateCalendarFeed(),
+    onSuccess: (updated) => {
+      queryClient.setQueryData(queryKeys.settings.calendarFeed(), updated);
+    },
   });
 }
 

--- a/frontend/src/lib/api/today.ts
+++ b/frontend/src/lib/api/today.ts
@@ -808,6 +808,27 @@ export async function fetchMedicationHistory(
   return payload.history;
 }
 
+export interface CalendarFeedResponse {
+  token: string;
+  feed_url: string;
+}
+
+export async function fetchCalendarFeed(signal?: AbortSignal): Promise<CalendarFeedResponse> {
+  const response = await fetchWithAuth("/api/calendar/feed", {
+    headers: { Accept: "application/json" },
+    signal,
+  });
+  return parseJsonResponse<CalendarFeedResponse>(response, "Failed to load calendar feed");
+}
+
+export async function regenerateCalendarFeed(): Promise<CalendarFeedResponse> {
+  const response = await fetchWithAuth("/api/calendar/feed/regenerate", {
+    method: "POST",
+    headers: { Accept: "application/json" },
+  });
+  return parseJsonResponse<CalendarFeedResponse>(response, "Failed to regenerate calendar feed", false);
+}
+
 export async function listIntegrationClients(signal?: AbortSignal): Promise<IntegrationClient[]> {
   const response = await fetchWithAuth("/api/integrations/clients", {
     headers: { Accept: "application/json" },

--- a/frontend/src/lib/query/queryKeys.ts
+++ b/frontend/src/lib/query/queryKeys.ts
@@ -48,6 +48,7 @@ export const queryKeys = {
     all: ["settings"] as const,
     user: () => [...queryKeys.settings.all, "user"] as const,
     integrationClients: () => [...queryKeys.settings.all, "integration-clients"] as const,
+    calendarFeed: () => [...queryKeys.settings.all, "calendar-feed"] as const,
   },
   search: {
     all: ["search"] as const,

--- a/frontend/src/mocks/handlers/settings.ts
+++ b/frontend/src/mocks/handlers/settings.ts
@@ -2,6 +2,8 @@ import { http, HttpResponse } from "msw";
 import { getMockState, mutateSettings } from "../data/state";
 import type { UserSettingsPatch } from "@/lib/api/today";
 
+let mockCalendarFeedToken = "mock-calendar-feed-token";
+
 export const settingsHandlers = [
   http.get("/api/users/me/settings", () =>
     HttpResponse.json(getMockState().settings),
@@ -11,6 +13,21 @@ export const settingsHandlers = [
     const patch = (await request.json()) as UserSettingsPatch;
     mutateSettings((s) => ({ ...s, ...patch }));
     return HttpResponse.json(getMockState().settings);
+  }),
+
+  http.get("/api/calendar/feed", () =>
+    HttpResponse.json({
+      token: mockCalendarFeedToken,
+      feed_url: `http://localhost/api/calendar/feed/${mockCalendarFeedToken}.ics`,
+    }),
+  ),
+
+  http.post("/api/calendar/feed/regenerate", () => {
+    mockCalendarFeedToken = `mock-calendar-feed-token-${Date.now()}`;
+    return HttpResponse.json({
+      token: mockCalendarFeedToken,
+      feed_url: `http://localhost/api/calendar/feed/${mockCalendarFeedToken}.ics`,
+    });
   }),
 
   http.get("/api/integrations/clients", () =>


### PR DESCRIPTION
### Motivation
- Provide users with a per-user iCal feed URL so Daynest planned items can be subscribed to from external calendar apps. 
- Allow users to view / rotate their feed URL from the Settings UI and expose a stable unauthenticated .ics endpoint for calendar subscriptions. 
- Serialize planned items reliably into iCalendar format (with UID, start/end, summary, description) honoring user timezone.

### Description
- Added a nullable, unique `calendar_feed_token` column to `users` with an Alembic migration and model field `calendar_feed_token` on `User`.
- Implemented endpoints: `GET /api/calendar/feed` (generate/return feed URL), `POST /api/calendar/feed/regenerate` (rotate token), and unauthenticated `GET /api/calendar/feed/{token}.ics` (serve `.ics` for token), and generation helpers using `token_urlsafe`.
- Built `.ics` serialization of planned items using `icalendar` including UID, DTSTAMP, DTSTART/DTEND, SUMMARY and DESCRIPTION; includes past 7 / next 90 day window and default duration handling for all-day vs timed items.
- Frontend: added API functions (`fetchCalendarFeed`, `regenerateCalendarFeed`), query hooks (`useCalendarFeedQuery`, `useRegenerateCalendarFeedMutation`), MSW mock handlers, and a Settings-page panel to display/copy/regenerate the feed URL with confirmation and copy feedback.

### Testing
- Ran targeted backend integration tests: `cd backend && uv run pytest tests/test_today_route_integration.py -q` which passed; added tests exercise token generation, rotation, .ics serialization and unknown-token 404.
- Ran full backend test suite: `cd backend && uv run pytest -q` which completed successfully (`240 passed`).
- Lint/type checks: `cd backend && uv run ruff check app tests/test_today_route_integration.py` passed; frontend compile/typecheck `cd frontend && pnpm paraglide:compile && pnpm exec tsc -b` and `cd frontend && pnpm lint` completed successfully after installing missing frontend deps.
- Captured a Playwright screenshot of the updated Settings UI after installing browser dependencies to verify the UI change (screenshot artifact was removed before commit).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a24ae518104832e8879aa59ee663e88)