### PR TITLE
Align Android applicationId with tjor.im domain convention

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -92,7 +92,11 @@ fun versionCodeFor(version: String): Int {
 }
 
 val gitCommit =
-    providers.exec { commandLine("git", "rev-parse", "--short", "HEAD") }.standardOutput.asText.get().trim()
+    providers.exec { commandLine("git", "rev-parse", "--short", "HEAD") }
+        .standardOutput
+        .asText
+        .get()
+        .trim()
 
 extensions.configure<ApplicationExtension> {
     namespace = "com.daynest.android"

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -123,7 +123,7 @@ extensions.configure<ApplicationExtension> {
     }
 
     defaultConfig {
-        applicationId = "com.daynest.android"
+        applicationId = "im.tjor.daynest"
         minSdk = 26
         targetSdk = 37
         // versionCode = MAJOR * 1000000 + MINOR * 1000 + PATCH (e.g. v1.2.3 → 1002003)
@@ -150,7 +150,7 @@ extensions.configure<ApplicationExtension> {
             buildConfigField("String[]", "CERTIFICATE_PINS", "new String[]{}")
             buildConfigField("String", "CERTIFICATE_PIN_HOST", "\"\"")
             buildConfigField("String", "OIDC_CLIENT_ID", "\"daynest\"")
-            buildConfigField("String", "OIDC_REDIRECT_URI", "\"com.daynest.android:/oauth2redirect\"")
+            buildConfigField("String", "OIDC_REDIRECT_URI", "\"im.tjor.daynest:/oauth2redirect\"")
         }
         release {
             isMinifyEnabled = true
@@ -206,7 +206,7 @@ extensions.configure<ApplicationExtension> {
             buildConfigField("String[]", "CERTIFICATE_PINS", CertPinning.pinsArrayLiteral(pins))
             buildConfigField("String", "CERTIFICATE_PIN_HOST", "\"$releaseCertificatePinHost\"")
             buildConfigField("String", "OIDC_CLIENT_ID", "\"daynest\"")
-            buildConfigField("String", "OIDC_REDIRECT_URI", "\"com.daynest.android:/oauth2redirect\"")
+            buildConfigField("String", "OIDC_REDIRECT_URI", "\"im.tjor.daynest:/oauth2redirect\"")
         }
     }
 

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -92,7 +92,8 @@ fun versionCodeFor(version: String): Int {
 }
 
 val gitCommit =
-    providers.exec { commandLine("git", "rev-parse", "--short", "HEAD") }
+    providers
+        .exec { commandLine("git", "rev-parse", "--short", "HEAD") }
         .standardOutput
         .asText
         .get()

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -43,7 +43,7 @@
                 <action android:name="android.intent.action.VIEW" />
                 <category android:name="android.intent.category.DEFAULT" />
                 <category android:name="android.intent.category.BROWSABLE" />
-                <data android:scheme="com.daynest.android" />
+                <data android:scheme="im.tjor.daynest" />
             </intent-filter>
         </activity>
         <service

--- a/android/wear/build.gradle.kts
+++ b/android/wear/build.gradle.kts
@@ -35,7 +35,7 @@ extensions.configure<ApplicationExtension> {
     compileSdk = 37
 
     defaultConfig {
-        applicationId = "com.daynest.android.wear"
+        applicationId = "im.tjor.daynest.wear"
         minSdk = 26
         targetSdk = 37
         versionCode = 1


### PR DESCRIPTION
## Summary
- \`applicationId\`: \`com.daynest.android\` → \`im.tjor.daynest\` (wear module: \`im.tjor.daynest.wear\`)
- OAuth redirect scheme (manifest + \`OIDC_REDIRECT_URI\` BuildConfig field, both debug and release) updated to match
- \`namespace\` (Kotlin source package) is untouched — no source files move

Closes #579

**Depends on:** tjorim/apps's Keycloak redirect URI update landing first, or logins on this build will fail.

## Test plan
- [ ] CI run on this branch builds successfully
- [ ] After merge + Keycloak update, verify OIDC login still works on a fresh install