### PR TITLE
feat(android): show device calendar events in native Calendar day view

### DIFF
--- a/android/app/src/main/java/com/daynest/android/core/storage/preferences/UserPreferences.kt
+++ b/android/app/src/main/java/com/daynest/android/core/storage/preferences/UserPreferences.kt
@@ -7,6 +7,8 @@ data class UserPreferences(
     val biometricIdleTimeoutMinutes: Int = 5,
     val pushNotificationsEnabled: Boolean = true,
     val calendarSyncEnabled: Boolean = false,
+    val showDeviceCalendars: Boolean = false,
+    val enabledDeviceCalendarIds: Set<String> = emptySet(),
     val lastBackgroundEpochMillis: Long = 0L,
     val lastFcmEndpoint: String? = null,
     val lastUnifiedPushEndpoint: String? = null,

--- a/android/app/src/main/java/com/daynest/android/core/storage/preferences/UserPreferencesRepository.kt
+++ b/android/app/src/main/java/com/daynest/android/core/storage/preferences/UserPreferencesRepository.kt
@@ -7,6 +7,7 @@ import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.intPreferencesKey
 import androidx.datastore.preferences.core.longPreferencesKey
 import androidx.datastore.preferences.core.stringPreferencesKey
+import androidx.datastore.preferences.core.stringSetPreferencesKey
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 import javax.inject.Inject
@@ -27,6 +28,8 @@ class UserPreferencesRepository
                     biometricIdleTimeoutMinutes = prefs[BIOMETRIC_IDLE_TIMEOUT_MINUTES] ?: 5,
                     pushNotificationsEnabled = prefs[PUSH_NOTIFICATIONS_ENABLED] ?: true,
                     calendarSyncEnabled = prefs[CALENDAR_SYNC_ENABLED] ?: false,
+                    showDeviceCalendars = prefs[SHOW_DEVICE_CALENDARS] ?: false,
+                    enabledDeviceCalendarIds = prefs[ENABLED_DEVICE_CALENDAR_IDS] ?: emptySet(),
                     lastBackgroundEpochMillis = prefs[LAST_BACKGROUND_EPOCH_MILLIS] ?: 0L,
                     lastFcmEndpoint = prefs[LAST_FCM_ENDPOINT],
                     lastUnifiedPushEndpoint = prefs[LAST_UNIFIED_PUSH_ENDPOINT],
@@ -74,6 +77,18 @@ class UserPreferencesRepository
             }
         }
 
+        suspend fun updateShowDeviceCalendars(enabled: Boolean) {
+            dataStore.edit { prefs ->
+                prefs[SHOW_DEVICE_CALENDARS] = enabled
+            }
+        }
+
+        suspend fun updateEnabledDeviceCalendarIds(ids: Set<String>) {
+            dataStore.edit { prefs ->
+                prefs[ENABLED_DEVICE_CALENDAR_IDS] = ids
+            }
+        }
+
         suspend fun updateLastBackgroundEpochMillis(epochMillis: Long) {
             dataStore.edit { prefs ->
                 prefs[LAST_BACKGROUND_EPOCH_MILLIS] = epochMillis
@@ -110,6 +125,8 @@ class UserPreferencesRepository
             val BIOMETRIC_IDLE_TIMEOUT_MINUTES = intPreferencesKey("biometric_idle_timeout_minutes")
             val PUSH_NOTIFICATIONS_ENABLED = booleanPreferencesKey("push_notifications_enabled")
             val CALENDAR_SYNC_ENABLED = booleanPreferencesKey("calendar_sync_enabled")
+            val SHOW_DEVICE_CALENDARS = booleanPreferencesKey("show_device_calendars")
+            val ENABLED_DEVICE_CALENDAR_IDS = stringSetPreferencesKey("enabled_device_calendar_ids")
             val LAST_BACKGROUND_EPOCH_MILLIS = longPreferencesKey("last_background_epoch_millis")
             val LAST_FCM_ENDPOINT = stringPreferencesKey("last_fcm_endpoint")
             val LAST_UNIFIED_PUSH_ENDPOINT = stringPreferencesKey("last_unified_push_endpoint")

--- a/android/app/src/main/java/com/daynest/android/data/calendar/DeviceCalendarRepository.kt
+++ b/android/app/src/main/java/com/daynest/android/data/calendar/DeviceCalendarRepository.kt
@@ -92,11 +92,12 @@ private fun ContentResolver.queryDeviceEvents(
 ): List<DeviceCalendarEvent> {
     val zone = ZoneId.systemDefault()
     val startMillis = date.atStartOfDay(zone).toInstant().toEpochMilli()
-    val endMillis = date
-        .plusDays(1)
-        .atStartOfDay(zone)
-        .toInstant()
-        .toEpochMilli()
+    val endMillis =
+        date
+            .plusDays(1)
+            .atStartOfDay(zone)
+            .toInstant()
+            .toEpochMilli()
     val projection =
         arrayOf(
             CalendarContract.Instances._ID,

--- a/android/app/src/main/java/com/daynest/android/data/calendar/DeviceCalendarRepository.kt
+++ b/android/app/src/main/java/com/daynest/android/data/calendar/DeviceCalendarRepository.kt
@@ -32,7 +32,10 @@ class DeviceCalendarRepository
             enabledCalendarIds: Set<String>,
         ): Result<List<DeviceCalendarEvent>> =
             withContext(Dispatchers.IO) {
-                if (!hasReadPermission() || enabledCalendarIds.isEmpty()) {
+                if (!hasReadPermission()) {
+                    return@withContext Result.failure(SecurityException("READ_CALENDAR permission not granted"))
+                }
+                if (enabledCalendarIds.isEmpty()) {
                     return@withContext Result.success(emptyList())
                 }
                 runCatching { context.contentResolver.queryDeviceEvents(date, enabledCalendarIds) }

--- a/android/app/src/main/java/com/daynest/android/data/calendar/DeviceCalendarRepository.kt
+++ b/android/app/src/main/java/com/daynest/android/data/calendar/DeviceCalendarRepository.kt
@@ -1,0 +1,165 @@
+package com.daynest.android.data.calendar
+
+import android.Manifest
+import android.content.ContentResolver
+import android.content.Context
+import android.content.pm.PackageManager
+import android.provider.CalendarContract
+import androidx.core.content.ContextCompat
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import java.time.Instant
+import java.time.LocalDate
+import java.time.ZoneId
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class DeviceCalendarRepository
+    @Inject
+    constructor(
+        @ApplicationContext private val context: Context,
+    ) {
+        suspend fun listCalendars(): Result<List<DeviceCalendar>> =
+            withContext(Dispatchers.IO) {
+                if (!hasReadPermission()) return@withContext Result.success(emptyList())
+                runCatching { context.contentResolver.queryDeviceCalendars() }
+            }
+
+        suspend fun listEventsForDay(
+            date: LocalDate,
+            enabledCalendarIds: Set<String>,
+        ): Result<List<DeviceCalendarEvent>> =
+            withContext(Dispatchers.IO) {
+                if (!hasReadPermission() || enabledCalendarIds.isEmpty()) {
+                    return@withContext Result.success(emptyList())
+                }
+                runCatching { context.contentResolver.queryDeviceEvents(date, enabledCalendarIds) }
+            }
+
+        private fun hasReadPermission(): Boolean =
+            ContextCompat.checkSelfPermission(
+                context,
+                Manifest.permission.READ_CALENDAR,
+            ) == PackageManager.PERMISSION_GRANTED
+    }
+
+private fun ContentResolver.queryDeviceCalendars(): List<DeviceCalendar> {
+    val projection =
+        arrayOf(
+            CalendarContract.Calendars._ID,
+            CalendarContract.Calendars.CALENDAR_DISPLAY_NAME,
+            CalendarContract.Calendars.ACCOUNT_NAME,
+            CalendarContract.Calendars.CALENDAR_COLOR,
+            CalendarContract.Calendars.VISIBLE,
+        )
+    return query(
+        CalendarContract.Calendars.CONTENT_URI,
+        projection,
+        null,
+        null,
+        "${CalendarContract.Calendars.CALENDAR_DISPLAY_NAME} ASC",
+    )?.use { cursor ->
+        buildList {
+            val idIndex = cursor.getColumnIndexOrThrow(CalendarContract.Calendars._ID)
+            val nameIndex = cursor.getColumnIndexOrThrow(CalendarContract.Calendars.CALENDAR_DISPLAY_NAME)
+            val accountIndex = cursor.getColumnIndexOrThrow(CalendarContract.Calendars.ACCOUNT_NAME)
+            val colorIndex = cursor.getColumnIndexOrThrow(CalendarContract.Calendars.CALENDAR_COLOR)
+            val visibleIndex = cursor.getColumnIndexOrThrow(CalendarContract.Calendars.VISIBLE)
+            while (cursor.moveToNext()) {
+                add(
+                    DeviceCalendar(
+                        id = cursor.getLong(idIndex).toString(),
+                        name = cursor.getString(nameIndex).orEmpty(),
+                        accountName = cursor.getString(accountIndex),
+                        color = cursor.getInt(colorIndex),
+                        visible = cursor.getInt(visibleIndex) == 1,
+                    ),
+                )
+            }
+        }
+    } ?: emptyList()
+}
+
+private fun ContentResolver.queryDeviceEvents(
+    date: LocalDate,
+    enabledCalendarIds: Set<String>,
+): List<DeviceCalendarEvent> {
+    val zone = ZoneId.systemDefault()
+    val startMillis = date.atStartOfDay(zone).toInstant().toEpochMilli()
+    val endMillis = date.plusDays(1).atStartOfDay(zone).toInstant().toEpochMilli()
+    val projection =
+        arrayOf(
+            CalendarContract.Instances.EVENT_ID,
+            CalendarContract.Instances.CALENDAR_ID,
+            CalendarContract.Instances.CALENDAR_DISPLAY_NAME,
+            CalendarContract.Instances.TITLE,
+            CalendarContract.Instances.DESCRIPTION,
+            CalendarContract.Instances.BEGIN,
+            CalendarContract.Instances.END,
+            CalendarContract.Instances.ALL_DAY,
+            CalendarContract.Instances.DISPLAY_COLOR,
+        )
+    val uri =
+        CalendarContract.Instances.CONTENT_URI.buildUpon()
+        .appendPath(startMillis.toString())
+        .appendPath((endMillis - 1).toString())
+        .build()
+    val calendarPlaceholders = enabledCalendarIds.joinToString(",") { "?" }
+    val selection = "${CalendarContract.Instances.CALENDAR_ID} IN ($calendarPlaceholders)"
+    return query(
+        uri,
+        projection,
+        selection,
+        enabledCalendarIds.toTypedArray(),
+        "${CalendarContract.Instances.BEGIN} ASC",
+    )?.use { cursor ->
+        buildList {
+            val eventIdIndex = cursor.getColumnIndexOrThrow(CalendarContract.Instances.EVENT_ID)
+            val calendarIdIndex = cursor.getColumnIndexOrThrow(CalendarContract.Instances.CALENDAR_ID)
+            val calendarNameIndex = cursor.getColumnIndexOrThrow(CalendarContract.Instances.CALENDAR_DISPLAY_NAME)
+            val titleIndex = cursor.getColumnIndexOrThrow(CalendarContract.Instances.TITLE)
+            val descriptionIndex = cursor.getColumnIndexOrThrow(CalendarContract.Instances.DESCRIPTION)
+            val beginIndex = cursor.getColumnIndexOrThrow(CalendarContract.Instances.BEGIN)
+            val endIndex = cursor.getColumnIndexOrThrow(CalendarContract.Instances.END)
+            val allDayIndex = cursor.getColumnIndexOrThrow(CalendarContract.Instances.ALL_DAY)
+            val colorIndex = cursor.getColumnIndexOrThrow(CalendarContract.Instances.DISPLAY_COLOR)
+            while (cursor.moveToNext()) {
+                add(
+                    DeviceCalendarEvent(
+                        id = cursor.getLong(eventIdIndex).toString(),
+                        calendarId = cursor.getLong(calendarIdIndex).toString(),
+                        calendarName = cursor.getString(calendarNameIndex).orEmpty(),
+                        title = cursor.getString(titleIndex).orEmpty().ifBlank { "(No title)" },
+                        description = cursor.getString(descriptionIndex),
+                        startsAt = Instant.ofEpochMilli(cursor.getLong(beginIndex)),
+                        endsAt = Instant.ofEpochMilli(cursor.getLong(endIndex)),
+                        allDay = cursor.getInt(allDayIndex) == 1,
+                        color = cursor.getInt(colorIndex),
+                    ),
+                )
+            }
+        }
+    } ?: emptyList()
+}
+
+data class DeviceCalendar(
+    val id: String,
+    val name: String,
+    val accountName: String?,
+    val color: Int,
+    val visible: Boolean,
+)
+
+data class DeviceCalendarEvent(
+    val id: String,
+    val calendarId: String,
+    val calendarName: String,
+    val title: String,
+    val description: String?,
+    val startsAt: Instant,
+    val endsAt: Instant,
+    val allDay: Boolean,
+    val color: Int,
+)

--- a/android/app/src/main/java/com/daynest/android/data/calendar/DeviceCalendarRepository.kt
+++ b/android/app/src/main/java/com/daynest/android/data/calendar/DeviceCalendarRepository.kt
@@ -95,7 +95,7 @@ private fun ContentResolver.queryDeviceEvents(
         .toEpochMilli()
     val projection =
         arrayOf(
-            CalendarContract.Instances.EVENT_ID,
+            CalendarContract.Instances._ID,
             CalendarContract.Instances.CALENDAR_ID,
             CalendarContract.Instances.CALENDAR_DISPLAY_NAME,
             CalendarContract.Instances.TITLE,
@@ -121,7 +121,7 @@ private fun ContentResolver.queryDeviceEvents(
         "${CalendarContract.Instances.BEGIN} ASC",
     )?.use { cursor ->
         buildList {
-            val eventIdIndex = cursor.getColumnIndexOrThrow(CalendarContract.Instances.EVENT_ID)
+            val eventIdIndex = cursor.getColumnIndexOrThrow(CalendarContract.Instances._ID)
             val calendarIdIndex = cursor.getColumnIndexOrThrow(CalendarContract.Instances.CALENDAR_ID)
             val calendarNameIndex = cursor.getColumnIndexOrThrow(CalendarContract.Instances.CALENDAR_DISPLAY_NAME)
             val titleIndex = cursor.getColumnIndexOrThrow(CalendarContract.Instances.TITLE)

--- a/android/app/src/main/java/com/daynest/android/data/calendar/DeviceCalendarRepository.kt
+++ b/android/app/src/main/java/com/daynest/android/data/calendar/DeviceCalendarRepository.kt
@@ -4,6 +4,7 @@ import android.Manifest
 import android.content.ContentResolver
 import android.content.Context
 import android.content.pm.PackageManager
+import android.database.Cursor
 import android.provider.CalendarContract
 import androidx.core.content.ContextCompat
 import dagger.hilt.android.qualifiers.ApplicationContext
@@ -122,35 +123,36 @@ private fun ContentResolver.queryDeviceEvents(
         selection,
         enabledCalendarIds.toTypedArray(),
         "${CalendarContract.Instances.BEGIN} ASC",
-    )?.use { cursor ->
-        buildList {
-            val eventIdIndex = cursor.getColumnIndexOrThrow(CalendarContract.Instances._ID)
-            val calendarIdIndex = cursor.getColumnIndexOrThrow(CalendarContract.Instances.CALENDAR_ID)
-            val calendarNameIndex = cursor.getColumnIndexOrThrow(CalendarContract.Instances.CALENDAR_DISPLAY_NAME)
-            val titleIndex = cursor.getColumnIndexOrThrow(CalendarContract.Instances.TITLE)
-            val descriptionIndex = cursor.getColumnIndexOrThrow(CalendarContract.Instances.DESCRIPTION)
-            val beginIndex = cursor.getColumnIndexOrThrow(CalendarContract.Instances.BEGIN)
-            val endIndex = cursor.getColumnIndexOrThrow(CalendarContract.Instances.END)
-            val allDayIndex = cursor.getColumnIndexOrThrow(CalendarContract.Instances.ALL_DAY)
-            val colorIndex = cursor.getColumnIndexOrThrow(CalendarContract.Instances.DISPLAY_COLOR)
-            while (cursor.moveToNext()) {
-                add(
-                    DeviceCalendarEvent(
-                        id = cursor.getLong(eventIdIndex).toString(),
-                        calendarId = cursor.getLong(calendarIdIndex).toString(),
-                        calendarName = cursor.getString(calendarNameIndex).orEmpty(),
-                        title = cursor.getString(titleIndex).orEmpty().ifBlank { "(No title)" },
-                        description = cursor.getString(descriptionIndex),
-                        startsAt = Instant.ofEpochMilli(cursor.getLong(beginIndex)),
-                        endsAt = Instant.ofEpochMilli(cursor.getLong(endIndex)),
-                        allDay = cursor.getInt(allDayIndex) == 1,
-                        color = cursor.getInt(colorIndex),
-                    ),
-                )
-            }
-        }
-    } ?: emptyList()
+    )?.use { cursor -> cursor.toDeviceCalendarEvents() } ?: emptyList()
 }
+
+private fun Cursor.toDeviceCalendarEvents(): List<DeviceCalendarEvent> =
+    buildList {
+        val eventIdIndex = getColumnIndexOrThrow(CalendarContract.Instances._ID)
+        val calendarIdIndex = getColumnIndexOrThrow(CalendarContract.Instances.CALENDAR_ID)
+        val calendarNameIndex = getColumnIndexOrThrow(CalendarContract.Instances.CALENDAR_DISPLAY_NAME)
+        val titleIndex = getColumnIndexOrThrow(CalendarContract.Instances.TITLE)
+        val descriptionIndex = getColumnIndexOrThrow(CalendarContract.Instances.DESCRIPTION)
+        val beginIndex = getColumnIndexOrThrow(CalendarContract.Instances.BEGIN)
+        val endIndex = getColumnIndexOrThrow(CalendarContract.Instances.END)
+        val allDayIndex = getColumnIndexOrThrow(CalendarContract.Instances.ALL_DAY)
+        val colorIndex = getColumnIndexOrThrow(CalendarContract.Instances.DISPLAY_COLOR)
+        while (moveToNext()) {
+            add(
+                DeviceCalendarEvent(
+                    id = getLong(eventIdIndex).toString(),
+                    calendarId = getLong(calendarIdIndex).toString(),
+                    calendarName = getString(calendarNameIndex).orEmpty(),
+                    title = getString(titleIndex).orEmpty().ifBlank { "(No title)" },
+                    description = getString(descriptionIndex),
+                    startsAt = Instant.ofEpochMilli(getLong(beginIndex)),
+                    endsAt = Instant.ofEpochMilli(getLong(endIndex)),
+                    allDay = getInt(allDayIndex) == 1,
+                    color = getInt(colorIndex),
+                ),
+            )
+        }
+    }
 
 data class DeviceCalendar(
     val id: String,

--- a/android/app/src/main/java/com/daynest/android/data/calendar/DeviceCalendarRepository.kt
+++ b/android/app/src/main/java/com/daynest/android/data/calendar/DeviceCalendarRepository.kt
@@ -88,7 +88,11 @@ private fun ContentResolver.queryDeviceEvents(
 ): List<DeviceCalendarEvent> {
     val zone = ZoneId.systemDefault()
     val startMillis = date.atStartOfDay(zone).toInstant().toEpochMilli()
-    val endMillis = date.plusDays(1).atStartOfDay(zone).toInstant().toEpochMilli()
+    val endMillis = date
+        .plusDays(1)
+        .atStartOfDay(zone)
+        .toInstant()
+        .toEpochMilli()
     val projection =
         arrayOf(
             CalendarContract.Instances.EVENT_ID,
@@ -102,10 +106,11 @@ private fun ContentResolver.queryDeviceEvents(
             CalendarContract.Instances.DISPLAY_COLOR,
         )
     val uri =
-        CalendarContract.Instances.CONTENT_URI.buildUpon()
-        .appendPath(startMillis.toString())
-        .appendPath((endMillis - 1).toString())
-        .build()
+        CalendarContract.Instances.CONTENT_URI
+            .buildUpon()
+            .appendPath(startMillis.toString())
+            .appendPath((endMillis - 1).toString())
+            .build()
     val calendarPlaceholders = enabledCalendarIds.joinToString(",") { "?" }
     val selection = "${CalendarContract.Instances.CALENDAR_ID} IN ($calendarPlaceholders)"
     return query(

--- a/android/app/src/main/java/com/daynest/android/feature/calendar/CalendarDeviceEventsHandler.kt
+++ b/android/app/src/main/java/com/daynest/android/feature/calendar/CalendarDeviceEventsHandler.kt
@@ -19,65 +19,49 @@ internal class CalendarDeviceEventsHandler(
     fun load(date: LocalDate) {
         scope.launch {
             if (!preferences().showDeviceCalendars) {
-                uiState.update { current ->
-                    if (current is CalendarUiState.Content) {
-                        current.copy(
-                            deviceCalendarEvents = emptyList(),
-                            deviceCalendarStatus = DeviceCalendarStatus.Idle,
-                        )
-                    } else {
-                        current
-                    }
+                updateContent {
+                    it.copy(
+                        deviceCalendarEvents = emptyList(),
+                        deviceCalendarStatus = DeviceCalendarStatus.Idle,
+                    )
                 }
                 return@launch
             }
             if (preferences().enabledDeviceCalendarIds.isEmpty()) {
-                uiState.update { current ->
-                    if (current is CalendarUiState.Content) {
-                        current.copy(
-                            deviceCalendarEvents = emptyList(),
-                            deviceCalendarStatus = DeviceCalendarStatus.NoEnabledCalendars,
-                        )
-                    } else {
-                        current
-                    }
+                updateContent {
+                    it.copy(
+                        deviceCalendarEvents = emptyList(),
+                        deviceCalendarStatus = DeviceCalendarStatus.NoEnabledCalendars,
+                    )
                 }
                 return@launch
             }
-            uiState.update { current ->
-                if (current is CalendarUiState.Content) {
-                    current.copy(deviceCalendarStatus = DeviceCalendarStatus.Loading)
-                } else {
-                    current
-                }
-            }
+            updateContent { it.copy(deviceCalendarStatus = DeviceCalendarStatus.Loading) }
             deviceCalendarRepository
                 .listEventsForDay(date, preferences().enabledDeviceCalendarIds)
                 .onSuccess { events ->
-                    uiState.update { current ->
-                        if (current is CalendarUiState.Content && current.selectedDate == date.toString()) {
-                            current.copy(
-                                deviceCalendarEvents = events,
-                                deviceCalendarStatus =
-                                    if (events.isEmpty()) DeviceCalendarStatus.Empty else DeviceCalendarStatus.Ready,
-                            )
-                        } else {
-                            current
-                        }
+                    updateContent { current ->
+                        if (current.selectedDate != date.toString()) return@updateContent current
+                        current.copy(
+                            deviceCalendarEvents = events,
+                            deviceCalendarStatus =
+                                if (events.isEmpty()) DeviceCalendarStatus.Empty else DeviceCalendarStatus.Ready,
+                        )
                     }
                 }.onFailure {
-                    uiState.update { current ->
-                        if (current is CalendarUiState.Content && current.selectedDate == date.toString()) {
-                            current.copy(
-                                deviceCalendarEvents = emptyList(),
-                                deviceCalendarStatus = DeviceCalendarStatus.PermissionRequired,
-                            )
-                        } else {
-                            current
-                        }
+                    updateContent { current ->
+                        if (current.selectedDate != date.toString()) return@updateContent current
+                        current.copy(
+                            deviceCalendarEvents = emptyList(),
+                            deviceCalendarStatus = DeviceCalendarStatus.PermissionRequired,
+                        )
                     }
                 }
         }
+    }
+
+    private fun updateContent(transform: (CalendarUiState.Content) -> CalendarUiState.Content) {
+        uiState.update { current -> if (current is CalendarUiState.Content) transform(current) else current }
     }
 
     fun handlePermissionResult(granted: Boolean) {

--- a/android/app/src/main/java/com/daynest/android/feature/calendar/CalendarDeviceEventsHandler.kt
+++ b/android/app/src/main/java/com/daynest/android/feature/calendar/CalendarDeviceEventsHandler.kt
@@ -1,7 +1,6 @@
 package com.daynest.android.feature.calendar
 
 import com.daynest.android.core.storage.preferences.UserPreferences
-import com.daynest.android.core.storage.preferences.UserPreferencesRepository
 import com.daynest.android.data.calendar.DeviceCalendarRepository
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -12,7 +11,6 @@ import java.time.LocalDate
 internal class CalendarDeviceEventsHandler(
     private val scope: CoroutineScope,
     private val deviceCalendarRepository: DeviceCalendarRepository,
-    private val userPreferencesRepository: UserPreferencesRepository,
     private val uiState: MutableStateFlow<CalendarUiState>,
     private val preferences: () -> UserPreferences,
 ) {
@@ -67,11 +65,9 @@ internal class CalendarDeviceEventsHandler(
     fun handlePermissionResult(granted: Boolean) {
         scope.launch {
             if (!granted) {
-                userPreferencesRepository.updateShowDeviceCalendars(false)
                 uiState.update { current ->
                     if (current is CalendarUiState.Content) {
                         current.copy(
-                            showDeviceCalendars = false,
                             deviceCalendarEvents = emptyList(),
                             deviceCalendarStatus = DeviceCalendarStatus.PermissionRequired,
                         )

--- a/android/app/src/main/java/com/daynest/android/feature/calendar/CalendarDeviceEventsHandler.kt
+++ b/android/app/src/main/java/com/daynest/android/feature/calendar/CalendarDeviceEventsHandler.kt
@@ -1,0 +1,104 @@
+package com.daynest.android.feature.calendar
+
+import com.daynest.android.core.storage.preferences.UserPreferences
+import com.daynest.android.core.storage.preferences.UserPreferencesRepository
+import com.daynest.android.data.calendar.DeviceCalendarRepository
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import java.time.LocalDate
+
+internal class CalendarDeviceEventsHandler(
+    private val scope: CoroutineScope,
+    private val deviceCalendarRepository: DeviceCalendarRepository,
+    private val userPreferencesRepository: UserPreferencesRepository,
+    private val uiState: MutableStateFlow<CalendarUiState>,
+    private val preferences: () -> UserPreferences,
+) {
+    fun load(date: LocalDate) {
+        scope.launch {
+            if (!preferences().showDeviceCalendars) {
+                uiState.update { current ->
+                    if (current is CalendarUiState.Content) {
+                        current.copy(
+                            deviceCalendarEvents = emptyList(),
+                            deviceCalendarStatus = DeviceCalendarStatus.Idle,
+                        )
+                    } else {
+                        current
+                    }
+                }
+                return@launch
+            }
+            if (preferences().enabledDeviceCalendarIds.isEmpty()) {
+                uiState.update { current ->
+                    if (current is CalendarUiState.Content) {
+                        current.copy(
+                            deviceCalendarEvents = emptyList(),
+                            deviceCalendarStatus = DeviceCalendarStatus.NoEnabledCalendars,
+                        )
+                    } else {
+                        current
+                    }
+                }
+                return@launch
+            }
+            uiState.update { current ->
+                if (current is CalendarUiState.Content) {
+                    current.copy(deviceCalendarStatus = DeviceCalendarStatus.Loading)
+                } else {
+                    current
+                }
+            }
+            deviceCalendarRepository
+                .listEventsForDay(date, preferences().enabledDeviceCalendarIds)
+                .onSuccess { events ->
+                    uiState.update { current ->
+                        if (current is CalendarUiState.Content && current.selectedDate == date.toString()) {
+                            current.copy(
+                                deviceCalendarEvents = events,
+                                deviceCalendarStatus =
+                                    if (events.isEmpty()) DeviceCalendarStatus.Empty else DeviceCalendarStatus.Ready,
+                            )
+                        } else {
+                            current
+                        }
+                    }
+                }.onFailure {
+                    uiState.update { current ->
+                        if (current is CalendarUiState.Content && current.selectedDate == date.toString()) {
+                            current.copy(
+                                deviceCalendarEvents = emptyList(),
+                                deviceCalendarStatus = DeviceCalendarStatus.PermissionRequired,
+                            )
+                        } else {
+                            current
+                        }
+                    }
+                }
+        }
+    }
+
+    fun handlePermissionResult(granted: Boolean) {
+        scope.launch {
+            if (!granted) {
+                userPreferencesRepository.updateShowDeviceCalendars(false)
+                uiState.update { current ->
+                    if (current is CalendarUiState.Content) {
+                        current.copy(
+                            showDeviceCalendars = false,
+                            deviceCalendarEvents = emptyList(),
+                            deviceCalendarStatus = DeviceCalendarStatus.PermissionRequired,
+                        )
+                    } else {
+                        current
+                    }
+                }
+                return@launch
+            }
+            val selectedDate = (uiState.value as? CalendarUiState.Content)?.selectedDate ?: return@launch
+            load(LocalDate.parse(selectedDate))
+        }
+    }
+}

--- a/android/app/src/main/java/com/daynest/android/feature/calendar/CalendarDeviceSection.kt
+++ b/android/app/src/main/java/com/daynest/android/feature/calendar/CalendarDeviceSection.kt
@@ -74,9 +74,10 @@ internal fun DeviceCalendarSectionHeader(
 internal fun DeviceCalendarEventCard(item: DeviceCalendarEvent) {
     val color = remember(item.color) { Color(item.color or 0xFF000000.toInt()) }
     val allDayText = stringResource(id = R.string.calendar_device_event_all_day)
-    val timeText = remember(item.startsAt, item.endsAt, item.allDay, allDayText) {
-        item.deviceEventTimeText(allDayText)
-    }
+    val timeText =
+        remember(item.startsAt, item.endsAt, item.allDay, allDayText) {
+            item.deviceEventTimeText(allDayText)
+        }
     Card(modifier = Modifier.fillMaxWidth()) {
         Row(
             modifier =

--- a/android/app/src/main/java/com/daynest/android/feature/calendar/CalendarDeviceSection.kt
+++ b/android/app/src/main/java/com/daynest/android/feature/calendar/CalendarDeviceSection.kt
@@ -1,0 +1,131 @@
+@file:Suppress("ktlint:standard:function-naming", "FunctionNaming")
+
+package com.daynest.android.feature.calendar
+
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import android.provider.Settings
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.Card
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import com.daynest.android.R
+import com.daynest.android.data.calendar.DeviceCalendarEvent
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
+
+@Composable
+internal fun DeviceCalendarSectionHeader(
+    status: DeviceCalendarStatus,
+    context: Context,
+) {
+    Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+        Text(
+            text = stringResource(id = R.string.calendar_device_events_header),
+            style = MaterialTheme.typography.titleSmall,
+        )
+        when (status) {
+            DeviceCalendarStatus.Loading -> CircularProgressIndicator(modifier = Modifier.size(20.dp))
+            DeviceCalendarStatus.Empty ->
+                Text(
+                    text = stringResource(id = R.string.calendar_device_events_empty),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.outline,
+                )
+            DeviceCalendarStatus.NoEnabledCalendars ->
+                Text(
+                    text = stringResource(id = R.string.calendar_device_events_no_calendars),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.outline,
+                )
+            DeviceCalendarStatus.PermissionRequired -> {
+                Text(
+                    text = stringResource(id = R.string.calendar_device_events_permission_required),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.outline,
+                )
+                TextButton(onClick = { context.openAppSettings() }) {
+                    Text(text = stringResource(id = R.string.action_open_settings))
+                }
+            }
+            else -> Unit
+        }
+    }
+}
+
+@Composable
+internal fun DeviceCalendarEventCard(item: DeviceCalendarEvent) {
+    val color = remember(item.color) { Color(item.color or 0xFF000000.toInt()) }
+    val allDayText = stringResource(id = R.string.calendar_device_event_all_day)
+    val timeText = remember(item.startsAt, item.endsAt, item.allDay, allDayText) {
+        item.deviceEventTimeText(allDayText)
+    }
+    Card(modifier = Modifier.fillMaxWidth()) {
+        Row(
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .padding(12.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Spacer(
+                modifier =
+                    Modifier
+                        .size(width = 4.dp, height = 48.dp)
+                        .background(color),
+            )
+            Column(
+                modifier =
+                    Modifier
+                        .weight(1f)
+                        .padding(start = 12.dp),
+            ) {
+                Text(text = item.title, style = MaterialTheme.typography.bodyMedium)
+                Text(
+                    text = stringResource(id = R.string.calendar_device_event_meta, item.calendarName, timeText),
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.primary,
+                )
+                if (!item.description.isNullOrBlank()) {
+                    Text(
+                        text = item.description,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.outline,
+                    )
+                }
+            }
+        }
+    }
+}
+
+private fun DeviceCalendarEvent.deviceEventTimeText(allDayText: String): String {
+    if (allDay) return allDayText
+    val formatter = DateTimeFormatter.ofPattern("HH:mm").withZone(ZoneId.systemDefault())
+    return "${formatter.format(startsAt)}–${formatter.format(endsAt)}"
+}
+
+private fun Context.openAppSettings() {
+    startActivity(
+        Intent(
+            Settings.ACTION_APPLICATION_DETAILS_SETTINGS,
+            Uri.fromParts("package", packageName, null),
+        ),
+    )
+}

--- a/android/app/src/main/java/com/daynest/android/feature/calendar/CalendarDeviceSection.kt
+++ b/android/app/src/main/java/com/daynest/android/feature/calendar/CalendarDeviceSection.kt
@@ -30,6 +30,7 @@ import com.daynest.android.R
 import com.daynest.android.data.calendar.DeviceCalendarEvent
 import java.time.ZoneId
 import java.time.format.DateTimeFormatter
+import java.time.format.FormatStyle
 
 @Composable
 internal fun DeviceCalendarSectionHeader(
@@ -118,7 +119,7 @@ internal fun DeviceCalendarEventCard(item: DeviceCalendarEvent) {
 
 private fun DeviceCalendarEvent.deviceEventTimeText(allDayText: String): String {
     if (allDay) return allDayText
-    val formatter = DateTimeFormatter.ofPattern("HH:mm").withZone(ZoneId.systemDefault())
+    val formatter = DateTimeFormatter.ofLocalizedTime(FormatStyle.SHORT).withZone(ZoneId.systemDefault())
     return "${formatter.format(startsAt)}–${formatter.format(endsAt)}"
 }
 

--- a/android/app/src/main/java/com/daynest/android/feature/calendar/CalendarRoute.kt
+++ b/android/app/src/main/java/com/daynest/android/feature/calendar/CalendarRoute.kt
@@ -336,8 +336,8 @@ private fun CalendarContent(
                 }
                 itemsIndexed(
                     state.deviceCalendarEvents,
-                    key = { index, item ->
-                        "device_${item.calendarId}_${item.id}_${item.startsAt.toEpochMilli()}_$index"
+                    key = { _, item ->
+                        "device_${item.id}"
                     },
                 ) { _, item ->
                     DeviceCalendarEventCard(item = item)

--- a/android/app/src/main/java/com/daynest/android/feature/calendar/CalendarRoute.kt
+++ b/android/app/src/main/java/com/daynest/android/feature/calendar/CalendarRoute.kt
@@ -3,14 +3,9 @@
 package com.daynest.android.feature.calendar
 
 import android.Manifest
-import android.content.Context
-import android.content.Intent
 import android.content.pm.PackageManager
-import android.net.Uri
-import android.provider.Settings
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
-import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -26,7 +21,6 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.material3.Button
-import androidx.compose.material3.Card
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
@@ -39,7 +33,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
@@ -52,7 +45,6 @@ import com.daynest.android.R
 import com.daynest.android.app.navigation.DaynestDestination
 import com.daynest.android.app.navigation.DaynestNavigationScaffold
 import com.daynest.android.data.calendar.CalendarDaySummaryDto
-import com.daynest.android.data.calendar.DeviceCalendarEvent
 import com.daynest.android.data.calendar.UnifiedDayItemDto
 import com.daynest.android.data.today.DeleteScope
 import com.daynest.android.data.today.EditScope
@@ -64,8 +56,6 @@ import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import java.time.LocalDate
-import java.time.ZoneId
-import java.time.format.DateTimeFormatter
 import java.time.format.TextStyle
 import java.time.temporal.WeekFields
 import java.util.Locale
@@ -380,105 +370,6 @@ private fun CalendarContent(
             onDismiss = { editingItem = null },
         )
     }
-}
-
-@Composable
-private fun DeviceCalendarSectionHeader(
-    status: DeviceCalendarStatus,
-    context: Context,
-) {
-    Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
-        Text(
-            text = stringResource(id = R.string.calendar_device_events_header),
-            style = MaterialTheme.typography.titleSmall,
-        )
-        when (status) {
-            DeviceCalendarStatus.Loading -> CircularProgressIndicator(modifier = Modifier.size(20.dp))
-            DeviceCalendarStatus.Empty ->
-                Text(
-                    text = stringResource(id = R.string.calendar_device_events_empty),
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.outline,
-                )
-            DeviceCalendarStatus.NoEnabledCalendars ->
-                Text(
-                    text = stringResource(id = R.string.calendar_device_events_no_calendars),
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.outline,
-                )
-            DeviceCalendarStatus.PermissionRequired -> {
-                Text(
-                    text = stringResource(id = R.string.calendar_device_events_permission_required),
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.outline,
-                )
-                TextButton(onClick = { context.openAppSettings() }) {
-                    Text(text = stringResource(id = R.string.action_open_settings))
-                }
-            }
-            else -> Unit
-        }
-    }
-}
-
-@Composable
-private fun DeviceCalendarEventCard(item: DeviceCalendarEvent) {
-    val color = remember(item.color) { Color(item.color or 0xFF000000.toInt()) }
-    val allDayText = stringResource(id = R.string.calendar_device_event_all_day)
-    val timeText = remember(item.startsAt, item.endsAt, item.allDay, allDayText) {
-        item.deviceEventTimeText(allDayText)
-    }
-    Card(modifier = Modifier.fillMaxWidth()) {
-        Row(
-            modifier =
-                Modifier
-                    .fillMaxWidth()
-                    .padding(12.dp),
-            verticalAlignment = Alignment.CenterVertically,
-        ) {
-            Spacer(
-                modifier =
-                    Modifier
-                        .size(width = 4.dp, height = 48.dp)
-                        .background(color),
-            )
-            Column(
-                modifier =
-                    Modifier
-                        .weight(1f)
-                        .padding(start = 12.dp),
-            ) {
-                Text(text = item.title, style = MaterialTheme.typography.bodyMedium)
-                Text(
-                    text = stringResource(id = R.string.calendar_device_event_meta, item.calendarName, timeText),
-                    style = MaterialTheme.typography.labelSmall,
-                    color = MaterialTheme.colorScheme.primary,
-                )
-                if (!item.description.isNullOrBlank()) {
-                    Text(
-                        text = item.description,
-                        style = MaterialTheme.typography.bodySmall,
-                        color = MaterialTheme.colorScheme.outline,
-                    )
-                }
-            }
-        }
-    }
-}
-
-private fun DeviceCalendarEvent.deviceEventTimeText(allDayText: String): String {
-    if (allDay) return allDayText
-    val formatter = DateTimeFormatter.ofPattern("HH:mm").withZone(ZoneId.systemDefault())
-    return "${formatter.format(startsAt)}–${formatter.format(endsAt)}"
-}
-
-private fun Context.openAppSettings() {
-    startActivity(
-        Intent(
-            Settings.ACTION_APPLICATION_DETAILS_SETTINGS,
-            Uri.fromParts("package", packageName, null),
-        ),
-    )
 }
 
 @Composable

--- a/android/app/src/main/java/com/daynest/android/feature/calendar/CalendarRoute.kt
+++ b/android/app/src/main/java/com/daynest/android/feature/calendar/CalendarRoute.kt
@@ -2,8 +2,15 @@
 
 package com.daynest.android.feature.calendar
 
+import android.Manifest
+import android.content.Context
+import android.content.Intent
+import android.content.pm.PackageManager
+import android.net.Uri
+import android.provider.Settings
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -19,28 +26,33 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.material3.Button
+import androidx.compose.material3.Card
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
+import androidx.core.content.ContextCompat
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.daynest.android.R
 import com.daynest.android.app.navigation.DaynestDestination
 import com.daynest.android.app.navigation.DaynestNavigationScaffold
 import com.daynest.android.data.calendar.CalendarDaySummaryDto
+import com.daynest.android.data.calendar.DeviceCalendarEvent
 import com.daynest.android.data.calendar.UnifiedDayItemDto
 import com.daynest.android.data.today.DeleteScope
 import com.daynest.android.data.today.EditScope
@@ -52,6 +64,8 @@ import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import java.time.LocalDate
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
 import java.time.format.TextStyle
 import java.time.temporal.WeekFields
 import java.util.Locale
@@ -177,6 +191,23 @@ private fun CalendarContent(
             }
             onEvent(CalendarUiEvent.ImportBackup(items))
         }
+
+    val calendarPermissionLauncher =
+        rememberLauncherForActivityResult(ActivityResultContracts.RequestPermission()) { granted ->
+            onEvent(CalendarUiEvent.CalendarPermissionResult(granted))
+        }
+    LaunchedEffect(state.selectedDate, state.showDeviceCalendars) {
+        if (
+            state.selectedDate != null &&
+            state.showDeviceCalendars &&
+            ContextCompat.checkSelfPermission(
+                context,
+                Manifest.permission.READ_CALENDAR,
+            ) != PackageManager.PERMISSION_GRANTED
+        ) {
+            calendarPermissionLauncher.launch(Manifest.permission.READ_CALENDAR)
+        }
+    }
 
     val backupMessageText = state.backupMessage?.asText()
     LazyColumn(
@@ -308,6 +339,20 @@ private fun CalendarContent(
                     )
                 }
             }
+
+            if (state.showDeviceCalendars) {
+                item {
+                    DeviceCalendarSectionHeader(state.deviceCalendarStatus, context)
+                }
+                itemsIndexed(
+                    state.deviceCalendarEvents,
+                    key = { index, item ->
+                        "device_${item.calendarId}_${item.id}_${item.startsAt.toEpochMilli()}_$index"
+                    },
+                ) { _, item ->
+                    DeviceCalendarEventCard(item = item)
+                }
+            }
         }
     }
 
@@ -327,12 +372,113 @@ private fun CalendarContent(
         EditPlannedItemDialog(
             item = currentEditingItem,
             onConfirm = { input, scope ->
-                onEvent(CalendarUiEvent.UpdatePlannedItem(currentEditingItem.itemId, state.selectedDate, input, scope))
+                onEvent(
+                    CalendarUiEvent.UpdatePlannedItem(currentEditingItem.itemId, state.selectedDate, input, scope),
+                )
                 editingItem = null
             },
             onDismiss = { editingItem = null },
         )
     }
+}
+
+@Composable
+private fun DeviceCalendarSectionHeader(
+    status: DeviceCalendarStatus,
+    context: Context,
+) {
+    Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+        Text(
+            text = stringResource(id = R.string.calendar_device_events_header),
+            style = MaterialTheme.typography.titleSmall,
+        )
+        when (status) {
+            DeviceCalendarStatus.Loading -> CircularProgressIndicator(modifier = Modifier.size(20.dp))
+            DeviceCalendarStatus.Empty ->
+                Text(
+                    text = stringResource(id = R.string.calendar_device_events_empty),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.outline,
+                )
+            DeviceCalendarStatus.NoEnabledCalendars ->
+                Text(
+                    text = stringResource(id = R.string.calendar_device_events_no_calendars),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.outline,
+                )
+            DeviceCalendarStatus.PermissionRequired -> {
+                Text(
+                    text = stringResource(id = R.string.calendar_device_events_permission_required),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.outline,
+                )
+                TextButton(onClick = { context.openAppSettings() }) {
+                    Text(text = stringResource(id = R.string.action_open_settings))
+                }
+            }
+            else -> Unit
+        }
+    }
+}
+
+@Composable
+private fun DeviceCalendarEventCard(item: DeviceCalendarEvent) {
+    val color = remember(item.color) { Color(item.color or 0xFF000000.toInt()) }
+    val allDayText = stringResource(id = R.string.calendar_device_event_all_day)
+    val timeText = remember(item.startsAt, item.endsAt, item.allDay, allDayText) {
+        item.deviceEventTimeText(allDayText)
+    }
+    Card(modifier = Modifier.fillMaxWidth()) {
+        Row(
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .padding(12.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Spacer(
+                modifier =
+                    Modifier
+                        .size(width = 4.dp, height = 48.dp)
+                        .background(color),
+            )
+            Column(
+                modifier =
+                    Modifier
+                        .weight(1f)
+                        .padding(start = 12.dp),
+            ) {
+                Text(text = item.title, style = MaterialTheme.typography.bodyMedium)
+                Text(
+                    text = stringResource(id = R.string.calendar_device_event_meta, item.calendarName, timeText),
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.primary,
+                )
+                if (!item.description.isNullOrBlank()) {
+                    Text(
+                        text = item.description,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.outline,
+                    )
+                }
+            }
+        }
+    }
+}
+
+private fun DeviceCalendarEvent.deviceEventTimeText(allDayText: String): String {
+    if (allDay) return allDayText
+    val formatter = DateTimeFormatter.ofPattern("HH:mm").withZone(ZoneId.systemDefault())
+    return "${formatter.format(startsAt)}–${formatter.format(endsAt)}"
+}
+
+private fun Context.openAppSettings() {
+    startActivity(
+        Intent(
+            Settings.ACTION_APPLICATION_DETAILS_SETTINGS,
+            Uri.fromParts("package", packageName, null),
+        ),
+    )
 }
 
 @Composable

--- a/android/app/src/main/java/com/daynest/android/feature/calendar/CalendarViewModel.kt
+++ b/android/app/src/main/java/com/daynest/android/feature/calendar/CalendarViewModel.kt
@@ -49,6 +49,15 @@ class CalendarViewModel
                 onRefresh = ::retryCurrentMonth,
             )
 
+        private val deviceEventsHandler =
+            CalendarDeviceEventsHandler(
+                scope = viewModelScope,
+                deviceCalendarRepository = deviceCalendarRepository,
+                userPreferencesRepository = userPreferencesRepository,
+                uiState = _uiState,
+                preferences = { preferences },
+            )
+
         init {
             observePreferences()
             loadMonth(today.year, today.monthValue)
@@ -68,7 +77,7 @@ class CalendarViewModel
                 is CalendarUiEvent.ExportMonthBackup -> backupHandler.exportMonthBackup(event.onReady)
                 is CalendarUiEvent.ImportBackup -> backupHandler.importBackup(event.items)
                 is CalendarUiEvent.BackupMessageChanged -> backupHandler.updateBackupMessage(event.message)
-                is CalendarUiEvent.CalendarPermissionResult -> handleCalendarPermissionResult(event.granted)
+                is CalendarUiEvent.CalendarPermissionResult -> deviceEventsHandler.handlePermissionResult(event.granted)
             }
         }
 
@@ -91,7 +100,7 @@ class CalendarViewModel
                             hadDeviceCalendars != prefs.showDeviceCalendars ||
                                 previousCalendarIds != prefs.enabledDeviceCalendarIds
                         if (current.selectedDate != null && deviceCalendarPreferencesChanged) {
-                            loadDeviceEvents(LocalDate.parse(current.selectedDate))
+                            deviceEventsHandler.load(LocalDate.parse(current.selectedDate))
                         }
                     }
                 }
@@ -216,95 +225,6 @@ class CalendarViewModel
                 } else {
                     current
                 }
-            }
-        }
-
-        private fun loadDeviceEvents(date: LocalDate) {
-            viewModelScope.launch {
-                if (!preferences.showDeviceCalendars) {
-                    _uiState.update { current ->
-                        if (current is CalendarUiState.Content) {
-                            current.copy(
-                                deviceCalendarEvents = emptyList(),
-                                deviceCalendarStatus = DeviceCalendarStatus.Idle,
-                            )
-                        } else {
-                            current
-                        }
-                    }
-                    return@launch
-                }
-                if (preferences.enabledDeviceCalendarIds.isEmpty()) {
-                    _uiState.update { current ->
-                        if (current is CalendarUiState.Content) {
-                            current.copy(
-                                deviceCalendarEvents = emptyList(),
-                                deviceCalendarStatus = DeviceCalendarStatus.NoEnabledCalendars,
-                            )
-                        } else {
-                            current
-                        }
-                    }
-                    return@launch
-                }
-                _uiState.update { current ->
-                    if (current is CalendarUiState.Content) {
-                        current.copy(deviceCalendarStatus = DeviceCalendarStatus.Loading)
-                    } else {
-                        current
-                    }
-                }
-                deviceCalendarRepository.listEventsForDay(date, preferences.enabledDeviceCalendarIds)
-                    .onSuccess { events ->
-                        _uiState.update { current ->
-                            if (current is CalendarUiState.Content && current.selectedDate == date.toString()) {
-                                current.copy(
-                                    deviceCalendarEvents = events,
-                                    deviceCalendarStatus =
-                                        if (events.isEmpty()) {
-                                            DeviceCalendarStatus.Empty
-                                        } else {
-                                            DeviceCalendarStatus.Ready
-                                        },
-                                )
-                            } else {
-                                current
-                            }
-                        }
-                    }.onFailure {
-                        _uiState.update { current ->
-                            if (current is CalendarUiState.Content && current.selectedDate == date.toString()) {
-                                current.copy(
-                                    deviceCalendarEvents = emptyList(),
-                                    deviceCalendarStatus = DeviceCalendarStatus.PermissionRequired,
-                                )
-                            } else {
-                                current
-                            }
-                        }
-                    }
-            }
-        }
-
-        private fun handleCalendarPermissionResult(granted: Boolean) {
-            viewModelScope.launch {
-                if (!granted) {
-                    userPreferencesRepository.updateShowDeviceCalendars(false)
-                    _uiState.update { current ->
-                        if (current is CalendarUiState.Content) {
-                            current.copy(
-                                showDeviceCalendars = false,
-                                deviceCalendarEvents = emptyList(),
-                                deviceCalendarStatus = DeviceCalendarStatus.PermissionRequired,
-                            )
-                        } else {
-                            current
-                        }
-                    }
-                    return@launch
-                }
-                val selectedDate = (_uiState.value as? CalendarUiState.Content)?.selectedDate ?: return@launch
-                loadDeviceEvents(LocalDate.parse(selectedDate))
             }
         }
 

--- a/android/app/src/main/java/com/daynest/android/feature/calendar/CalendarViewModel.kt
+++ b/android/app/src/main/java/com/daynest/android/feature/calendar/CalendarViewModel.kt
@@ -2,8 +2,12 @@ package com.daynest.android.feature.calendar
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.daynest.android.core.storage.preferences.UserPreferences
+import com.daynest.android.core.storage.preferences.UserPreferencesRepository
 import com.daynest.android.data.calendar.CalendarDaySummaryDto
 import com.daynest.android.data.calendar.CalendarRepository
+import com.daynest.android.data.calendar.DeviceCalendarEvent
+import com.daynest.android.data.calendar.DeviceCalendarRepository
 import com.daynest.android.data.calendar.UnifiedDayItemDto
 import com.daynest.android.data.today.DeleteScope
 import com.daynest.android.data.today.EditScope
@@ -28,11 +32,14 @@ class CalendarViewModel
     constructor(
         private val calendarRepository: CalendarRepository,
         private val plannedItemRepository: PlannedItemRepository,
+        private val deviceCalendarRepository: DeviceCalendarRepository,
+        private val userPreferencesRepository: UserPreferencesRepository,
     ) : ViewModel() {
         private val _uiState = MutableStateFlow<CalendarUiState>(CalendarUiState.Loading)
         val uiState: StateFlow<CalendarUiState> = _uiState.asStateFlow()
 
         private val today = LocalDate.now()
+        private var preferences = UserPreferences()
 
         private val backupHandler =
             CalendarBackupHandler(
@@ -43,6 +50,7 @@ class CalendarViewModel
             )
 
         init {
+            observePreferences()
             loadMonth(today.year, today.monthValue)
         }
 
@@ -60,6 +68,33 @@ class CalendarViewModel
                 is CalendarUiEvent.ExportMonthBackup -> backupHandler.exportMonthBackup(event.onReady)
                 is CalendarUiEvent.ImportBackup -> backupHandler.importBackup(event.items)
                 is CalendarUiEvent.BackupMessageChanged -> backupHandler.updateBackupMessage(event.message)
+                is CalendarUiEvent.CalendarPermissionResult -> handleCalendarPermissionResult(event.granted)
+            }
+        }
+
+        private fun observePreferences() {
+            viewModelScope.launch {
+                userPreferencesRepository.preferences.collect { prefs ->
+                    val hadDeviceCalendars = preferences.showDeviceCalendars
+                    val previousCalendarIds = preferences.enabledDeviceCalendarIds
+                    preferences = prefs
+                    val current = _uiState.value
+                    if (current is CalendarUiState.Content) {
+                        _uiState.update {
+                            if (it is CalendarUiState.Content) {
+                                it.copy(showDeviceCalendars = prefs.showDeviceCalendars)
+                            } else {
+                                it
+                            }
+                        }
+                        val deviceCalendarPreferencesChanged =
+                            hadDeviceCalendars != prefs.showDeviceCalendars ||
+                                previousCalendarIds != prefs.enabledDeviceCalendarIds
+                        if (current.selectedDate != null && deviceCalendarPreferencesChanged) {
+                            loadDeviceEvents(LocalDate.parse(current.selectedDate))
+                        }
+                    }
+                }
             }
         }
 
@@ -113,6 +148,7 @@ class CalendarViewModel
                                     dayItems = emptyList(),
                                     isLoadingMonth = false,
                                     isLoadingDay = false,
+                                    showDeviceCalendars = preferences.showDeviceCalendars,
                                 )
                             } else {
                                 current
@@ -140,7 +176,13 @@ class CalendarViewModel
             viewModelScope.launch {
                 _uiState.update { current ->
                     if (current is CalendarUiState.Content) {
-                        current.copy(selectedDate = date, isLoadingDay = true, dayItems = emptyList())
+                        current.copy(
+                            selectedDate = date,
+                            isLoadingDay = true,
+                            dayItems = emptyList(),
+                            deviceCalendarEvents = emptyList(),
+                            deviceCalendarStatus = DeviceCalendarStatus.Idle,
+                        )
                     } else {
                         current
                     }
@@ -170,10 +212,99 @@ class CalendarViewModel
         private fun clearDay() {
             _uiState.update { current ->
                 if (current is CalendarUiState.Content) {
-                    current.copy(selectedDate = null, dayItems = emptyList())
+                    current.copy(selectedDate = null, dayItems = emptyList(), deviceCalendarEvents = emptyList())
                 } else {
                     current
                 }
+            }
+        }
+
+        private fun loadDeviceEvents(date: LocalDate) {
+            viewModelScope.launch {
+                if (!preferences.showDeviceCalendars) {
+                    _uiState.update { current ->
+                        if (current is CalendarUiState.Content) {
+                            current.copy(
+                                deviceCalendarEvents = emptyList(),
+                                deviceCalendarStatus = DeviceCalendarStatus.Idle,
+                            )
+                        } else {
+                            current
+                        }
+                    }
+                    return@launch
+                }
+                if (preferences.enabledDeviceCalendarIds.isEmpty()) {
+                    _uiState.update { current ->
+                        if (current is CalendarUiState.Content) {
+                            current.copy(
+                                deviceCalendarEvents = emptyList(),
+                                deviceCalendarStatus = DeviceCalendarStatus.NoEnabledCalendars,
+                            )
+                        } else {
+                            current
+                        }
+                    }
+                    return@launch
+                }
+                _uiState.update { current ->
+                    if (current is CalendarUiState.Content) {
+                        current.copy(deviceCalendarStatus = DeviceCalendarStatus.Loading)
+                    } else {
+                        current
+                    }
+                }
+                deviceCalendarRepository.listEventsForDay(date, preferences.enabledDeviceCalendarIds)
+                    .onSuccess { events ->
+                        _uiState.update { current ->
+                            if (current is CalendarUiState.Content && current.selectedDate == date.toString()) {
+                                current.copy(
+                                    deviceCalendarEvents = events,
+                                    deviceCalendarStatus =
+                                        if (events.isEmpty()) {
+                                            DeviceCalendarStatus.Empty
+                                        } else {
+                                            DeviceCalendarStatus.Ready
+                                        },
+                                )
+                            } else {
+                                current
+                            }
+                        }
+                    }.onFailure {
+                        _uiState.update { current ->
+                            if (current is CalendarUiState.Content && current.selectedDate == date.toString()) {
+                                current.copy(
+                                    deviceCalendarEvents = emptyList(),
+                                    deviceCalendarStatus = DeviceCalendarStatus.PermissionRequired,
+                                )
+                            } else {
+                                current
+                            }
+                        }
+                    }
+            }
+        }
+
+        private fun handleCalendarPermissionResult(granted: Boolean) {
+            viewModelScope.launch {
+                if (!granted) {
+                    userPreferencesRepository.updateShowDeviceCalendars(false)
+                    _uiState.update { current ->
+                        if (current is CalendarUiState.Content) {
+                            current.copy(
+                                showDeviceCalendars = false,
+                                deviceCalendarEvents = emptyList(),
+                                deviceCalendarStatus = DeviceCalendarStatus.PermissionRequired,
+                            )
+                        } else {
+                            current
+                        }
+                    }
+                    return@launch
+                }
+                val selectedDate = (_uiState.value as? CalendarUiState.Content)?.selectedDate ?: return@launch
+                loadDeviceEvents(LocalDate.parse(selectedDate))
             }
         }
 
@@ -382,6 +513,9 @@ sealed interface CalendarUiState {
         val isLoadingMonth: Boolean,
         val isLoadingDay: Boolean,
         val backupMessage: CalendarBackupMessage? = null,
+        val showDeviceCalendars: Boolean = false,
+        val deviceCalendarEvents: List<DeviceCalendarEvent> = emptyList(),
+        val deviceCalendarStatus: DeviceCalendarStatus = DeviceCalendarStatus.Idle,
     ) : CalendarUiState
 
     data class Error(
@@ -430,6 +564,19 @@ sealed interface CalendarUiEvent {
     data class BackupMessageChanged(
         val message: CalendarBackupMessage,
     ) : CalendarUiEvent
+
+    data class CalendarPermissionResult(
+        val granted: Boolean,
+    ) : CalendarUiEvent
+}
+
+enum class DeviceCalendarStatus {
+    Idle,
+    Loading,
+    Ready,
+    Empty,
+    NoEnabledCalendars,
+    PermissionRequired,
 }
 
 sealed interface CalendarBackupMessage {

--- a/android/app/src/main/java/com/daynest/android/feature/calendar/CalendarViewModel.kt
+++ b/android/app/src/main/java/com/daynest/android/feature/calendar/CalendarViewModel.kt
@@ -53,7 +53,6 @@ class CalendarViewModel
             CalendarDeviceEventsHandler(
                 scope = viewModelScope,
                 deviceCalendarRepository = deviceCalendarRepository,
-                userPreferencesRepository = userPreferencesRepository,
                 uiState = _uiState,
                 preferences = { preferences },
             )
@@ -196,6 +195,7 @@ class CalendarViewModel
                         current
                     }
                 }
+                deviceEventsHandler.load(LocalDate.parse(date))
                 val result = calendarRepository.getDay(date)
                 result
                     .onSuccess { dayDto ->

--- a/android/app/src/main/java/com/daynest/android/feature/settings/SettingsDeviceCalendarComponents.kt
+++ b/android/app/src/main/java/com/daynest/android/feature/settings/SettingsDeviceCalendarComponents.kt
@@ -1,0 +1,117 @@
+package com.daynest.android.feature.settings
+
+import android.Manifest
+import android.content.Context
+import android.content.pm.PackageManager
+import androidx.activity.result.ActivityResultLauncher
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyListScope
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.Card
+import androidx.compose.material3.Checkbox
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.core.content.ContextCompat
+import com.daynest.android.R
+import com.daynest.android.data.calendar.DeviceCalendar
+
+@Composable
+internal fun deviceCalendarToggleRow(
+    calendar: DeviceCalendar,
+    checked: Boolean,
+    onCheckedChange: (Boolean) -> Unit,
+) {
+    Card(modifier = Modifier.fillMaxWidth()) {
+        Row(
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .padding(12.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Column(modifier = Modifier.weight(1f)) {
+                Text(text = calendar.name, style = MaterialTheme.typography.bodyMedium)
+                if (!calendar.accountName.isNullOrBlank()) {
+                    Text(
+                        text = calendar.accountName,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.outline,
+                    )
+                }
+            }
+            Checkbox(checked = checked, onCheckedChange = onCheckedChange)
+        }
+    }
+}
+
+internal fun LazyListScope.settingsDeviceCalendarsToggleAndList(
+    state: SettingsUiState.Content,
+    context: Context,
+    deviceCalendarPermissionLauncher: ActivityResultLauncher<String>,
+    onEvent: (SettingsUiEvent) -> Unit,
+) {
+    item {
+        SettingToggleCard(
+            title = stringResource(id = R.string.settings_device_calendars_label),
+            subtitle = stringResource(id = R.string.settings_device_calendars_hint),
+            checked = state.showDeviceCalendars,
+            onCheckedChange = { enabled ->
+                handleDeviceCalendarsChanged(
+                    enabled = enabled,
+                    context = context,
+                    permissionLauncher = deviceCalendarPermissionLauncher,
+                    onEvent = onEvent,
+                )
+            },
+        )
+    }
+    settingsDeviceCalendarsSubList(state, onEvent)
+}
+
+internal fun LazyListScope.settingsDeviceCalendarsSubList(
+    state: SettingsUiState.Content,
+    onEvent: (SettingsUiEvent) -> Unit,
+) {
+    if (!state.showDeviceCalendars) return
+    if (state.deviceCalendars.isEmpty()) {
+        item { emptyStateText(R.string.settings_device_calendars_empty) }
+    } else {
+        items(state.deviceCalendars, key = { it.id }) { calendar ->
+            deviceCalendarToggleRow(
+                calendar = calendar,
+                checked = calendar.id in state.enabledDeviceCalendarIds,
+                onCheckedChange = { onEvent(SettingsUiEvent.UpdateDeviceCalendarEnabled(calendar.id, it)) },
+            )
+        }
+    }
+}
+
+internal fun handleDeviceCalendarsChanged(
+    enabled: Boolean,
+    context: Context,
+    permissionLauncher: ActivityResultLauncher<String>,
+    onEvent: (SettingsUiEvent) -> Unit,
+) {
+    if (!enabled) {
+        onEvent(SettingsUiEvent.UpdateShowDeviceCalendars(false))
+        return
+    }
+    if (
+        ContextCompat.checkSelfPermission(
+            context,
+            Manifest.permission.READ_CALENDAR,
+        ) == PackageManager.PERMISSION_GRANTED
+    ) {
+        onEvent(SettingsUiEvent.UpdateShowDeviceCalendars(true))
+    } else {
+        permissionLauncher.launch(Manifest.permission.READ_CALENDAR)
+    }
+}

--- a/android/app/src/main/java/com/daynest/android/feature/settings/SettingsDeviceCalendarHandler.kt
+++ b/android/app/src/main/java/com/daynest/android/feature/settings/SettingsDeviceCalendarHandler.kt
@@ -20,7 +20,8 @@ internal class SettingsDeviceCalendarHandler(
         when (event) {
             is SettingsUiEvent.UpdateCalendarSyncEnabled -> updateCalendarSyncEnabled(event.enabled)
             is SettingsUiEvent.UpdateShowDeviceCalendars -> updateShowDeviceCalendars(event.enabled)
-            is SettingsUiEvent.UpdateDeviceCalendarEnabled -> updateDeviceCalendarEnabled(event.calendarId, event.enabled)
+            is SettingsUiEvent.UpdateDeviceCalendarEnabled ->
+                updateDeviceCalendarEnabled(event.calendarId, event.enabled)
             else -> Unit
         }
     }

--- a/android/app/src/main/java/com/daynest/android/feature/settings/SettingsDeviceCalendarHandler.kt
+++ b/android/app/src/main/java/com/daynest/android/feature/settings/SettingsDeviceCalendarHandler.kt
@@ -48,27 +48,27 @@ internal class SettingsDeviceCalendarHandler(
                     } else {
                         emptyList()
                     }
+                var enabledIds: Set<String>? = null
                 uiState.update { current ->
                     if (current is SettingsUiState.Content) {
-                        val enabledIds =
+                        val updatedIds =
                             if (enabled && current.enabledDeviceCalendarIds.isEmpty()) {
                                 calendars.filter { it.visible }.map { it.id }.toSet()
                             } else {
                                 current.enabledDeviceCalendarIds
                             }
-                        if (enabledIds != current.enabledDeviceCalendarIds) {
-                            scope.launch {
-                                userPreferencesRepository.updateEnabledDeviceCalendarIds(enabledIds)
-                            }
-                        }
+                        enabledIds = updatedIds.takeIf { it != current.enabledDeviceCalendarIds }
                         current.copy(
                             showDeviceCalendars = enabled,
                             deviceCalendars = calendars,
-                            enabledDeviceCalendarIds = enabledIds,
+                            enabledDeviceCalendarIds = updatedIds,
                         )
                     } else {
                         current
                     }
+                }
+                enabledIds?.let { ids ->
+                    runCatching { userPreferencesRepository.updateEnabledDeviceCalendarIds(ids) }
                 }
             }
         }
@@ -79,21 +79,23 @@ internal class SettingsDeviceCalendarHandler(
         enabled: Boolean,
     ) {
         scope.launch {
-            val current = (uiState.value as? SettingsUiState.Content) ?: return@launch
-            val updatedIds =
-                if (enabled) {
-                    current.enabledDeviceCalendarIds + calendarId
+            var updatedIds: Set<String>? = null
+            uiState.update { state ->
+                if (state is SettingsUiState.Content) {
+                    val ids =
+                        if (enabled) {
+                            state.enabledDeviceCalendarIds + calendarId
+                        } else {
+                            state.enabledDeviceCalendarIds - calendarId
+                        }
+                    updatedIds = ids
+                    state.copy(enabledDeviceCalendarIds = ids)
                 } else {
-                    current.enabledDeviceCalendarIds - calendarId
+                    state
                 }
-            runCatching { userPreferencesRepository.updateEnabledDeviceCalendarIds(updatedIds) }.onSuccess {
-                uiState.update { state ->
-                    if (state is SettingsUiState.Content) {
-                        state.copy(enabledDeviceCalendarIds = updatedIds)
-                    } else {
-                        state
-                    }
-                }
+            }
+            updatedIds?.let { ids ->
+                runCatching { userPreferencesRepository.updateEnabledDeviceCalendarIds(ids) }
             }
         }
     }

--- a/android/app/src/main/java/com/daynest/android/feature/settings/SettingsDeviceCalendarHandler.kt
+++ b/android/app/src/main/java/com/daynest/android/feature/settings/SettingsDeviceCalendarHandler.kt
@@ -1,0 +1,99 @@
+package com.daynest.android.feature.settings
+
+import android.content.Context
+import com.daynest.android.core.storage.preferences.UserPreferencesRepository
+import com.daynest.android.data.calendar.DeviceCalendarRepository
+import com.daynest.android.data.sync.DaynestSyncScheduler
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+
+internal class SettingsDeviceCalendarHandler(
+    private val scope: CoroutineScope,
+    private val appContext: Context,
+    private val deviceCalendarRepository: DeviceCalendarRepository,
+    private val userPreferencesRepository: UserPreferencesRepository,
+    private val uiState: MutableStateFlow<SettingsUiState>,
+) {
+    fun onPreferencesEvent(event: SettingsUiEvent) {
+        when (event) {
+            is SettingsUiEvent.UpdateCalendarSyncEnabled -> updateCalendarSyncEnabled(event.enabled)
+            is SettingsUiEvent.UpdateShowDeviceCalendars -> updateShowDeviceCalendars(event.enabled)
+            is SettingsUiEvent.UpdateDeviceCalendarEnabled -> updateDeviceCalendarEnabled(event.calendarId, event.enabled)
+            else -> Unit
+        }
+    }
+
+    fun updateCalendarSyncEnabled(enabled: Boolean) {
+        scope.launch {
+            runCatching { userPreferencesRepository.updateCalendarSyncEnabled(enabled) }.onSuccess {
+                uiState.update { current ->
+                    if (current is SettingsUiState.Content) current.copy(calendarSyncEnabled = enabled) else current
+                }
+                if (enabled) {
+                    DaynestSyncScheduler.enqueueOneShot(appContext)
+                }
+            }
+        }
+    }
+
+    fun updateShowDeviceCalendars(enabled: Boolean) {
+        scope.launch {
+            runCatching { userPreferencesRepository.updateShowDeviceCalendars(enabled) }.onSuccess {
+                val calendars =
+                    if (enabled) {
+                        deviceCalendarRepository.listCalendars().getOrElse { emptyList() }
+                    } else {
+                        emptyList()
+                    }
+                uiState.update { current ->
+                    if (current is SettingsUiState.Content) {
+                        val enabledIds =
+                            if (enabled && current.enabledDeviceCalendarIds.isEmpty()) {
+                                calendars.filter { it.visible }.map { it.id }.toSet()
+                            } else {
+                                current.enabledDeviceCalendarIds
+                            }
+                        if (enabledIds != current.enabledDeviceCalendarIds) {
+                            scope.launch {
+                                userPreferencesRepository.updateEnabledDeviceCalendarIds(enabledIds)
+                            }
+                        }
+                        current.copy(
+                            showDeviceCalendars = enabled,
+                            deviceCalendars = calendars,
+                            enabledDeviceCalendarIds = enabledIds,
+                        )
+                    } else {
+                        current
+                    }
+                }
+            }
+        }
+    }
+
+    fun updateDeviceCalendarEnabled(
+        calendarId: String,
+        enabled: Boolean,
+    ) {
+        scope.launch {
+            val current = (uiState.value as? SettingsUiState.Content) ?: return@launch
+            val updatedIds =
+                if (enabled) {
+                    current.enabledDeviceCalendarIds + calendarId
+                } else {
+                    current.enabledDeviceCalendarIds - calendarId
+                }
+            runCatching { userPreferencesRepository.updateEnabledDeviceCalendarIds(updatedIds) }.onSuccess {
+                uiState.update { state ->
+                    if (state is SettingsUiState.Content) {
+                        state.copy(enabledDeviceCalendarIds = updatedIds)
+                    } else {
+                        state
+                    }
+                }
+            }
+        }
+    }
+}

--- a/android/app/src/main/java/com/daynest/android/feature/settings/SettingsRoute.kt
+++ b/android/app/src/main/java/com/daynest/android/feature/settings/SettingsRoute.kt
@@ -103,6 +103,10 @@ private fun SettingsContent(
     modifier: Modifier = Modifier,
 ) {
     val context = LocalContext.current
+    val deviceCalendarPermissionLauncher =
+        rememberLauncherForActivityResult(ActivityResultContracts.RequestPermission()) { granted ->
+            onEvent(SettingsUiEvent.UpdateShowDeviceCalendars(granted))
+        }
     val calendarPermissionLauncher =
         rememberLauncherForActivityResult(ActivityResultContracts.RequestMultiplePermissions()) { result ->
             val granted =
@@ -133,6 +137,7 @@ private fun SettingsContent(
             context = context,
             notificationsPermissionLauncher = notificationsPermissionLauncher,
             calendarPermissionLauncher = calendarPermissionLauncher,
+            deviceCalendarPermissionLauncher = deviceCalendarPermissionLauncher,
             onEvent = onEvent,
         )
         settingsAccountSection(onEvent)

--- a/android/app/src/main/java/com/daynest/android/feature/settings/SettingsRouteSections.kt
+++ b/android/app/src/main/java/com/daynest/android/feature/settings/SettingsRouteSections.kt
@@ -5,6 +5,7 @@ import android.content.Context
 import android.content.pm.PackageManager
 import android.os.Build
 import androidx.activity.compose.ManagedActivityResultLauncher
+import androidx.activity.result.ActivityResultLauncher
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -13,6 +14,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyListScope
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.Card
+import androidx.compose.material3.Checkbox
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
@@ -25,6 +27,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.core.content.ContextCompat
 import com.daynest.android.R
+import com.daynest.android.data.calendar.DeviceCalendar
 
 internal fun LazyListScope.settingsServerSection(
     state: SettingsUiState.Content,
@@ -51,6 +54,7 @@ internal fun LazyListScope.settingsPrivacySection(
     context: Context,
     notificationsPermissionLauncher: ManagedActivityResultLauncher<String, Boolean>,
     calendarPermissionLauncher: ManagedActivityResultLauncher<Array<String>, Map<String, Boolean>>,
+    deviceCalendarPermissionLauncher: ActivityResultLauncher<String>,
     onEvent: (SettingsUiEvent) -> Unit,
 ) {
     item {
@@ -100,6 +104,63 @@ internal fun LazyListScope.settingsPrivacySection(
                 )
             },
         )
+    }
+    item {
+        SettingToggleCard(
+            title = stringResource(id = R.string.settings_device_calendars_label),
+            subtitle = stringResource(id = R.string.settings_device_calendars_hint),
+            checked = state.showDeviceCalendars,
+            onCheckedChange = { enabled ->
+                handleDeviceCalendarsChanged(
+                    enabled = enabled,
+                    context = context,
+                    permissionLauncher = deviceCalendarPermissionLauncher,
+                    onEvent = onEvent,
+                )
+            },
+        )
+    }
+    if (state.showDeviceCalendars) {
+        if (state.deviceCalendars.isEmpty()) {
+            item { emptyStateText(R.string.settings_device_calendars_empty) }
+        } else {
+            items(state.deviceCalendars, key = { it.id }) { calendar ->
+                DeviceCalendarToggleRow(
+                    calendar = calendar,
+                    checked = calendar.id in state.enabledDeviceCalendarIds,
+                    onCheckedChange = { onEvent(SettingsUiEvent.UpdateDeviceCalendarEnabled(calendar.id, it)) },
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun DeviceCalendarToggleRow(
+    calendar: DeviceCalendar,
+    checked: Boolean,
+    onCheckedChange: (Boolean) -> Unit,
+) {
+    Card(modifier = Modifier.fillMaxWidth()) {
+        Row(
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .padding(12.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Column(modifier = Modifier.weight(1f)) {
+                Text(text = calendar.name, style = MaterialTheme.typography.bodyMedium)
+                if (!calendar.accountName.isNullOrBlank()) {
+                    Text(
+                        text = calendar.accountName,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.outline,
+                    )
+                }
+            }
+            Checkbox(checked = checked, onCheckedChange = onCheckedChange)
+        }
     }
 }
 
@@ -280,6 +341,28 @@ private fun handleNotificationsChanged(
         notificationsPermissionLauncher.launch(Manifest.permission.POST_NOTIFICATIONS)
     } else {
         onEvent(SettingsUiEvent.UpdatePushNotificationsEnabled(true))
+    }
+}
+
+private fun handleDeviceCalendarsChanged(
+    enabled: Boolean,
+    context: Context,
+    permissionLauncher: ActivityResultLauncher<String>,
+    onEvent: (SettingsUiEvent) -> Unit,
+) {
+    if (!enabled) {
+        onEvent(SettingsUiEvent.UpdateShowDeviceCalendars(false))
+        return
+    }
+    if (
+        ContextCompat.checkSelfPermission(
+            context,
+            Manifest.permission.READ_CALENDAR,
+        ) == PackageManager.PERMISSION_GRANTED
+    ) {
+        onEvent(SettingsUiEvent.UpdateShowDeviceCalendars(true))
+    } else {
+        permissionLauncher.launch(Manifest.permission.READ_CALENDAR)
     }
 }
 

--- a/android/app/src/main/java/com/daynest/android/feature/settings/SettingsRouteSections.kt
+++ b/android/app/src/main/java/com/daynest/android/feature/settings/SettingsRouteSections.kt
@@ -14,7 +14,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyListScope
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.Card
-import androidx.compose.material3.Checkbox
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
@@ -28,6 +27,7 @@ import androidx.compose.ui.unit.dp
 import androidx.core.content.ContextCompat
 import com.daynest.android.R
 import com.daynest.android.data.calendar.DeviceCalendar
+import com.daynest.android.ui.ServerUrlPicker
 
 internal fun LazyListScope.settingsServerSection(
     state: SettingsUiState.Content,
@@ -79,17 +79,7 @@ internal fun LazyListScope.settingsPrivacySection(
             },
         )
     }
-    item {
-        SettingToggleCard(
-            title = stringResource(id = R.string.settings_biometric_label),
-            subtitle = stringResource(id = R.string.settings_biometric_hint),
-            checked = state.biometricLockEnabled,
-            onCheckedChange = { onEvent(SettingsUiEvent.UpdateBiometricLockEnabled(it)) },
-        )
-    }
-    item {
-        biometricTimeoutCard(state, onEvent)
-    }
+    settingsBiometricItems(state, onEvent)
     item {
         SettingToggleCard(
             title = stringResource(id = R.string.settings_calendar_sync_label),
@@ -105,62 +95,28 @@ internal fun LazyListScope.settingsPrivacySection(
             },
         )
     }
-    item {
-        SettingToggleCard(
-            title = stringResource(id = R.string.settings_device_calendars_label),
-            subtitle = stringResource(id = R.string.settings_device_calendars_hint),
-            checked = state.showDeviceCalendars,
-            onCheckedChange = { enabled ->
-                handleDeviceCalendarsChanged(
-                    enabled = enabled,
-                    context = context,
-                    permissionLauncher = deviceCalendarPermissionLauncher,
-                    onEvent = onEvent,
-                )
-            },
-        )
-    }
-    if (state.showDeviceCalendars) {
-        if (state.deviceCalendars.isEmpty()) {
-            item { emptyStateText(R.string.settings_device_calendars_empty) }
-        } else {
-            items(state.deviceCalendars, key = { it.id }) { calendar ->
-                DeviceCalendarToggleRow(
-                    calendar = calendar,
-                    checked = calendar.id in state.enabledDeviceCalendarIds,
-                    onCheckedChange = { onEvent(SettingsUiEvent.UpdateDeviceCalendarEnabled(calendar.id, it)) },
-                )
-            }
-        }
-    }
+    settingsDeviceCalendarsToggleAndList(
+        state = state,
+        context = context,
+        deviceCalendarPermissionLauncher = deviceCalendarPermissionLauncher,
+        onEvent = onEvent,
+    )
 }
 
-@Composable
-private fun DeviceCalendarToggleRow(
-    calendar: DeviceCalendar,
-    checked: Boolean,
-    onCheckedChange: (Boolean) -> Unit,
+private fun LazyListScope.settingsBiometricItems(
+    state: SettingsUiState.Content,
+    onEvent: (SettingsUiEvent) -> Unit,
 ) {
-    Card(modifier = Modifier.fillMaxWidth()) {
-        Row(
-            modifier =
-                Modifier
-                    .fillMaxWidth()
-                    .padding(12.dp),
-            verticalAlignment = Alignment.CenterVertically,
-        ) {
-            Column(modifier = Modifier.weight(1f)) {
-                Text(text = calendar.name, style = MaterialTheme.typography.bodyMedium)
-                if (!calendar.accountName.isNullOrBlank()) {
-                    Text(
-                        text = calendar.accountName,
-                        style = MaterialTheme.typography.bodySmall,
-                        color = MaterialTheme.colorScheme.outline,
-                    )
-                }
-            }
-            Checkbox(checked = checked, onCheckedChange = onCheckedChange)
-        }
+    item {
+        SettingToggleCard(
+            title = stringResource(id = R.string.settings_biometric_label),
+            subtitle = stringResource(id = R.string.settings_biometric_hint),
+            checked = state.biometricLockEnabled,
+            onCheckedChange = { onEvent(SettingsUiEvent.UpdateBiometricLockEnabled(it)) },
+        )
+    }
+    item {
+        biometricTimeoutCard(state, onEvent)
     }
 }
 
@@ -315,7 +271,7 @@ private fun loadErrorText(
 }
 
 @Composable
-private fun emptyStateText(messageRes: Int) {
+internal fun emptyStateText(messageRes: Int) {
     Text(
         text = stringResource(id = messageRes),
         style = MaterialTheme.typography.bodyMedium,
@@ -341,28 +297,6 @@ private fun handleNotificationsChanged(
         notificationsPermissionLauncher.launch(Manifest.permission.POST_NOTIFICATIONS)
     } else {
         onEvent(SettingsUiEvent.UpdatePushNotificationsEnabled(true))
-    }
-}
-
-private fun handleDeviceCalendarsChanged(
-    enabled: Boolean,
-    context: Context,
-    permissionLauncher: ActivityResultLauncher<String>,
-    onEvent: (SettingsUiEvent) -> Unit,
-) {
-    if (!enabled) {
-        onEvent(SettingsUiEvent.UpdateShowDeviceCalendars(false))
-        return
-    }
-    if (
-        ContextCompat.checkSelfPermission(
-            context,
-            Manifest.permission.READ_CALENDAR,
-        ) == PackageManager.PERMISSION_GRANTED
-    ) {
-        onEvent(SettingsUiEvent.UpdateShowDeviceCalendars(true))
-    } else {
-        permissionLauncher.launch(Manifest.permission.READ_CALENDAR)
     }
 }
 

--- a/android/app/src/main/java/com/daynest/android/feature/settings/SettingsRouteSections.kt
+++ b/android/app/src/main/java/com/daynest/android/feature/settings/SettingsRouteSections.kt
@@ -26,8 +26,6 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.core.content.ContextCompat
 import com.daynest.android.R
-import com.daynest.android.data.calendar.DeviceCalendar
-import com.daynest.android.ui.ServerUrlPicker
 
 internal fun LazyListScope.settingsServerSection(
     state: SettingsUiState.Content,

--- a/android/app/src/main/java/com/daynest/android/feature/settings/SettingsViewModel.kt
+++ b/android/app/src/main/java/com/daynest/android/feature/settings/SettingsViewModel.kt
@@ -6,6 +6,8 @@ import androidx.lifecycle.viewModelScope
 import com.daynest.android.BuildConfig
 import com.daynest.android.core.auth.OidcAuthService
 import com.daynest.android.core.storage.preferences.UserPreferencesRepository
+import com.daynest.android.data.calendar.DeviceCalendar
+import com.daynest.android.data.calendar.DeviceCalendarRepository
 import com.daynest.android.data.push.PushRegistrationManager
 import com.daynest.android.data.settings.IntegrationClientCreateResponseDto
 import com.daynest.android.data.settings.IntegrationClientDto
@@ -32,6 +34,7 @@ class SettingsViewModel
         private val oidcAuthService: OidcAuthService,
         private val userPreferencesRepository: UserPreferencesRepository,
         private val pushRegistrationManager: PushRegistrationManager,
+        private val deviceCalendarRepository: DeviceCalendarRepository,
         @ApplicationContext private val appContext: Context,
     ) : ViewModel() {
         private val _uiState = MutableStateFlow<SettingsUiState>(SettingsUiState.Loading)
@@ -59,6 +62,9 @@ class SettingsViewModel
                 is SettingsUiEvent.UpdateBiometricLockEnabled -> updateBiometricLockEnabled(event.enabled)
                 is SettingsUiEvent.UpdateBiometricIdleTimeoutMinutes -> updateBiometricIdleTimeoutMinutes(event.minutes)
                 is SettingsUiEvent.UpdateCalendarSyncEnabled -> updateCalendarSyncEnabled(event.enabled)
+                is SettingsUiEvent.UpdateShowDeviceCalendars -> updateShowDeviceCalendars(event.enabled)
+                is SettingsUiEvent.UpdateDeviceCalendarEnabled ->
+                    updateDeviceCalendarEnabled(event.calendarId, event.enabled)
             }
         }
 
@@ -68,9 +74,11 @@ class SettingsViewModel
                 val prefsDeferred = async { userPreferencesRepository.preferences.first() }
                 val clientsDeferred = async { settingsRepository.listClients() }
                 val sessionsDeferred = async { settingsRepository.listSessions() }
+                val deviceCalendarsDeferred = async { deviceCalendarRepository.listCalendars() }
                 val prefs = prefsDeferred.await()
                 val clientsResult = clientsDeferred.await()
                 val sessionsResult = sessionsDeferred.await()
+                val deviceCalendarsResult = deviceCalendarsDeferred.await()
                 _uiState.value =
                     SettingsUiState.Content(
                         clients = clientsResult.getOrElse { emptyList() },
@@ -85,6 +93,9 @@ class SettingsViewModel
                         biometricLockEnabled = prefs.biometricLockEnabled,
                         biometricIdleTimeoutMinutes = prefs.biometricIdleTimeoutMinutes,
                         calendarSyncEnabled = prefs.calendarSyncEnabled,
+                        showDeviceCalendars = prefs.showDeviceCalendars,
+                        deviceCalendars = deviceCalendarsResult.getOrElse { emptyList() },
+                        enabledDeviceCalendarIds = prefs.enabledDeviceCalendarIds,
                     )
             }
         }
@@ -178,6 +189,65 @@ class SettingsViewModel
             }
         }
 
+        private fun updateShowDeviceCalendars(enabled: Boolean) {
+            viewModelScope.launch {
+                runCatching { userPreferencesRepository.updateShowDeviceCalendars(enabled) }.onSuccess {
+                    val calendars =
+                        if (enabled) {
+                            deviceCalendarRepository.listCalendars().getOrElse { emptyList() }
+                        } else {
+                            emptyList()
+                        }
+                    _uiState.update { current ->
+                        if (current is SettingsUiState.Content) {
+                            val enabledIds =
+                                if (enabled && current.enabledDeviceCalendarIds.isEmpty()) {
+                                    calendars.filter { it.visible }.map { it.id }.toSet()
+                                } else {
+                                    current.enabledDeviceCalendarIds
+                                }
+                            if (enabledIds != current.enabledDeviceCalendarIds) {
+                                viewModelScope.launch {
+                                    userPreferencesRepository.updateEnabledDeviceCalendarIds(enabledIds)
+                                }
+                            }
+                            current.copy(
+                                showDeviceCalendars = enabled,
+                                deviceCalendars = calendars,
+                                enabledDeviceCalendarIds = enabledIds,
+                            )
+                        } else {
+                            current
+                        }
+                    }
+                }
+            }
+        }
+
+        private fun updateDeviceCalendarEnabled(
+            calendarId: String,
+            enabled: Boolean,
+        ) {
+            viewModelScope.launch {
+                val current = (_uiState.value as? SettingsUiState.Content) ?: return@launch
+                val updatedIds =
+                    if (enabled) {
+                        current.enabledDeviceCalendarIds + calendarId
+                    } else {
+                        current.enabledDeviceCalendarIds - calendarId
+                    }
+                runCatching { userPreferencesRepository.updateEnabledDeviceCalendarIds(updatedIds) }.onSuccess {
+                    _uiState.update { state ->
+                        if (state is SettingsUiState.Content) {
+                            state.copy(enabledDeviceCalendarIds = updatedIds)
+                        } else {
+                            state
+                        }
+                    }
+                }
+            }
+        }
+
         private fun revokeSession(id: String) {
             viewModelScope.launch {
                 val result = settingsRepository.revokeSession(id)
@@ -224,6 +294,9 @@ sealed interface SettingsUiState {
         val biometricLockEnabled: Boolean,
         val biometricIdleTimeoutMinutes: Int,
         val calendarSyncEnabled: Boolean,
+        val showDeviceCalendars: Boolean,
+        val deviceCalendars: List<DeviceCalendar>,
+        val enabledDeviceCalendarIds: Set<String>,
     ) : SettingsUiState
 
     data object SignedOut : SettingsUiState
@@ -265,6 +338,15 @@ sealed interface SettingsUiEvent {
     ) : SettingsUiEvent
 
     data class UpdateCalendarSyncEnabled(
+        val enabled: Boolean,
+    ) : SettingsUiEvent
+
+    data class UpdateShowDeviceCalendars(
+        val enabled: Boolean,
+    ) : SettingsUiEvent
+
+    data class UpdateDeviceCalendarEnabled(
+        val calendarId: String,
         val enabled: Boolean,
     ) : SettingsUiEvent
 }

--- a/android/app/src/main/java/com/daynest/android/feature/settings/SettingsViewModel.kt
+++ b/android/app/src/main/java/com/daynest/android/feature/settings/SettingsViewModel.kt
@@ -14,7 +14,6 @@ import com.daynest.android.data.settings.IntegrationClientDto
 import com.daynest.android.data.settings.IntegrationClientInputDto
 import com.daynest.android.data.settings.OAuthSessionDto
 import com.daynest.android.data.settings.SettingsRepository
-import com.daynest.android.data.sync.DaynestSyncScheduler
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.async
@@ -40,6 +39,15 @@ class SettingsViewModel
         private val _uiState = MutableStateFlow<SettingsUiState>(SettingsUiState.Loading)
         val uiState: StateFlow<SettingsUiState> = _uiState.asStateFlow()
 
+        private val deviceCalendarHandler =
+            SettingsDeviceCalendarHandler(
+                scope = viewModelScope,
+                appContext = appContext,
+                deviceCalendarRepository = deviceCalendarRepository,
+                userPreferencesRepository = userPreferencesRepository,
+                uiState = _uiState,
+            )
+
         init {
             load()
         }
@@ -58,13 +66,16 @@ class SettingsViewModel
                 is SettingsUiEvent.CreateClient -> createClient(event.input)
                 is SettingsUiEvent.UpdateServerUrl -> updateServerUrl(event.url)
                 is SettingsUiEvent.RevokeSessionClicked -> revokeSession(event.sessionId)
+                else -> onPreferencesEvent(event)
+            }
+        }
+
+        private fun onPreferencesEvent(event: SettingsUiEvent) {
+            when (event) {
                 is SettingsUiEvent.UpdatePushNotificationsEnabled -> updatePushNotificationsEnabled(event.enabled)
                 is SettingsUiEvent.UpdateBiometricLockEnabled -> updateBiometricLockEnabled(event.enabled)
                 is SettingsUiEvent.UpdateBiometricIdleTimeoutMinutes -> updateBiometricIdleTimeoutMinutes(event.minutes)
-                is SettingsUiEvent.UpdateCalendarSyncEnabled -> updateCalendarSyncEnabled(event.enabled)
-                is SettingsUiEvent.UpdateShowDeviceCalendars -> updateShowDeviceCalendars(event.enabled)
-                is SettingsUiEvent.UpdateDeviceCalendarEnabled ->
-                    updateDeviceCalendarEnabled(event.calendarId, event.enabled)
+                else -> deviceCalendarHandler.onPreferencesEvent(event)
             }
         }
 
@@ -170,78 +181,6 @@ class SettingsViewModel
                             current.copy(biometricIdleTimeoutMinutes = clamped)
                         } else {
                             current
-                        }
-                    }
-                }
-            }
-        }
-
-        private fun updateCalendarSyncEnabled(enabled: Boolean) {
-            viewModelScope.launch {
-                runCatching { userPreferencesRepository.updateCalendarSyncEnabled(enabled) }.onSuccess {
-                    _uiState.update { current ->
-                        if (current is SettingsUiState.Content) current.copy(calendarSyncEnabled = enabled) else current
-                    }
-                    if (enabled) {
-                        DaynestSyncScheduler.enqueueOneShot(appContext)
-                    }
-                }
-            }
-        }
-
-        private fun updateShowDeviceCalendars(enabled: Boolean) {
-            viewModelScope.launch {
-                runCatching { userPreferencesRepository.updateShowDeviceCalendars(enabled) }.onSuccess {
-                    val calendars =
-                        if (enabled) {
-                            deviceCalendarRepository.listCalendars().getOrElse { emptyList() }
-                        } else {
-                            emptyList()
-                        }
-                    _uiState.update { current ->
-                        if (current is SettingsUiState.Content) {
-                            val enabledIds =
-                                if (enabled && current.enabledDeviceCalendarIds.isEmpty()) {
-                                    calendars.filter { it.visible }.map { it.id }.toSet()
-                                } else {
-                                    current.enabledDeviceCalendarIds
-                                }
-                            if (enabledIds != current.enabledDeviceCalendarIds) {
-                                viewModelScope.launch {
-                                    userPreferencesRepository.updateEnabledDeviceCalendarIds(enabledIds)
-                                }
-                            }
-                            current.copy(
-                                showDeviceCalendars = enabled,
-                                deviceCalendars = calendars,
-                                enabledDeviceCalendarIds = enabledIds,
-                            )
-                        } else {
-                            current
-                        }
-                    }
-                }
-            }
-        }
-
-        private fun updateDeviceCalendarEnabled(
-            calendarId: String,
-            enabled: Boolean,
-        ) {
-            viewModelScope.launch {
-                val current = (_uiState.value as? SettingsUiState.Content) ?: return@launch
-                val updatedIds =
-                    if (enabled) {
-                        current.enabledDeviceCalendarIds + calendarId
-                    } else {
-                        current.enabledDeviceCalendarIds - calendarId
-                    }
-                runCatching { userPreferencesRepository.updateEnabledDeviceCalendarIds(updatedIds) }.onSuccess {
-                    _uiState.update { state ->
-                        if (state is SettingsUiState.Content) {
-                            state.copy(enabledDeviceCalendarIds = updatedIds)
-                        } else {
-                            state
                         }
                     }
                 }

--- a/android/app/src/main/res/values-nl/strings.xml
+++ b/android/app/src/main/res/values-nl/strings.xml
@@ -65,6 +65,16 @@
     <string name="calendar_month_year">%1$s %2$s</string>
     <string name="calendar_day_detail_header">%1$s</string>
     <string name="calendar_day_empty">Geen items voor deze dag.</string>
+    <string name="calendar_device_events_header">Apparaatkalendergebeurtenissen</string>
+    <string name="calendar_device_events_empty">Geen apparaatkalendergebeurtenissen voor deze dag.</string>
+    <string name="calendar_device_events_no_calendars">Kies kalenders in Instellingen om apparaatgebeurtenissen hier te tonen.</string>
+    <string name="calendar_device_events_permission_required">Kalenderpermissie is nodig om apparaatgebeurtenissen te tonen.</string>
+    <string name="calendar_device_event_meta">%1$s • %2$s</string>
+    <string name="calendar_device_event_all_day">Hele dag</string>
+    <string name="action_open_settings">Instellingen openen</string>
+    <string name="settings_device_calendars_label">Apparaatkalenders tonen</string>
+    <string name="settings_device_calendars_hint">Lees gesynchroniseerde apparaatkalenders lokaal en toon hun gebeurtenissen in de Daynest-kalender.</string>
+    <string name="settings_device_calendars_empty">Geen leesbare apparaatkalenders gevonden.</string>
     <string name="calendar_add_planned">+ Gepland toevoegen</string>
     <string name="calendar_add_planned_title">Gepland item toevoegen</string>
     <string name="calendar_edit_planned_title">Gepland item bewerken</string>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -65,6 +65,16 @@
     <string name="calendar_month_year">%1$s %2$s</string>
     <string name="calendar_day_detail_header">%1$s</string>
     <string name="calendar_day_empty">No items for this day.</string>
+    <string name="calendar_device_events_header">Device calendar events</string>
+    <string name="calendar_device_events_empty">No device calendar events for this day.</string>
+    <string name="calendar_device_events_no_calendars">Choose calendars in Settings to show device events here.</string>
+    <string name="calendar_device_events_permission_required">Calendar permission is needed to show device events.</string>
+    <string name="calendar_device_event_meta">%1$s • %2$s</string>
+    <string name="calendar_device_event_all_day">All day</string>
+    <string name="action_open_settings">Open settings</string>
+    <string name="settings_device_calendars_label">Show device calendars</string>
+    <string name="settings_device_calendars_hint">Read synced device calendars locally and display their events in the Daynest calendar.</string>
+    <string name="settings_device_calendars_empty">No readable device calendars found.</string>
     <string name="calendar_add_planned">+ Add planned</string>
     <string name="calendar_add_planned_title">Add planned item</string>
     <string name="calendar_edit_planned_title">Edit planned item</string>

--- a/android/app/src/test/java/com/daynest/android/core/storage/preferences/UserPreferencesRepositoryTest.kt
+++ b/android/app/src/test/java/com/daynest/android/core/storage/preferences/UserPreferencesRepositoryTest.kt
@@ -25,6 +25,8 @@ class UserPreferencesRepositoryTest {
                 assertEquals(5, prefs.biometricIdleTimeoutMinutes)
                 assertEquals(true, prefs.pushNotificationsEnabled)
                 assertEquals(false, prefs.calendarSyncEnabled)
+                assertEquals(false, prefs.showDeviceCalendars)
+                assertEquals(emptySet<String>(), prefs.enabledDeviceCalendarIds)
                 cancelAndIgnoreRemainingEvents()
             }
         }
@@ -84,12 +86,18 @@ class UserPreferencesRepositoryTest {
                 repository.updatePushNotificationsEnabled(false)
                 awaitItem()
                 repository.updateCalendarSyncEnabled(true)
+                awaitItem()
+                repository.updateShowDeviceCalendars(true)
+                awaitItem()
+                repository.updateEnabledDeviceCalendarIds(setOf("1", "2"))
 
                 val updated = awaitItem()
                 assertEquals(true, updated.biometricLockEnabled)
                 assertEquals(30, updated.biometricIdleTimeoutMinutes)
                 assertEquals(false, updated.pushNotificationsEnabled)
                 assertEquals(true, updated.calendarSyncEnabled)
+                assertEquals(true, updated.showDeviceCalendars)
+                assertEquals(setOf("1", "2"), updated.enabledDeviceCalendarIds)
                 cancelAndIgnoreRemainingEvents()
             }
         }


### PR DESCRIPTION
### Motivation

- Provide an option to surface read-only device calendar events in the native Android Calendar day view so users can see system calendar items alongside Daynest planned items.
- Persist user choices (show device calendars + which device calendars to include) in DataStore so the setting survives restarts.
- Respect Android runtime permission model and show helpful UI states when permission is missing or no calendars are enabled.

### Description

- Add `DeviceCalendarRepository` to read device calendars and day instances via `CalendarContract` guarded by `READ_CALENDAR`, and typed `DeviceCalendar` / `DeviceCalendarEvent` models (new file `android/.../data/calendar/DeviceCalendarRepository.kt`).
- Extend `UserPreferences` and `UserPreferencesRepository` with `showDeviceCalendars` and `enabledDeviceCalendarIds` preferences and persistence helpers (`stringSet` key + update helpers).
- Add Settings UI and flow: a top-level toggle for "Show device calendars", per-calendar checkboxes, permission request flow, and ViewModel handling in `SettingsViewModel`/`SettingsRouteSections` to manage toggles and persist enabled calendar IDs.
- Extend calendar UI/ViewModel (`CalendarViewModel`, `CalendarRoute`) to observe preferences, load selected device calendar events for the chosen day, and render read-only device events in the day detail view with color tint, permission state messages, and open-app-settings action.
- Update localization strings (English + Dutch) for device calendar feature and add a small unit-test update for `UserPreferencesRepositoryTest` to cover the new preferences.

### Testing

- Ran `git diff --check` to validate whitespace / diff issues and it passed with no problems.
- Attempted an Android Kotlin compile with `./android/gradlew -p android :app:compileDebugKotlin`, which failed due to an environment/build configuration issue (Gradle plugin `org.gradle.toolchains.foojay-resolver-convention:1.0.0` could not be resolved from the configured repositories), so a full local build could not be completed in CI-like environment.
- Updated `UserPreferencesRepository` unit test to exercise the new preference keys, but unit tests were not executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a24b7eece1c832e8f5d702e110a5a49)