### PR TITLE
Add account deletion flow

### DIFF
--- a/android/app/src/main/java/com/daynest/android/data/settings/SettingsApi.kt
+++ b/android/app/src/main/java/com/daynest/android/data/settings/SettingsApi.kt
@@ -20,6 +20,9 @@ interface SettingsApi {
 
     @DELETE("api/v1/auth/sessions/{id}")
     suspend fun revokeSession(@Path("id") id: String)
+
+    @DELETE("api/v1/users/me")
+    suspend fun deleteCurrentUser()
 }
 
 @Serializable

--- a/android/app/src/main/java/com/daynest/android/data/settings/SettingsRepository.kt
+++ b/android/app/src/main/java/com/daynest/android/data/settings/SettingsRepository.kt
@@ -16,4 +16,6 @@ constructor(private val settingsApi: SettingsApi) {
     suspend fun listSessions(): Result<List<OAuthSessionDto>> = safeApiCall { settingsApi.listSessions() }
 
     suspend fun revokeSession(id: String): Result<Unit> = safeApiCall { settingsApi.revokeSession(id) }
+
+    suspend fun deleteCurrentUser(): Result<Unit> = safeApiCall { settingsApi.deleteCurrentUser() }
 }

--- a/android/app/src/main/java/com/daynest/android/feature/settings/SettingsAccountCards.kt
+++ b/android/app/src/main/java/com/daynest/android/feature/settings/SettingsAccountCards.kt
@@ -1,0 +1,88 @@
+package com.daynest.android.feature.settings
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Card
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import com.daynest.android.R
+
+@Composable
+internal fun accountSessionCard(onEvent: (SettingsUiEvent) -> Unit) {
+    Card(modifier = Modifier.fillMaxWidth()) {
+        Row(
+            modifier =
+            Modifier
+                .fillMaxWidth()
+                .padding(12.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Text(
+                text = stringResource(id = R.string.settings_session_active),
+                style = MaterialTheme.typography.bodyMedium,
+                modifier = Modifier.weight(1f)
+            )
+            TextButton(onClick = { onEvent(SettingsUiEvent.SignOutClicked) }) {
+                Text(
+                    text = stringResource(id = R.string.settings_sign_out),
+                    color = MaterialTheme.colorScheme.error
+                )
+            }
+        }
+    }
+}
+
+@Composable
+internal fun deleteAccountCard(state: SettingsUiState.Content, onEvent: (SettingsUiEvent) -> Unit) {
+    Card(modifier = Modifier.fillMaxWidth()) {
+        Column(
+            modifier =
+            Modifier
+                .fillMaxWidth()
+                .padding(12.dp),
+            verticalArrangement = Arrangement.spacedBy(4.dp)
+        ) {
+            Text(
+                text = stringResource(id = R.string.settings_delete_account_title),
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.error
+            )
+            Text(
+                text = stringResource(id = R.string.settings_delete_account_hint),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.outline
+            )
+            state.accountDeletionError?.let { message ->
+                Text(
+                    text = message,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.error
+                )
+            }
+            TextButton(
+                onClick = { onEvent(SettingsUiEvent.ShowDeleteAccountDialog) },
+                enabled = !state.isDeletingAccount,
+                colors = ButtonDefaults.textButtonColors(contentColor = MaterialTheme.colorScheme.error)
+            ) {
+                Text(text = deleteAccountActionText(state.isDeletingAccount))
+            }
+        }
+    }
+}
+
+@Composable
+private fun deleteAccountActionText(isDeletingAccount: Boolean): String = if (isDeletingAccount) {
+    stringResource(id = R.string.settings_delete_account_deleting)
+} else {
+    stringResource(id = R.string.settings_delete_account_action)
+}

--- a/android/app/src/main/java/com/daynest/android/feature/settings/SettingsRoute.kt
+++ b/android/app/src/main/java/com/daynest/android/feature/settings/SettingsRoute.kt
@@ -141,20 +141,23 @@ private fun SettingsContent(
         settingsSessionsSection(state, onEvent)
     }
 
+    SettingsDialogs(state = state, onEvent = onEvent)
+}
+
+@Composable
+private fun SettingsDialogs(state: SettingsUiState.Content, onEvent: (SettingsUiEvent) -> Unit) {
     if (state.showCreateForm) {
         CreateClientDialog(
             onConfirm = { onEvent(SettingsUiEvent.CreateClient(it)) },
             onDismiss = { onEvent(SettingsUiEvent.DismissCreateClientForm) }
         )
     }
-
     if (state.newApiKey != null) {
         NewApiKeyDialog(
             apiKey = state.newApiKey,
             onDismiss = { onEvent(SettingsUiEvent.DismissNewKeyDialog) }
         )
     }
-
     if (state.showDeleteAccountConfirm) {
         DeleteAccountDialog(
             isDeleting = state.isDeletingAccount,

--- a/android/app/src/main/java/com/daynest/android/feature/settings/SettingsRoute.kt
+++ b/android/app/src/main/java/com/daynest/android/feature/settings/SettingsRoute.kt
@@ -136,7 +136,7 @@ private fun SettingsContent(
             deviceCalendarPermissionLauncher = deviceCalendarPermissionLauncher,
             onEvent = onEvent
         )
-        settingsAccountSection(onEvent)
+        settingsAccountSection(state, onEvent)
         settingsClientsSection(state, onEvent)
         settingsSessionsSection(state, onEvent)
     }
@@ -152,6 +152,14 @@ private fun SettingsContent(
         NewApiKeyDialog(
             apiKey = state.newApiKey,
             onDismiss = { onEvent(SettingsUiEvent.DismissNewKeyDialog) }
+        )
+    }
+
+    if (state.showDeleteAccountConfirm) {
+        DeleteAccountDialog(
+            isDeleting = state.isDeletingAccount,
+            onConfirm = { onEvent(SettingsUiEvent.DeleteAccountConfirmed) },
+            onDismiss = { onEvent(SettingsUiEvent.DismissDeleteAccountDialog) }
         )
     }
 }
@@ -341,6 +349,27 @@ private fun NewApiKeyDialog(apiKey: String, onDismiss: () -> Unit) {
         confirmButton = {
             TextButton(onClick = onDismiss) {
                 Text(text = stringResource(id = R.string.settings_new_key_dismiss))
+            }
+        }
+    )
+}
+
+@Composable
+private fun DeleteAccountDialog(isDeleting: Boolean, onConfirm: () -> Unit, onDismiss: () -> Unit) {
+    AlertDialog(
+        onDismissRequest = {
+            if (!isDeleting) onDismiss()
+        },
+        title = { Text(text = stringResource(id = R.string.settings_delete_account_title)) },
+        text = { Text(text = stringResource(id = R.string.settings_delete_account_confirm)) },
+        confirmButton = {
+            TextButton(onClick = onConfirm, enabled = !isDeleting) {
+                Text(text = stringResource(id = R.string.settings_delete_account_confirm_action))
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss, enabled = !isDeleting) {
+                Text(text = stringResource(id = R.string.action_cancel))
             }
         }
     )

--- a/android/app/src/main/java/com/daynest/android/feature/settings/SettingsRouteSections.kt
+++ b/android/app/src/main/java/com/daynest/android/feature/settings/SettingsRouteSections.kt
@@ -13,6 +13,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyListScope
 import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Card
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
@@ -112,7 +113,7 @@ private fun LazyListScope.settingsBiometricItems(state: SettingsUiState.Content,
     }
 }
 
-internal fun LazyListScope.settingsAccountSection(onEvent: (SettingsUiEvent) -> Unit) {
+internal fun LazyListScope.settingsAccountSection(state: SettingsUiState.Content, onEvent: (SettingsUiEvent) -> Unit) {
     item {
         HorizontalDivider(modifier = Modifier.padding(vertical = 4.dp))
         Text(
@@ -138,6 +139,49 @@ internal fun LazyListScope.settingsAccountSection(onEvent: (SettingsUiEvent) -> 
                     Text(
                         text = stringResource(id = R.string.settings_sign_out),
                         color = MaterialTheme.colorScheme.error
+                    )
+                }
+            }
+        }
+    }
+    item {
+        Card(modifier = Modifier.fillMaxWidth()) {
+            Column(
+                modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .padding(12.dp),
+                verticalArrangement = Arrangement.spacedBy(4.dp)
+            ) {
+                Text(
+                    text = stringResource(id = R.string.settings_delete_account_title),
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.error
+                )
+                Text(
+                    text = stringResource(id = R.string.settings_delete_account_hint),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.outline
+                )
+                state.accountDeletionError?.let { message ->
+                    Text(
+                        text = message,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.error
+                    )
+                }
+                TextButton(
+                    onClick = { onEvent(SettingsUiEvent.ShowDeleteAccountDialog) },
+                    enabled = !state.isDeletingAccount,
+                    colors = ButtonDefaults.textButtonColors(contentColor = MaterialTheme.colorScheme.error)
+                ) {
+                    Text(
+                        text =
+                        if (state.isDeletingAccount) {
+                            stringResource(id = R.string.settings_delete_account_deleting)
+                        } else {
+                            stringResource(id = R.string.settings_delete_account_action)
+                        }
                     )
                 }
             }

--- a/android/app/src/main/java/com/daynest/android/feature/settings/SettingsRouteSections.kt
+++ b/android/app/src/main/java/com/daynest/android/feature/settings/SettingsRouteSections.kt
@@ -13,7 +13,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyListScope
 import androidx.compose.foundation.lazy.items
-import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Card
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
@@ -122,70 +121,10 @@ internal fun LazyListScope.settingsAccountSection(state: SettingsUiState.Content
         )
     }
     item {
-        Card(modifier = Modifier.fillMaxWidth()) {
-            Row(
-                modifier =
-                Modifier
-                    .fillMaxWidth()
-                    .padding(12.dp),
-                verticalAlignment = Alignment.CenterVertically
-            ) {
-                Text(
-                    text = stringResource(id = R.string.settings_session_active),
-                    style = MaterialTheme.typography.bodyMedium,
-                    modifier = Modifier.weight(1f)
-                )
-                TextButton(onClick = { onEvent(SettingsUiEvent.SignOutClicked) }) {
-                    Text(
-                        text = stringResource(id = R.string.settings_sign_out),
-                        color = MaterialTheme.colorScheme.error
-                    )
-                }
-            }
-        }
+        accountSessionCard(onEvent = onEvent)
     }
     item {
-        Card(modifier = Modifier.fillMaxWidth()) {
-            Column(
-                modifier =
-                Modifier
-                    .fillMaxWidth()
-                    .padding(12.dp),
-                verticalArrangement = Arrangement.spacedBy(4.dp)
-            ) {
-                Text(
-                    text = stringResource(id = R.string.settings_delete_account_title),
-                    style = MaterialTheme.typography.bodyMedium,
-                    color = MaterialTheme.colorScheme.error
-                )
-                Text(
-                    text = stringResource(id = R.string.settings_delete_account_hint),
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.outline
-                )
-                state.accountDeletionError?.let { message ->
-                    Text(
-                        text = message,
-                        style = MaterialTheme.typography.bodySmall,
-                        color = MaterialTheme.colorScheme.error
-                    )
-                }
-                TextButton(
-                    onClick = { onEvent(SettingsUiEvent.ShowDeleteAccountDialog) },
-                    enabled = !state.isDeletingAccount,
-                    colors = ButtonDefaults.textButtonColors(contentColor = MaterialTheme.colorScheme.error)
-                ) {
-                    Text(
-                        text =
-                        if (state.isDeletingAccount) {
-                            stringResource(id = R.string.settings_delete_account_deleting)
-                        } else {
-                            stringResource(id = R.string.settings_delete_account_action)
-                        }
-                    )
-                }
-            }
-        }
+        deleteAccountCard(state = state, onEvent = onEvent)
     }
 }
 

--- a/android/app/src/main/java/com/daynest/android/feature/settings/SettingsViewModel.kt
+++ b/android/app/src/main/java/com/daynest/android/feature/settings/SettingsViewModel.kt
@@ -19,6 +19,7 @@ import com.daynest.android.data.settings.SettingsRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
 import javax.inject.Inject
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.async
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -224,9 +225,13 @@ constructor(
     private fun deleteCurrentAccount() {
         viewModelScope.launch {
             updateContent { it.copy(isDeletingAccount = true, accountDeletionError = null) }
+            try {
+                pushRegistrationManager.unregisterAllKnownEndpoints()
+            } catch (error: Exception) {
+                if (error is CancellationException) throw error
+            }
             settingsRepository.deleteCurrentUser()
                 .onSuccess {
-                    runCatching { pushRegistrationManager.unregisterAllKnownEndpoints() }
                     oidcAuthService.signOut()
                     _uiState.value = SettingsUiState.SignedOut
                 }

--- a/android/app/src/main/java/com/daynest/android/feature/settings/SettingsViewModel.kt
+++ b/android/app/src/main/java/com/daynest/android/feature/settings/SettingsViewModel.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.daynest.android.BuildConfig
+import com.daynest.android.R
 import com.daynest.android.core.auth.OidcAuthService
 import com.daynest.android.core.storage.ApiBaseUrlOverrideStore
 import com.daynest.android.core.storage.preferences.UserPreferencesRepository
@@ -65,6 +66,11 @@ constructor(
             SettingsUiEvent.ShowCreateClientForm -> updateContent { it.copy(showCreateForm = true) }
             SettingsUiEvent.DismissCreateClientForm -> updateContent { it.copy(showCreateForm = false) }
             SettingsUiEvent.DismissNewKeyDialog -> updateContent { it.copy(newApiKey = null) }
+            SettingsUiEvent.ShowDeleteAccountDialog -> updateContent {
+                it.copy(showDeleteAccountConfirm = true, accountDeletionError = null)
+            }
+            SettingsUiEvent.DismissDeleteAccountDialog -> updateContent { it.copy(showDeleteAccountConfirm = false) }
+            SettingsUiEvent.DeleteAccountConfirmed -> deleteCurrentAccount()
             is SettingsUiEvent.CreateClient -> createClient(event.input)
             is SettingsUiEvent.UpdateServerUrl -> updateServerUrl(event.url)
             is SettingsUiEvent.RevokeSessionClicked -> revokeSession(event.sessionId)
@@ -100,6 +106,9 @@ constructor(
                     sessions = sessionsResult.getOrElse { emptyList() },
                     showCreateForm = false,
                     newApiKey = null,
+                    showDeleteAccountConfirm = false,
+                    isDeletingAccount = false,
+                    accountDeletionError = null,
                     clientsLoadError = clientsResult.isFailure,
                     sessionsLoadError = sessionsResult.isFailure,
                     customServerUrl = customServerUrl,
@@ -212,6 +221,28 @@ constructor(
         }
     }
 
+    private fun deleteCurrentAccount() {
+        viewModelScope.launch {
+            updateContent { it.copy(isDeletingAccount = true, accountDeletionError = null) }
+            settingsRepository.deleteCurrentUser()
+                .onSuccess {
+                    runCatching { pushRegistrationManager.unregisterAllKnownEndpoints() }
+                    oidcAuthService.signOut()
+                    _uiState.value = SettingsUiState.SignedOut
+                }
+                .onFailure { error ->
+                    updateContent {
+                        it.copy(
+                            showDeleteAccountConfirm = false,
+                            isDeletingAccount = false,
+                            accountDeletionError =
+                            error.message ?: appContext.getString(R.string.settings_delete_account_error)
+                        )
+                    }
+                }
+        }
+    }
+
     private fun updateContent(transform: (SettingsUiState.Content) -> SettingsUiState.Content) {
         _uiState.update { current ->
             if (current is SettingsUiState.Content) transform(current) else current
@@ -234,6 +265,9 @@ sealed interface SettingsUiState {
         val sessions: List<OAuthSessionDto> = emptyList(),
         val showCreateForm: Boolean,
         val newApiKey: String?,
+        val showDeleteAccountConfirm: Boolean,
+        val isDeletingAccount: Boolean,
+        val accountDeletionError: String?,
         val clientsLoadError: Boolean,
         val sessionsLoadError: Boolean,
         val customServerUrl: String?,
@@ -260,6 +294,12 @@ sealed interface SettingsUiEvent {
     data object DismissCreateClientForm : SettingsUiEvent
 
     data object DismissNewKeyDialog : SettingsUiEvent
+
+    data object ShowDeleteAccountDialog : SettingsUiEvent
+
+    data object DismissDeleteAccountDialog : SettingsUiEvent
+
+    data object DeleteAccountConfirmed : SettingsUiEvent
 
     data class CreateClient(val input: IntegrationClientInputDto) : SettingsUiEvent
 

--- a/android/app/src/main/java/com/daynest/android/feature/settings/SettingsViewModel.kt
+++ b/android/app/src/main/java/com/daynest/android/feature/settings/SettingsViewModel.kt
@@ -19,7 +19,6 @@ import com.daynest.android.data.settings.SettingsRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
 import javax.inject.Inject
-import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.async
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -225,11 +224,7 @@ constructor(
     private fun deleteCurrentAccount() {
         viewModelScope.launch {
             updateContent { it.copy(isDeletingAccount = true, accountDeletionError = null) }
-            try {
-                pushRegistrationManager.unregisterAllKnownEndpoints()
-            } catch (error: Exception) {
-                if (error is CancellationException) throw error
-            }
+            pushRegistrationManager.unregisterAllKnownEndpoints()
             settingsRepository.deleteCurrentUser()
                 .onSuccess {
                     oidcAuthService.signOut()
@@ -253,14 +248,14 @@ constructor(
             if (current is SettingsUiState.Content) transform(current) else current
         }
     }
-
-    private fun IntegrationClientCreateResponseDto.toDto() = IntegrationClientDto(
-        id = id,
-        name = name,
-        rateLimitPerMinute = rateLimitPerMinute,
-        isActive = isActive
-    )
 }
+
+private fun IntegrationClientCreateResponseDto.toDto() = IntegrationClientDto(
+    id = id,
+    name = name,
+    rateLimitPerMinute = rateLimitPerMinute,
+    isActive = isActive
+)
 
 sealed interface SettingsUiState {
     data object Loading : SettingsUiState

--- a/android/app/src/main/res/values-nl/strings.xml
+++ b/android/app/src/main/res/values-nl/strings.xml
@@ -185,6 +185,13 @@
     <string name="settings_account_section">Account</string>
     <string name="settings_session_active">Aangemeld</string>
     <string name="settings_sign_out">Afmelden</string>
+    <string name="settings_delete_account_title">Account verwijderen</string>
+    <string name="settings_delete_account_hint">Verwijder uw Daynest-account en persoonlijke gegevens permanent. Gedeelde huishoudelijke klusjes moeten eerst worden verwijderd, overgedragen of verlaten.</string>
+    <string name="settings_delete_account_action">Mijn account verwijderen</string>
+    <string name="settings_delete_account_deleting">Verwijderen…</string>
+    <string name="settings_delete_account_confirm">Dit verwijdert uw Daynest-account en persoonlijke gegevens permanent. Dit kan niet ongedaan worden gemaakt.</string>
+    <string name="settings_delete_account_confirm_action">Account verwijderen</string>
+    <string name="settings_delete_account_error">Kan account niet verwijderen. Probeer het opnieuw.</string>
     <string name="settings_integrations_section">Integratieclients</string>
     <string name="settings_new_client">+ Nieuwe client</string>
     <string name="settings_no_clients">Geen integratieclients geconfigureerd.</string>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -185,6 +185,13 @@
     <string name="settings_account_section">Account</string>
     <string name="settings_session_active">Signed in</string>
     <string name="settings_sign_out">Sign out</string>
+    <string name="settings_delete_account_title">Delete account</string>
+    <string name="settings_delete_account_hint">Permanently delete your Daynest account and personal data. Household-shared chores must be deleted, transferred, or left first.</string>
+    <string name="settings_delete_account_action">Delete my account</string>
+    <string name="settings_delete_account_deleting">Deleting…</string>
+    <string name="settings_delete_account_confirm">This permanently deletes your Daynest account and personal data. This cannot be undone.</string>
+    <string name="settings_delete_account_confirm_action">Delete account</string>
+    <string name="settings_delete_account_error">Unable to delete account. Please try again.</string>
     <string name="settings_integrations_section">Integration Clients</string>
     <string name="settings_new_client">+ New client</string>
     <string name="settings_no_clients">No integration clients configured.</string>

--- a/backend/app/api/routes/users.py
+++ b/backend/app/api/routes/users.py
@@ -2,7 +2,7 @@ from typing import Any
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 from fastapi import APIRouter, Body, Depends, HTTPException, Query, Response, status
-from sqlalchemy import exists, select
+from sqlalchemy import select
 from sqlalchemy.orm import Session
 
 from app.api.dependencies.auth import get_current_user
@@ -17,21 +17,16 @@ router = APIRouter(prefix="/users", tags=["users"])
 
 
 def _has_household_shared_chores(db: Session, user_id: int) -> bool:
-    other_household_member = (
-        select(HouseholdMember.id)
-        .where(HouseholdMember.household_id == ChoreTemplate.household_id)
-        .where(HouseholdMember.user_id != user_id)
+    stmt = (
+        select(ChoreTemplate.id)
+        .join(HouseholdMember, HouseholdMember.household_id == ChoreTemplate.household_id)
+        .where(
+            ChoreTemplate.user_id == user_id,
+            HouseholdMember.user_id != user_id,
+        )
         .exists()
     )
-    return db.scalar(
-        select(
-            exists().where(
-                ChoreTemplate.user_id == user_id,
-                ChoreTemplate.household_id.is_not(None),
-                other_household_member,
-            )
-        )
-    ) or False
+    return db.scalar(select(stmt)) or False
 
 
 def _to_response(user: User) -> UserSettingsResponse:

--- a/backend/app/api/routes/users.py
+++ b/backend/app/api/routes/users.py
@@ -2,15 +2,36 @@ from typing import Any
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 from fastapi import APIRouter, Body, Depends, HTTPException, Query, Response, status
+from sqlalchemy import exists, select
 from sqlalchemy.orm import Session
 
 from app.api.dependencies.auth import get_current_user
 from app.db.session import get_db
+from app.models.chore_template import ChoreTemplate
+from app.models.household_member import HouseholdMember
 from app.models.user import User
 from app.schemas.users import UserSettingsPatchRequest, UserSettingsResponse
 from app.services.export_import_service import build_user_export, import_user_export, user_export_to_csv
 
 router = APIRouter(prefix="/users", tags=["users"])
+
+
+def _has_household_shared_chores(db: Session, user_id: int) -> bool:
+    other_household_member = (
+        select(HouseholdMember.id)
+        .where(HouseholdMember.household_id == ChoreTemplate.household_id)
+        .where(HouseholdMember.user_id != user_id)
+        .exists()
+    )
+    return db.scalar(
+        select(
+            exists().where(
+                ChoreTemplate.user_id == user_id,
+                ChoreTemplate.household_id.is_not(None),
+                other_household_member,
+            )
+        )
+    ) or False
 
 
 def _to_response(user: User) -> UserSettingsResponse:
@@ -87,3 +108,22 @@ def import_user_data(
 ) -> dict[str, Any]:
     counts = import_user_export(db, current_user, payload, replace=replace)
     return {"imported": counts}
+
+
+@router.delete("/me", status_code=status.HTTP_204_NO_CONTENT)
+def delete_current_user(
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+) -> Response:
+    if _has_household_shared_chores(db, current_user.id):
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=(
+                "Account deletion is blocked while you own household-shared chores. "
+                "Delete or transfer those chores, or leave shared households before deleting your account."
+            ),
+        )
+
+    db.delete(current_user)
+    db.commit()
+    return Response(status_code=status.HTTP_204_NO_CONTENT)

--- a/backend/app/api/routes/users.py
+++ b/backend/app/api/routes/users.py
@@ -3,9 +3,10 @@ from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 from fastapi import APIRouter, Body, Depends, HTTPException, Query, Response, status
 from sqlalchemy import select
-from sqlalchemy.orm import Session
+from sqlalchemy.orm import Session, aliased
 
 from app.api.dependencies.auth import get_current_user
+from app.core.enums import HouseholdMemberRole
 from app.db.session import get_db
 from app.models.chore_template import ChoreTemplate
 from app.models.household_member import HouseholdMember
@@ -23,6 +24,41 @@ def _has_household_shared_chores(db: Session, user_id: int) -> bool:
         .where(
             ChoreTemplate.user_id == user_id,
             HouseholdMember.user_id != user_id,
+        )
+        .exists()
+    )
+    return db.scalar(select(stmt)) or False
+
+
+def _is_sole_owner_of_shared_household(db: Session, user_id: int) -> bool:
+    owner = aliased(HouseholdMember)
+    other_member = aliased(HouseholdMember)
+    other_owner = aliased(HouseholdMember)
+
+    has_other_member = (
+        select(other_member.id)
+        .where(
+            other_member.household_id == owner.household_id,
+            other_member.user_id != user_id,
+        )
+        .exists()
+    )
+    has_other_owner = (
+        select(other_owner.id)
+        .where(
+            other_owner.household_id == owner.household_id,
+            other_owner.user_id != user_id,
+            other_owner.role == HouseholdMemberRole.owner,
+        )
+        .exists()
+    )
+    stmt = (
+        select(owner.id)
+        .where(
+            owner.user_id == user_id,
+            owner.role == HouseholdMemberRole.owner,
+            has_other_member,
+            ~has_other_owner,
         )
         .exists()
     )
@@ -116,6 +152,15 @@ def delete_current_user(
             detail=(
                 "Account deletion is blocked while you own household-shared chores. "
                 "Delete or transfer those chores, or leave shared households before deleting your account."
+            ),
+        )
+
+    if _is_sole_owner_of_shared_household(db, current_user.id):
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=(
+                "Account deletion is blocked while you are the sole owner of a shared household. "
+                "Transfer ownership, remove the other members, or delete the household before deleting your account."
             ),
         )
 

--- a/backend/tests/test_users.py
+++ b/backend/tests/test_users.py
@@ -81,3 +81,23 @@ def test_delete_current_user_blocks_household_shared_chores(client: TestClient, 
     assert response.status_code == 409
     assert "household-shared chores" in response.json()["detail"]
     assert db_session.get(User, owner.id) is not None
+
+
+def test_delete_current_user_blocks_sole_owner_of_shared_household(client: TestClient, db_session: Session) -> None:
+    owner = _create_user(db_session, "sole-owner@example.com")
+    member = _create_user(db_session, "ownerless-member@example.com")
+    household = Household(name="Shared home")
+    db_session.add(household)
+    db_session.flush()
+    db_session.add_all([
+        HouseholdMember(household_id=household.id, user_id=owner.id, role="owner"),
+        HouseholdMember(household_id=household.id, user_id=member.id, role="member"),
+    ])
+    db_session.commit()
+    _auth_as(owner)
+
+    response = client.delete("/api/users/me")
+
+    assert response.status_code == 409
+    assert "sole owner" in response.json()["detail"]
+    assert db_session.get(User, owner.id) is not None

--- a/backend/tests/test_users.py
+++ b/backend/tests/test_users.py
@@ -1,0 +1,83 @@
+"""Tests for user account settings and deletion endpoints."""
+
+from datetime import date, time
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+from app.api.dependencies.auth import get_current_user
+from app.main import app
+from app.models.chore_template import ChoreTemplate
+from app.models.household import Household
+from app.models.household_member import HouseholdMember
+from app.models.medication_plan import MedicationPlan
+from app.models.user import User
+
+
+def _create_user(db_session: Session, email: str) -> User:
+    user = User(email=email, full_name="Test User", is_active=True)
+    db_session.add(user)
+    db_session.commit()
+    db_session.refresh(user)
+    return user
+
+
+def _auth_as(user: User) -> None:
+    async def _dep() -> User:
+        return user
+
+    app.dependency_overrides[get_current_user] = _dep
+
+
+def _clear_auth() -> None:
+    app.dependency_overrides.pop(get_current_user, None)
+
+
+@pytest.fixture(autouse=True)
+def clear_auth_override():
+    yield
+    _clear_auth()
+
+
+def test_delete_current_user_removes_personal_data(client: TestClient, db_session: Session) -> None:
+    user = _create_user(db_session, "delete-me@example.com")
+    plan = MedicationPlan(user_id=user.id, name="Vitamin D", instructions="Take daily", start_date=date.today(), schedule_time=time(8, 0))
+    db_session.add(plan)
+    db_session.commit()
+    _auth_as(user)
+
+    response = client.delete("/api/users/me")
+
+    assert response.status_code == 204
+    assert db_session.get(User, user.id) is None
+    assert db_session.get(MedicationPlan, plan.id) is None
+
+
+def test_delete_current_user_blocks_household_shared_chores(client: TestClient, db_session: Session) -> None:
+    owner = _create_user(db_session, "shared-owner@example.com")
+    member = _create_user(db_session, "shared-member@example.com")
+    household = Household(name="Shared home")
+    db_session.add(household)
+    db_session.flush()
+    db_session.add_all([
+        HouseholdMember(household_id=household.id, user_id=owner.id, role="owner"),
+        HouseholdMember(household_id=household.id, user_id=member.id, role="member"),
+    ])
+    db_session.add(
+        ChoreTemplate(
+            user_id=owner.id,
+            household_id=household.id,
+            name="Shared dishes",
+            start_date=date.today(),
+            every_n_days=1,
+        )
+    )
+    db_session.commit()
+    _auth_as(owner)
+
+    response = client.delete("/api/users/me")
+
+    assert response.status_code == 409
+    assert "household-shared chores" in response.json()["detail"]
+    assert db_session.get(User, owner.id) is not None

--- a/docs/play-store/data_safety.csv
+++ b/docs/play-store/data_safety.csv
@@ -8,11 +8,11 @@ PSL_SUPPORTED_ACCOUNT_CREATION_METHODS,PSL_ACM_OAUTH,,MULTIPLE_CHOICE,Which of t
 PSL_SUPPORTED_ACCOUNT_CREATION_METHODS,PSL_ACM_OTHER,,MULTIPLE_CHOICE,Which of the following methods of account creation does your app support? Select all that apply/Other
 PSL_SUPPORTED_ACCOUNT_CREATION_METHODS,PSL_ACM_NONE,true,MULTIPLE_CHOICE,Which of the following methods of account creation does your app support? Select all that apply/My app does not allow users to create an account
 PSL_ACM_SPECIFY,,,MAYBE_REQUIRED,Describe the method of account creation that your app supports
-PSL_ACCOUNT_DELETION_URL,https://daynest.app/settings,,MAYBE_REQUIRED,Add a link that users can use to request that their account and associated data be deleted
+PSL_ACCOUNT_DELETION_URL,,https://daynest.app/settings,MAYBE_REQUIRED,Add a link that users can use to request that their account and associated data be deleted
 PSL_SUPPORT_DATA_DELETION_BY_USER,DATA_DELETION_YES,true,SINGLE_CHOICE,Do you provide a way for users to request that their data is deleted?/Yes
 PSL_SUPPORT_DATA_DELETION_BY_USER,DATA_DELETION_NO,,SINGLE_CHOICE,Do you provide a way for users to request that their data is deleted?/No
 PSL_SUPPORT_DATA_DELETION_BY_USER,DATA_DELETION_NO_AUTO_DELETED,,SINGLE_CHOICE,"Do you provide a way for users to request that their data is deleted?/No, but user data is automatically deleted within 90 days"
-PSL_DATA_DELETION_URL,https://daynest.app/settings,,MAYBE_REQUIRED,Delete data URL
+PSL_DATA_DELETION_URL,,https://daynest.app/settings,MAYBE_REQUIRED,Delete data URL
 PSL_DATA_COLLECTION_COMPLIES_FAMILY_POLICY,,,OPTIONAL,"Only answer this question if you've indicated that your app's target age group includes children, or you've opted into the Designed for Families programme. If either of the above is true, you are required to follow the Google Play Families policy (https://support.google.com/googleplay/android-developer/answer/9893335). Do you want to let users know about this commitment in the Data safety section on your Store Listing?"
 PSL_INDEPENDENTLY_VALIDATED,,,OPTIONAL,"Has your app successfully completed an independent security review, according to the Mobile Application Security Assessment (MASA) framework? Only answer 'yes' if the review is in good standing."
 PSL_UPI_BADGE_OPT_IN,,,OPTIONAL,Do you want to show this badge on your store listing?

--- a/docs/play-store/data_safety.csv
+++ b/docs/play-store/data_safety.csv
@@ -8,11 +8,11 @@ PSL_SUPPORTED_ACCOUNT_CREATION_METHODS,PSL_ACM_OAUTH,,MULTIPLE_CHOICE,Which of t
 PSL_SUPPORTED_ACCOUNT_CREATION_METHODS,PSL_ACM_OTHER,,MULTIPLE_CHOICE,Which of the following methods of account creation does your app support? Select all that apply/Other
 PSL_SUPPORTED_ACCOUNT_CREATION_METHODS,PSL_ACM_NONE,true,MULTIPLE_CHOICE,Which of the following methods of account creation does your app support? Select all that apply/My app does not allow users to create an account
 PSL_ACM_SPECIFY,,,MAYBE_REQUIRED,Describe the method of account creation that your app supports
-PSL_ACCOUNT_DELETION_URL,,,MAYBE_REQUIRED,Add a link that users can use to request that their account and associated data be deleted
-PSL_SUPPORT_DATA_DELETION_BY_USER,DATA_DELETION_YES,,SINGLE_CHOICE,Do you provide a way for users to request that their data is deleted?/Yes
-PSL_SUPPORT_DATA_DELETION_BY_USER,DATA_DELETION_NO,true,SINGLE_CHOICE,Do you provide a way for users to request that their data is deleted?/No
+PSL_ACCOUNT_DELETION_URL,https://daynest.app/settings,,MAYBE_REQUIRED,Add a link that users can use to request that their account and associated data be deleted
+PSL_SUPPORT_DATA_DELETION_BY_USER,DATA_DELETION_YES,true,SINGLE_CHOICE,Do you provide a way for users to request that their data is deleted?/Yes
+PSL_SUPPORT_DATA_DELETION_BY_USER,DATA_DELETION_NO,,SINGLE_CHOICE,Do you provide a way for users to request that their data is deleted?/No
 PSL_SUPPORT_DATA_DELETION_BY_USER,DATA_DELETION_NO_AUTO_DELETED,,SINGLE_CHOICE,"Do you provide a way for users to request that their data is deleted?/No, but user data is automatically deleted within 90 days"
-PSL_DATA_DELETION_URL,,,MAYBE_REQUIRED,Delete data URL
+PSL_DATA_DELETION_URL,https://daynest.app/settings,,MAYBE_REQUIRED,Delete data URL
 PSL_DATA_COLLECTION_COMPLIES_FAMILY_POLICY,,,OPTIONAL,"Only answer this question if you've indicated that your app's target age group includes children, or you've opted into the Designed for Families programme. If either of the above is true, you are required to follow the Google Play Families policy (https://support.google.com/googleplay/android-developer/answer/9893335). Do you want to let users know about this commitment in the Data safety section on your Store Listing?"
 PSL_INDEPENDENTLY_VALIDATED,,,OPTIONAL,"Has your app successfully completed an independent security review, according to the Mobile Application Security Assessment (MASA) framework? Only answer 'yes' if the review is in good standing."
 PSL_UPI_BADGE_OPT_IN,,,OPTIONAL,Do you want to show this badge on your store listing?

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -454,5 +454,11 @@
   "privacy_page_contact_title": "Contact",
   "privacy_page_contact_body": "Questions, data access, or deletion requests can be sent to",
   "privacy_page_contact_or": ", or filed as an issue on the",
-  "privacy_page_contact_github_link": "Daynest GitHub repository"
+  "privacy_page_contact_github_link": "Daynest GitHub repository",
+  "settings_delete_account_header": "Delete account",
+  "settings_delete_account_description": "Permanently delete your Daynest account and personal data, including medication, planning, calendar, push notification, session, and integration data. Household-shared chores must be deleted, transferred, or left before account deletion.",
+  "settings_delete_account_button": "Delete my account",
+  "settings_delete_account_deleting": "Deleting…",
+  "settings_delete_account_confirm": "This permanently deletes your Daynest account and personal data. This cannot be undone. Continue?",
+  "settings_delete_account_error": "Failed to delete account."
 }

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -453,8 +453,6 @@
   "privacy_page_changes_body": "We may update this policy as the app evolves. Material changes will be reflected by updating the “Last updated” date above.",
   "privacy_page_contact_title": "Contact",
   "privacy_page_contact_body": "Questions, data access, or deletion requests can be sent to",
-  "privacy_page_contact_or": ", or filed as an issue on the",
-  "privacy_page_contact_github_link": "Daynest GitHub repository",
   "settings_delete_account_header": "Delete account",
   "settings_delete_account_description": "Permanently delete your Daynest account and personal data, including medication, planning, calendar, push notification, session, and integration data. Household-shared chores must be deleted, transferred, or left before account deletion.",
   "settings_delete_account_button": "Delete my account",

--- a/frontend/messages/nl.json
+++ b/frontend/messages/nl.json
@@ -453,8 +453,6 @@
   "privacy_page_changes_body": "Wij kunnen dit beleid bijwerken naarmate de app zich ontwikkelt. Materiële wijzigingen worden weergegeven door de datum \"Laatst bijgewerkt\" hierboven te actualiseren.",
   "privacy_page_contact_title": "Contact",
   "privacy_page_contact_body": "Vragen, verzoeken tot inzage of verwijdering van gegevens kunt u sturen naar",
-  "privacy_page_contact_or": ", of indienen als issue op de",
-  "privacy_page_contact_github_link": "Daynest GitHub-repository",
   "settings_delete_account_header": "Account verwijderen",
   "settings_delete_account_description": "Verwijder je Daynest-account en persoonlijke gegevens permanent, inclusief medicatie-, planning-, kalender-, pushmelding-, sessie- en integratiegegevens. Huishoudelijke gedeelde klusjes moeten eerst worden verwijderd, overgedragen of verlaten.",
   "settings_delete_account_button": "Mijn account verwijderen",

--- a/frontend/messages/nl.json
+++ b/frontend/messages/nl.json
@@ -454,5 +454,11 @@
   "privacy_page_contact_title": "Contact",
   "privacy_page_contact_body": "Vragen, verzoeken tot inzage of verwijdering van gegevens kunt u sturen naar",
   "privacy_page_contact_or": ", of indienen als issue op de",
-  "privacy_page_contact_github_link": "Daynest GitHub-repository"
+  "privacy_page_contact_github_link": "Daynest GitHub-repository",
+  "settings_delete_account_header": "Account verwijderen",
+  "settings_delete_account_description": "Verwijder je Daynest-account en persoonlijke gegevens permanent, inclusief medicatie-, planning-, kalender-, pushmelding-, sessie- en integratiegegevens. Huishoudelijke gedeelde klusjes moeten eerst worden verwijderd, overgedragen of verlaten.",
+  "settings_delete_account_button": "Mijn account verwijderen",
+  "settings_delete_account_deleting": "Verwijderen…",
+  "settings_delete_account_confirm": "Dit verwijdert je Daynest-account en persoonlijke gegevens permanent. Dit kan niet ongedaan worden gemaakt. Doorgaan?",
+  "settings_delete_account_error": "Account verwijderen mislukt."
 }

--- a/frontend/src/features/legal/PrivacyPolicyPage.tsx
+++ b/frontend/src/features/legal/PrivacyPolicyPage.tsx
@@ -61,12 +61,7 @@ export function PrivacyPolicyPage() {
       <h3 className="h5 mt-4">{m.privacy_page_contact_title()}</h3>
       <p>
         {m.privacy_page_contact_body()}{" "}
-        <a href="mailto:tielemans.jorim@gmail.com">tielemans.jorim@gmail.com</a>
-        {m.privacy_page_contact_or()}{" "}
-        <a href="https://github.com/tjorim/daynest" target="_blank" rel="noreferrer">
-          {m.privacy_page_contact_github_link()}
-        </a>
-        .
+        <a href="mailto:tielemans.jorim@gmail.com">tielemans.jorim@gmail.com</a>.
       </p>
     </section>
   );

--- a/frontend/src/features/settings/SettingsPage.tsx
+++ b/frontend/src/features/settings/SettingsPage.tsx
@@ -7,6 +7,7 @@ import { ServerConfigSection } from "@/features/settings/sections/ServerConfigSe
 import { UserPreferencesSection } from "@/features/settings/sections/UserPreferencesSection";
 import { IntegrationClientsSection } from "@/features/settings/sections/IntegrationClientsSection";
 import { OAuthSessionsSection } from "@/features/settings/sections/OAuthSessionsSection";
+import { AccountDeletionSection } from "@/features/settings/sections/AccountDeletionSection";
 
 export function SettingsPage() {
   useLanguage();
@@ -31,6 +32,7 @@ export function SettingsPage() {
         <div className="col-lg-7">
           <IntegrationClientsSection backendBaseUrl={backendBaseUrl} />
           <OAuthSessionsSection />
+          <AccountDeletionSection />
         </div>
       </div>
     </section>

--- a/frontend/src/features/settings/sections/AccountDeletionSection.tsx
+++ b/frontend/src/features/settings/sections/AccountDeletionSection.tsx
@@ -1,0 +1,38 @@
+import { useContext, useState } from "react";
+import * as m from "@/paraglide/messages";
+import { AuthContext } from "@/app/providers/AuthProvider";
+import { deleteAccount } from "@/lib/api/settings";
+
+export function AccountDeletionSection() {
+  const auth = useContext(AuthContext);
+  const [isDeleting, setIsDeleting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleDelete = async () => {
+    setError(null);
+    const confirmed = window.confirm(m.settings_delete_account_confirm());
+    if (!confirmed) return;
+
+    setIsDeleting(true);
+    try {
+      await deleteAccount();
+      auth?.logout();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : m.settings_delete_account_error());
+      setIsDeleting(false);
+    }
+  };
+
+  return (
+    <div className="card mt-3 border-danger">
+      <div className="card-header fw-semibold py-2 text-danger">{m.settings_delete_account_header()}</div>
+      <div className="card-body py-2">
+        <p className="text-muted small mb-2">{m.settings_delete_account_description()}</p>
+        {error ? <div className="alert alert-danger py-2 small mb-2">{error}</div> : null}
+        <button type="button" className="btn btn-outline-danger btn-sm" onClick={handleDelete} disabled={isDeleting}>
+          {isDeleting ? m.settings_delete_account_deleting() : m.settings_delete_account_button()}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/lib/api/settings.ts
+++ b/frontend/src/lib/api/settings.ts
@@ -1,4 +1,4 @@
-import { getJson, sendJson } from "@/lib/api/http";
+import { fetchWithAuth, getJson, sendJson } from "@/lib/api/http";
 import { z } from "zod";
 
 export interface CalendarFeedResponse {
@@ -64,4 +64,18 @@ export async function fetchUserSettings(signal?: AbortSignal): Promise<UserSetti
 
 export async function updateUserSettings(patch: UserSettingsPatch): Promise<UserSettings> {
   return sendJson("PATCH", "/api/users/me/settings", patch, userSettingsSchema, "Failed to update settings");
+}
+
+export async function deleteAccount(): Promise<void> {
+  const response = await fetchWithAuth("/api/users/me", { method: "DELETE" });
+  if (response.ok) return;
+
+  let message = "Failed to delete account";
+  try {
+    const body = (await response.json()) as { detail?: unknown };
+    if (typeof body.detail === "string") message = body.detail;
+  } catch {
+    // keep fallback message
+  }
+  throw new Error(message);
 }

--- a/frontend/src/lib/api/settings.ts
+++ b/frontend/src/lib/api/settings.ts
@@ -1,5 +1,4 @@
 import { fetchWithAuth, getJson, sendJson } from "@/lib/api/http";
-import { setOidcAccessToken } from "@/lib/auth/session";
 import { z } from "zod";
 
 export interface CalendarFeedResponse {
@@ -70,7 +69,6 @@ export async function updateUserSettings(patch: UserSettingsPatch): Promise<User
 export async function deleteAccount(): Promise<void> {
   const response = await fetchWithAuth("/api/users/me", { method: "DELETE" });
   if (response.ok) {
-    setOidcAccessToken(undefined);
     return;
   }
 

--- a/frontend/src/lib/api/settings.ts
+++ b/frontend/src/lib/api/settings.ts
@@ -1,4 +1,5 @@
 import { fetchWithAuth, getJson, sendJson } from "@/lib/api/http";
+import { setOidcAccessToken } from "@/lib/auth/session";
 import { z } from "zod";
 
 export interface CalendarFeedResponse {
@@ -68,7 +69,10 @@ export async function updateUserSettings(patch: UserSettingsPatch): Promise<User
 
 export async function deleteAccount(): Promise<void> {
   const response = await fetchWithAuth("/api/users/me", { method: "DELETE" });
-  if (response.ok) return;
+  if (response.ok) {
+    setOidcAccessToken(undefined);
+    return;
+  }
 
   let message = "Failed to delete account";
   try {

--- a/frontend/tests/features/legal/PrivacyPolicyPage.test.tsx
+++ b/frontend/tests/features/legal/PrivacyPolicyPage.test.tsx
@@ -1,0 +1,22 @@
+// @vitest-environment jsdom
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { PrivacyPolicyPage } from "@/features/legal/PrivacyPolicyPage";
+
+describe("PrivacyPolicyPage", () => {
+  it("does not expose a GitHub issue deletion flow", () => {
+    render(<PrivacyPolicyPage />);
+
+    expect(screen.queryByRole("link", { name: /github/i })).not.toBeInTheDocument();
+    expect(screen.queryByText(/github\.com/i)).not.toBeInTheDocument();
+  });
+
+  it("points deletion requests to email contact", () => {
+    render(<PrivacyPolicyPage />);
+
+    expect(screen.getByRole("link", { name: /tielemans\.jorim@gmail\.com/i })).toHaveAttribute(
+      "href",
+      "mailto:tielemans.jorim@gmail.com",
+    );
+  });
+});

--- a/frontend/tests/features/settings/AccountDeletionSection.test.tsx
+++ b/frontend/tests/features/settings/AccountDeletionSection.test.tsx
@@ -1,0 +1,84 @@
+// @vitest-environment jsdom
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { AuthContext } from "@/app/providers/AuthProvider";
+import { AccountDeletionSection } from "@/features/settings/sections/AccountDeletionSection";
+
+const apiMock = vi.hoisted(() => ({
+  deleteAccount: vi.fn(),
+}));
+
+vi.mock("@/lib/api/settings", () => ({
+  deleteAccount: apiMock.deleteAccount,
+}));
+
+function renderSection(logout = vi.fn()) {
+  render(
+    <AuthContext.Provider
+      value={{
+        user: {
+          id: 1,
+          email: "user@example.com",
+          full_name: "Test User",
+          is_active: true,
+          roles: [],
+        },
+        isLoading: false,
+        isAuthenticated: true,
+        login: vi.fn(),
+        logout,
+        refreshUser: vi.fn(),
+      }}
+    >
+      <AccountDeletionSection />
+    </AuthContext.Provider>,
+  );
+  return { logout };
+}
+
+describe("AccountDeletionSection", () => {
+  beforeEach(() => {
+    apiMock.deleteAccount.mockReset();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("does not delete the account when confirmation is cancelled", async () => {
+    const user = userEvent.setup();
+    vi.spyOn(window, "confirm").mockReturnValue(false);
+    renderSection();
+
+    await user.click(screen.getByRole("button", { name: /delete my account/i }));
+
+    expect(apiMock.deleteAccount).not.toHaveBeenCalled();
+  });
+
+  it("deletes the account and logs out after confirmation", async () => {
+    const user = userEvent.setup();
+    const { logout } = renderSection();
+    vi.spyOn(window, "confirm").mockReturnValue(true);
+    apiMock.deleteAccount.mockResolvedValue(undefined);
+
+    await user.click(screen.getByRole("button", { name: /delete my account/i }));
+
+    await waitFor(() => {
+      expect(apiMock.deleteAccount).toHaveBeenCalledTimes(1);
+      expect(logout).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it("shows the server error when deletion is blocked", async () => {
+    const user = userEvent.setup();
+    const { logout } = renderSection();
+    vi.spyOn(window, "confirm").mockReturnValue(true);
+    apiMock.deleteAccount.mockRejectedValue(new Error("Delete shared chores first."));
+
+    await user.click(screen.getByRole("button", { name: /delete my account/i }));
+
+    expect(await screen.findByText("Delete shared chores first.")).toBeInTheDocument();
+    expect(logout).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/tests/features/settings/SettingsPage.table.test.tsx
+++ b/frontend/tests/features/settings/SettingsPage.table.test.tsx
@@ -17,6 +17,7 @@ const apiMock = vi.hoisted(() => ({
   rotateIntegrationClient: vi.fn(),
   fetchUserSettings: vi.fn(),
   updateUserSettings: vi.fn(),
+  deleteAccount: vi.fn(),
 }));
 
 const authMock = vi.hoisted(() => ({
@@ -40,6 +41,7 @@ vi.mock("@/lib/api/integrationClients", () => ({
 vi.mock("@/lib/api/settings", () => ({
   fetchUserSettings: apiMock.fetchUserSettings,
   updateUserSettings: apiMock.updateUserSettings,
+  deleteAccount: apiMock.deleteAccount,
 }));
 
 vi.mock("@/lib/api/auth", () => ({

--- a/frontend/tests/features/settings/SettingsPage.test.tsx
+++ b/frontend/tests/features/settings/SettingsPage.test.tsx
@@ -14,6 +14,7 @@ const apiMock = vi.hoisted(() => ({
   rotateIntegrationClient: vi.fn(),
   fetchUserSettings: vi.fn(),
   updateUserSettings: vi.fn(),
+  deleteAccount: vi.fn(),
 }));
 
 const pwaMock = vi.hoisted(() => ({
@@ -32,6 +33,7 @@ vi.mock("@/lib/api/integrationClients", () => ({
 vi.mock("@/lib/api/settings", () => ({
   fetchUserSettings: apiMock.fetchUserSettings,
   updateUserSettings: apiMock.updateUserSettings,
+  deleteAccount: apiMock.deleteAccount,
 }));
 
 vi.mock("@/app/pwa/installPrompt", () => ({
@@ -50,6 +52,7 @@ describe("SettingsPage", () => {
     apiMock.rotateIntegrationClient.mockReset();
     apiMock.fetchUserSettings.mockReset();
     apiMock.updateUserSettings.mockReset();
+    apiMock.deleteAccount.mockReset();
     pwaMock.getDeferredInstallPrompt.mockReset();
     pwaMock.promptToInstallApp.mockReset();
     pwaMock.subscribeInstallPrompt.mockReset();


### PR DESCRIPTION
### Motivation
- Provide a user-facing way to permanently delete their Daynest account and associated personal data via the settings UI and API.  
- Prevent accidental removal of shared household planning data by blocking account deletion when the user owns household-shared chores in a household with other members.  
- Reflect support for user-requested data deletion in Play Store data-safety metadata.

### Description
- Add `DELETE /api/users/me` in `backend/app/api/routes/users.py` with helper `_has_household_shared_chores(db, user_id)` that uses `select`/`exists` against `ChoreTemplate` and `HouseholdMember` to block deletion with HTTP `409` when shared household chores exist.  
- Add backend tests in `backend/tests/test_users.py` covering successful deletion of personal data and the household-shared chore conflict case.  
- Add a frontend danger-zone card `AccountDeletionSection` and include it in `SettingsPage`, plus a `deleteAccount()` helper in `frontend/src/lib/api/settings.ts` that calls the new endpoint and surfaces backend error messages.  
- Add i18n strings in `frontend/messages/en.json` and `frontend/messages/nl.json`, and update `docs/play-store/data_safety.csv` to mark user-requested data deletion as supported and provide the settings URL.

### Testing
- Ran targeted backend tests with `uv run --project backend pytest -q backend/tests/test_users.py`, which passed (`2 passed`).  
- Ran linting with `uv run --project backend ruff check backend/app/api/routes/users.py backend/tests/test_users.py`, which passed.  
- Ran frontend unit tests with `pnpm --dir frontend test -- tests/features/settings/SettingsPage.test.tsx tests/features/settings/SettingsPage.table.test.tsx` and the full suite during CI checks, all passing (`126 passed` in this run).  
- Performed a production frontend build with `pnpm --dir frontend build`, which completed successfully, and validated `git diff --check` produced no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a492c5157ac832eba94613437e68f46)