### PR TITLE
Fix Android "Unable to sign in" by dropping redundant OIDC issuer discovery

### DIFF
--- a/android/app/src/main/java/com/daynest/android/core/auth/OidcAuthService.kt
+++ b/android/app/src/main/java/com/daynest/android/core/auth/OidcAuthService.kt
@@ -118,20 +118,23 @@ class OidcAuthService
                         if (body.isBlank()) {
                             throw IOException("Empty response from OIDC config endpoint")
                         }
-                        try {
-                            val json = JSONObject(body)
-                            AuthorizationServiceConfiguration(
-                                Uri.parse(json.getString("authorization_url")),
-                                Uri.parse(json.getString("token_url")),
-                            )
-                        } catch (e: JSONException) {
-                            throw IOException("Failed to parse OIDC config response", e)
-                        }
+                        parseServiceConfiguration(body)
                     }
                 }
             serviceConfiguration = config
             return config
         }
+
+        private fun parseServiceConfiguration(body: String): AuthorizationServiceConfiguration =
+            try {
+                val json = JSONObject(body)
+                AuthorizationServiceConfiguration(
+                    Uri.parse(json.getString("authorization_url")),
+                    Uri.parse(json.getString("token_url")),
+                )
+            } catch (e: JSONException) {
+                throw IOException("Failed to parse OIDC config response", e)
+            }
 
         private fun loadPersistedState(): AuthState {
             val json = securePreferences.getString(KEY_AUTH_STATE, null) ?: return AuthState()

--- a/android/app/src/main/java/com/daynest/android/core/auth/OidcAuthService.kt
+++ b/android/app/src/main/java/com/daynest/android/core/auth/OidcAuthService.kt
@@ -21,6 +21,7 @@ import net.openid.appauth.AuthorizationServiceConfiguration
 import net.openid.appauth.ResponseTypeValues
 import okhttp3.OkHttpClient
 import okhttp3.Request
+import org.json.JSONException
 import org.json.JSONObject
 import java.io.IOException
 import javax.inject.Inject
@@ -117,11 +118,15 @@ class OidcAuthService
                         if (body.isBlank()) {
                             throw IOException("Empty response from OIDC config endpoint")
                         }
-                        val json = JSONObject(body)
-                        AuthorizationServiceConfiguration(
-                            Uri.parse(json.getString("authorization_url")),
-                            Uri.parse(json.getString("token_url")),
-                        )
+                        try {
+                            val json = JSONObject(body)
+                            AuthorizationServiceConfiguration(
+                                Uri.parse(json.getString("authorization_url")),
+                                Uri.parse(json.getString("token_url")),
+                            )
+                        } catch (e: JSONException) {
+                            throw IOException("Failed to parse OIDC config response", e)
+                        }
                     }
                 }
             serviceConfiguration = config

--- a/android/app/src/main/java/com/daynest/android/core/auth/OidcAuthService.kt
+++ b/android/app/src/main/java/com/daynest/android/core/auth/OidcAuthService.kt
@@ -27,7 +27,6 @@ import javax.inject.Inject
 import javax.inject.Named
 import javax.inject.Singleton
 import kotlin.coroutines.resume
-import kotlin.coroutines.resumeWithException
 
 @Singleton
 class OidcAuthService
@@ -44,8 +43,6 @@ class OidcAuthService
         @Volatile private var authState: AuthState = loadPersistedState()
 
         @Volatile private var serviceConfiguration: AuthorizationServiceConfiguration? = null
-
-        @Volatile private var cachedIssuerUri: Uri? = null
 
         val isAuthorized: Boolean get() = authState.isAuthorized
         val currentAccessToken: String? get() = authState.accessToken
@@ -104,10 +101,10 @@ class OidcAuthService
 
         fun signOut() = clearState()
 
-        private suspend fun resolveIssuerUri(): Uri {
-            cachedIssuerUri?.let { return it }
+        private suspend fun discoverServiceConfiguration(): AuthorizationServiceConfiguration {
+            serviceConfiguration?.let { return it }
             val url = "${serverUrlHolder.currentUrl.trimEnd('/')}/$OIDC_CONFIG_PATH"
-            val issuer =
+            val config =
                 withContext(Dispatchers.IO) {
                     val request = Request.Builder().url(url).build()
                     discoveryClient.newCall(request).execute().use { response ->
@@ -120,25 +117,15 @@ class OidcAuthService
                         if (body.isBlank()) {
                             throw IOException("Empty response from OIDC config endpoint")
                         }
-                        JSONObject(body).getString("issuer")
+                        val json = JSONObject(body)
+                        AuthorizationServiceConfiguration(
+                            Uri.parse(json.getString("authorization_url")),
+                            Uri.parse(json.getString("token_url")),
+                        )
                     }
                 }
-            return Uri.parse(issuer).also { cachedIssuerUri = it }
-        }
-
-        private suspend fun discoverServiceConfiguration(): AuthorizationServiceConfiguration {
-            serviceConfiguration?.let { return it }
-            val issuerUri = resolveIssuerUri()
-            return suspendCancellableCoroutine { cont ->
-                AuthorizationServiceConfiguration.fetchFromIssuer(issuerUri) { config, ex ->
-                    if (config != null) {
-                        serviceConfiguration = config
-                        cont.resume(config)
-                    } else {
-                        cont.resumeWithException(ex ?: IllegalStateException("OIDC discovery failed"))
-                    }
-                }
-            }
+            serviceConfiguration = config
+            return config
         }
 
         private fun loadPersistedState(): AuthState {


### PR DESCRIPTION
## Summary
- The Android app's sign-in flow fetched `authorization_url`/`token_url` from the backend's `/api/v1/auth/oidc-config` endpoint, then discarded them and made a *second*, independent request straight from the device to `{issuer}/.well-known/openid-configuration` via AppAuth's `fetchFromIssuer()`.
- That second hop requires the raw OIDC issuer host (Keycloak) to be reachable directly from the phone. In self-hosted/dev setups where Keycloak sits behind an internal-only address (e.g. `http://keycloak:8080/realms/daynest` in `backend/env/dev.env`) that the backend can reach but the device can't, this fails before the browser ever opens — matching the "Unable to sign in. Please try again." error shown immediately on the sign-in screen.
- `OidcAuthService.discoverServiceConfiguration()` now builds the `AuthorizationServiceConfiguration` directly from the `authorization_url`/`token_url` already returned by our own backend (a host the device has already proven it can reach), removing the redundant network dependency entirely.

## Test plan
- [ ] Manual: sign in against a deployment where the OIDC issuer host isn't independently reachable from the device, confirm sign-in now proceeds to the browser instead of failing immediately.
- [ ] Manual: sign in against a normal deployment, confirm the full OAuth code flow still completes and the app reaches the signed-in state.
- Not run in this environment: no network access to download the Gradle distribution/dependencies, so the Kotlin compiler couldn't be run here to verify the build.


---
_Generated by [Claude Code](https://claude.ai/code/session_01TGb9mcAXwuWh6D4PoUHSsc)_