### PR TITLE
Add Today empty-state CTA and avoid cloning event-streams in MSW

### DIFF
--- a/android/app/src/main/java/com/daynest/android/core/auth/OidcAuthService.kt
+++ b/android/app/src/main/java/com/daynest/android/core/auth/OidcAuthService.kt
@@ -21,6 +21,7 @@ import net.openid.appauth.AuthorizationRequest
 import net.openid.appauth.AuthorizationResponse
 import net.openid.appauth.AuthorizationService
 import net.openid.appauth.AuthorizationServiceConfiguration
+import net.openid.appauth.EndSessionRequest
 import net.openid.appauth.ResponseTypeValues
 
 @Singleton
@@ -89,6 +90,23 @@ constructor(
                     cont.resume(accessToken)
                 }
             }
+        }
+    }
+
+    suspend fun buildSignOutIntent(): Intent? {
+        val idToken = authState.idToken
+        val config = discoverServiceConfiguration()
+        return if (idToken != null && config.endSessionEndpoint != null) {
+            clearState()
+            val request =
+                EndSessionRequest
+                    .Builder(config)
+                    .setPostLogoutRedirectUri(oidcConfig.redirectUri)
+                    .setIdTokenHint(idToken)
+                    .build()
+            authorizationService.getEndSessionRequestIntent(request)
+        } else {
+            null
         }
     }
 

--- a/android/app/src/main/java/com/daynest/android/core/auth/OidcAuthService.kt
+++ b/android/app/src/main/java/com/daynest/android/core/auth/OidcAuthService.kt
@@ -59,21 +59,33 @@ constructor(
         return authorizationService.getAuthorizationRequestIntent(request)
     }
 
-    suspend fun handleAuthorizationResult(resultCode: Int, data: Intent?): Boolean {
+    suspend fun handleAuthorizationResult(resultCode: Int, data: Intent?): AuthorizationResult {
         val isOk = resultCode == Activity.RESULT_OK && data != null
         val response = data?.let { AuthorizationResponse.fromIntent(it) }
         val exception = data?.let { AuthorizationException.fromIntent(it) }
-        if (!isOk || response == null || exception != null) {
-            return false
-        }
-        return suspendCancellableCoroutine { cont ->
-            authorizationService.performTokenRequest(response.createTokenExchangeRequest()) { tokenResponse, ex ->
-                if (tokenResponse != null) {
-                    val newState = AuthState(response, null).apply { update(tokenResponse, ex) }
-                    persistState(newState)
-                    cont.resume(true)
-                } else {
-                    cont.resume(false)
+
+        return when {
+            resultCode == Activity.RESULT_CANCELED ||
+                exception == AuthorizationException.GeneralErrors.USER_CANCELED_AUTH_FLOW -> {
+                AuthorizationResult.Cancelled
+            }
+            !isOk || response == null || exception != null -> {
+                AuthorizationResult.Failed
+            }
+            else -> {
+                suspendCancellableCoroutine { cont ->
+                    authorizationService.performTokenRequest(
+                        response.createTokenExchangeRequest()
+                    ) { tokenResponse, ex ->
+                        when (tokenResponse) {
+                            null -> cont.resume(AuthorizationResult.Failed)
+                            else -> {
+                                val newState = AuthState(response, null).apply { update(tokenResponse, ex) }
+                                persistState(newState)
+                                cont.resume(AuthorizationResult.Authorized)
+                            }
+                        }
+                    }
                 }
             }
         }
@@ -137,4 +149,10 @@ constructor(
         authState = AuthState()
         secureSessionStore.clear()
     }
+}
+
+enum class AuthorizationResult {
+    Authorized,
+    Cancelled,
+    Failed
 }

--- a/android/app/src/main/java/com/daynest/android/core/auth/OidcServiceConfigurationDiscovery.kt
+++ b/android/app/src/main/java/com/daynest/android/core/auth/OidcServiceConfigurationDiscovery.kt
@@ -40,7 +40,9 @@ constructor(
         val json = JSONObject(body)
         AuthorizationServiceConfiguration(
             Uri.parse(json.getString("authorization_url")),
-            Uri.parse(json.getString("token_url"))
+            Uri.parse(json.getString("token_url")),
+            null,
+            json.optString("end_session_endpoint").takeIf { it.isNotBlank() }?.let { Uri.parse(it) }
         )
     } catch (e: JSONException) {
         throw IOException("Failed to parse OIDC config response", e)

--- a/android/app/src/main/java/com/daynest/android/feature/auth/AuthViewModel.kt
+++ b/android/app/src/main/java/com/daynest/android/feature/auth/AuthViewModel.kt
@@ -4,6 +4,7 @@ import android.content.Intent
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.daynest.android.BuildConfig
+import com.daynest.android.core.auth.AuthorizationResult
 import com.daynest.android.core.auth.OidcAuthService
 import com.daynest.android.core.storage.ApiBaseUrlOverrideStore
 import com.daynest.android.data.push.PushRegistrationManager
@@ -73,15 +74,15 @@ constructor(
     fun handleAuthorizationResult(resultCode: Int, data: Intent?) {
         viewModelScope.launch {
             _uiState.update { it.copy(isLoading = true, error = null) }
-            val succeeded = oidcAuthService.handleAuthorizationResult(resultCode, data)
-            if (succeeded) {
-                runCatching { pushRegistrationManager.registerIfEnabled() }
+            val authorizationResult = oidcAuthService.handleAuthorizationResult(resultCode, data)
+            if (authorizationResult == AuthorizationResult.Authorized) {
+                launch { runCatching { pushRegistrationManager.registerIfEnabled() } }
             }
             _uiState.update {
                 it.copy(
                     isLoading = false,
-                    isSignedIn = succeeded,
-                    error = if (succeeded) null else AuthError.SignInFailed
+                    isSignedIn = authorizationResult == AuthorizationResult.Authorized,
+                    error = if (authorizationResult == AuthorizationResult.Failed) AuthError.SignInFailed else null
                 )
             }
         }

--- a/android/app/src/main/java/com/daynest/android/feature/settings/SettingsRoute.kt
+++ b/android/app/src/main/java/com/daynest/android/feature/settings/SettingsRoute.kt
@@ -54,6 +54,17 @@ fun SettingsRoute(
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
 
+    val signOutLauncher =
+        rememberLauncherForActivityResult(
+            contract = ActivityResultContracts.StartActivityForResult()
+        ) { }
+
+    LaunchedEffect(Unit) {
+        viewModel.signOutIntent.collect { intent ->
+            signOutLauncher.launch(intent)
+        }
+    }
+
     LaunchedEffect(uiState) {
         if (uiState is SettingsUiState.SignedOut) {
             onSignedOut?.invoke()

--- a/android/app/src/main/java/com/daynest/android/feature/settings/SettingsSignOutHandler.kt
+++ b/android/app/src/main/java/com/daynest/android/feature/settings/SettingsSignOutHandler.kt
@@ -1,0 +1,44 @@
+package com.daynest.android.feature.settings
+
+import android.content.Intent
+import com.daynest.android.core.auth.OidcAuthService
+import com.daynest.android.data.push.PushRegistrationManager
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.launch
+
+internal class SettingsSignOutHandler(
+    private val scope: CoroutineScope,
+    private val oidcAuthService: OidcAuthService,
+    private val pushRegistrationManager: PushRegistrationManager,
+    private val uiState: MutableStateFlow<SettingsUiState>,
+    private val signOutIntent: MutableSharedFlow<Intent>
+) {
+    @Suppress("TooGenericExceptionCaught")
+    fun signOut(unregisterPushEndpoints: Boolean = true) {
+        scope.launch {
+            if (unregisterPushEndpoints) {
+                try {
+                    pushRegistrationManager.unregisterAllKnownEndpoints()
+                } catch (e: Exception) {
+                    if (e is CancellationException) throw e
+                }
+            }
+            val endSessionIntent =
+                try {
+                    oidcAuthService.buildSignOutIntent()
+                } catch (e: Exception) {
+                    if (e is CancellationException) throw e
+                    null
+                }
+            if (endSessionIntent != null) {
+                signOutIntent.emit(endSessionIntent)
+            } else {
+                oidcAuthService.signOut()
+            }
+            uiState.value = SettingsUiState.SignedOut
+        }
+    }
+}

--- a/android/app/src/main/java/com/daynest/android/feature/settings/SettingsViewModel.kt
+++ b/android/app/src/main/java/com/daynest/android/feature/settings/SettingsViewModel.kt
@@ -1,6 +1,7 @@
 package com.daynest.android.feature.settings
 
 import android.content.Context
+import android.content.Intent
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.daynest.android.BuildConfig
@@ -20,8 +21,11 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
 import javax.inject.Inject
 import kotlinx.coroutines.async
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.update
@@ -41,6 +45,18 @@ constructor(
 ) : ViewModel() {
     private val _uiState = MutableStateFlow<SettingsUiState>(SettingsUiState.Loading)
     val uiState: StateFlow<SettingsUiState> = _uiState.asStateFlow()
+
+    private val _signOutIntent = MutableSharedFlow<Intent>(extraBufferCapacity = 1)
+    val signOutIntent: SharedFlow<Intent> = _signOutIntent.asSharedFlow()
+
+    private val signOutHandler =
+        SettingsSignOutHandler(
+            scope = viewModelScope,
+            oidcAuthService = oidcAuthService,
+            pushRegistrationManager = pushRegistrationManager,
+            uiState = _uiState,
+            signOutIntent = _signOutIntent
+        )
 
     private val deviceCalendarHandler =
         SettingsDeviceCalendarHandler(
@@ -65,11 +81,7 @@ constructor(
     fun onEvent(event: SettingsUiEvent) {
         when (event) {
             SettingsUiEvent.RetryClicked -> load()
-            SettingsUiEvent.SignOutClicked -> {
-                viewModelScope.launch { runCatching { pushRegistrationManager.unregisterAllKnownEndpoints() } }
-                oidcAuthService.signOut()
-                _uiState.value = SettingsUiState.SignedOut
-            }
+            SettingsUiEvent.SignOutClicked -> signOutHandler.signOut()
             SettingsUiEvent.ShowCreateClientForm -> updateContent { it.copy(showCreateForm = true) }
             SettingsUiEvent.DismissCreateClientForm -> updateContent { it.copy(showCreateForm = false) }
             SettingsUiEvent.DismissNewKeyDialog -> updateContent { it.copy(newApiKey = null) }
@@ -257,8 +269,7 @@ constructor(
             pushRegistrationManager.unregisterAllKnownEndpoints()
             settingsRepository.deleteCurrentUser()
                 .onSuccess {
-                    oidcAuthService.signOut()
-                    _uiState.value = SettingsUiState.SignedOut
+                    signOutHandler.signOut(unregisterPushEndpoints = false)
                 }
                 .onFailure { error ->
                     updateContent {

--- a/android/app/src/test/java/com/daynest/android/core/auth/OidcServiceConfigurationDiscoveryTest.kt
+++ b/android/app/src/test/java/com/daynest/android/core/auth/OidcServiceConfigurationDiscoveryTest.kt
@@ -48,7 +48,8 @@ class OidcServiceConfigurationDiscoveryTest {
                 {
                   "issuer": "https://auth.example.test/realms/daynest",
                   "authorization_url": "https://auth.example.test/realms/daynest/protocol/openid-connect/auth",
-                  "token_url": "https://auth.example.test/realms/daynest/protocol/openid-connect/token"
+                  "token_url": "https://auth.example.test/realms/daynest/protocol/openid-connect/token",
+                  "end_session_endpoint": "https://auth.example.test/realms/daynest/protocol/openid-connect/logout"
                 }
                 """.trimIndent()
             )
@@ -66,6 +67,10 @@ class OidcServiceConfigurationDiscoveryTest {
         assertEquals(
             "https://auth.example.test/realms/daynest/protocol/openid-connect/token",
             config.tokenEndpoint.toString()
+        )
+        assertEquals(
+            "https://auth.example.test/realms/daynest/protocol/openid-connect/logout",
+            config.endSessionEndpoint.toString()
         )
     }
 

--- a/backend/app/api/dependencies/auth.py
+++ b/backend/app/api/dependencies/auth.py
@@ -12,6 +12,7 @@ bearer_scheme = HTTPBearer(auto_error=False)
 def _set_request_auth_state(request: Request, user: User, claims: dict[str, object]) -> None:
     request.state.user_id = user.id
     request.state.roles = _extract_roles(claims)
+    request.state.oidc_session_id = claims.get("sid")
     request.state.auth_type = "oidc"
 
 

--- a/backend/app/api/routes/auth.py
+++ b/backend/app/api/routes/auth.py
@@ -75,6 +75,7 @@ async def discover_oidc_endpoints() -> OidcDiscoveryConfig:
                 "issuer": data.get("issuer", issuer),
                 "authorization_url": data["authorization_endpoint"],
                 "token_url": data["token_endpoint"],
+                "end_session_endpoint": data.get("end_session_endpoint"),
             }
         )
     except (KeyError, ValueError) as exc:

--- a/backend/app/api/routes/auth.py
+++ b/backend/app/api/routes/auth.py
@@ -114,6 +114,7 @@ async def update_me(
 
 @router.get("/sessions", response_model=list[OAuthSessionResponse])
 async def list_sessions(
+    request: Request,
     credentials: HTTPAuthorizationCredentials | None = Depends(bearer_scheme),
     current_user: User = Depends(get_current_user),
 ) -> list[OAuthSessionResponse]:
@@ -151,7 +152,9 @@ async def list_sessions(
             status_code=status.HTTP_502_BAD_GATEWAY,
             detail="Invalid response from OIDC provider.",
         )
-    return [
+    current_session_id = getattr(request.state, "oidc_session_id", None)
+
+    sessions = [
         OAuthSessionResponse(
             id=s["id"],
             ip_address=s.get("ipAddress"),
@@ -159,10 +162,12 @@ async def list_sessions(
             last_access=s.get("lastAccess"),
             expires=s.get("expires"),
             clients=s.get("clients") or [],
+            is_current=isinstance(current_session_id, str) and s["id"] == current_session_id,
         )
         for s in raw_sessions
         if isinstance(s, dict) and s.get("id")
     ]
+    return sorted(sessions, key=lambda session: not session.is_current)
 
 
 @router.delete("/sessions/{session_id}", status_code=status.HTTP_204_NO_CONTENT)

--- a/backend/app/schemas/auth.py
+++ b/backend/app/schemas/auth.py
@@ -51,3 +51,4 @@ class OAuthSessionResponse(BaseModel):
     last_access: int | None = None
     expires: int | None = None
     clients: list[OAuthSessionClient] = []
+    is_current: bool = False

--- a/backend/app/schemas/auth.py
+++ b/backend/app/schemas/auth.py
@@ -29,6 +29,7 @@ class OidcDiscoveryConfig(BaseModel):
     issuer: HttpUrl
     authorization_url: HttpUrl
     token_url: HttpUrl
+    end_session_endpoint: HttpUrl | None = None
 
 
 class OAuthSessionClient(BaseModel):

--- a/backend/tests/test_auth_routes.py
+++ b/backend/tests/test_auth_routes.py
@@ -7,7 +7,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import httpx
 import pytest
-from fastapi import HTTPException
+from fastapi import HTTPException, Request
 from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
 
@@ -31,9 +31,10 @@ def _make_user(db: Session, *, email: str, oidc_subject: str | None = None, full
     return user
 
 
-def _override_auth(user: User):
+def _override_auth(user: User, *, oidc_session_id: str | None = None):
     """Return an async dependency that always yields *user*."""
-    async def _dep() -> User:
+    async def _dep(request: Request) -> User:
+        request.state.oidc_session_id = oidc_session_id
         return user
     app.dependency_overrides[get_current_user] = _dep
 
@@ -318,7 +319,29 @@ class TestListSessions:
             assert data[0]["id"] == "session-abc123"
             assert data[0]["ip_address"] == "192.168.1.1"
             assert data[0]["clients"] == [{"clientId": "claude-ai-mcp", "clientName": "Claude.ai MCP Connector", "userConsentRequired": False, "inUse": True, "offlineAccess": False}]
+            assert data[0]["is_current"] is False
             assert data[1]["id"] == "session-def456"
+            assert data[1]["is_current"] is False
+        finally:
+            _clear_auth()
+
+
+    def test_marks_current_session_and_sorts_it_first(
+        self, client: TestClient, db_session: Session, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        user = _make_user(db_session, email="current-session@example.com", oidc_subject="sub-current")
+        _override_auth(user, oidc_session_id="session-def456")
+        monkeypatch.setattr("app.api.routes.auth._http_client", MagicMock(
+            get=AsyncMock(return_value=_make_httpx_response(200, SAMPLE_SESSIONS))
+        ))
+        monkeypatch.setattr("app.api.routes.auth.settings.oidc_issuer_url", "http://keycloak/realms/daynest")
+        try:
+            resp = client.get("/api/auth/sessions", headers={"Authorization": "Bearer dummy-token"})
+            assert resp.status_code == 200
+            data = resp.json()
+            assert [session["id"] for session in data] == ["session-def456", "session-abc123"]
+            assert data[0]["is_current"] is True
+            assert data[1]["is_current"] is False
         finally:
             _clear_auth()
 
@@ -374,6 +397,26 @@ class TestRevokeSession:
                 headers={"Authorization": "Bearer dummy-token"},
             )
             assert resp.status_code == 204
+        finally:
+            _clear_auth()
+
+
+    def test_marks_current_session_and_sorts_it_first(
+        self, client: TestClient, db_session: Session, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        user = _make_user(db_session, email="current-session@example.com", oidc_subject="sub-current")
+        _override_auth(user, oidc_session_id="session-def456")
+        monkeypatch.setattr("app.api.routes.auth._http_client", MagicMock(
+            get=AsyncMock(return_value=_make_httpx_response(200, SAMPLE_SESSIONS))
+        ))
+        monkeypatch.setattr("app.api.routes.auth.settings.oidc_issuer_url", "http://keycloak/realms/daynest")
+        try:
+            resp = client.get("/api/auth/sessions", headers={"Authorization": "Bearer dummy-token"})
+            assert resp.status_code == 200
+            data = resp.json()
+            assert [session["id"] for session in data] == ["session-def456", "session-abc123"]
+            assert data[0]["is_current"] is True
+            assert data[1]["is_current"] is False
         finally:
             _clear_auth()
 

--- a/backend/tests/test_auth_routes.py
+++ b/backend/tests/test_auth_routes.py
@@ -62,6 +62,7 @@ class TestOidcConfigEndpoint:
                 "issuer": issuer,
                 "authorization_endpoint": f"{issuer}/protocol/openid-connect/auth",
                 "token_endpoint": f"{issuer}/protocol/openid-connect/token",
+                "end_session_endpoint": f"{issuer}/protocol/openid-connect/logout",
             }),
         )
 
@@ -71,6 +72,7 @@ class TestOidcConfigEndpoint:
         assert str(config.issuer) == issuer
         assert str(config.authorization_url) == f"{issuer}/protocol/openid-connect/auth"
         assert str(config.token_url) == f"{issuer}/protocol/openid-connect/token"
+        assert str(config.end_session_endpoint) == f"{issuer}/protocol/openid-connect/logout"
 
     def test_oidc_config_caches_discovery(self, monkeypatch: pytest.MonkeyPatch) -> None:
         issuer = "https://auth.example.test/application/o/daynest"

--- a/backend/tests/test_auth_routes.py
+++ b/backend/tests/test_auth_routes.py
@@ -401,25 +401,6 @@ class TestRevokeSession:
             _clear_auth()
 
 
-    def test_marks_current_session_and_sorts_it_first(
-        self, client: TestClient, db_session: Session, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        user = _make_user(db_session, email="current-session@example.com", oidc_subject="sub-current")
-        _override_auth(user, oidc_session_id="session-def456")
-        monkeypatch.setattr("app.api.routes.auth._http_client", MagicMock(
-            get=AsyncMock(return_value=_make_httpx_response(200, SAMPLE_SESSIONS))
-        ))
-        monkeypatch.setattr("app.api.routes.auth.settings.oidc_issuer_url", "http://keycloak/realms/daynest")
-        try:
-            resp = client.get("/api/auth/sessions", headers={"Authorization": "Bearer dummy-token"})
-            assert resp.status_code == 200
-            data = resp.json()
-            assert [session["id"] for session in data] == ["session-def456", "session-abc123"]
-            assert data[0]["is_current"] is True
-            assert data[1]["is_current"] is False
-        finally:
-            _clear_auth()
-
     def test_returns_501_when_oidc_not_configured(
         self, client: TestClient, db_session: Session, monkeypatch: pytest.MonkeyPatch
     ) -> None:

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -337,6 +337,8 @@
   "settings_rotate_secret": "Rotate secret",
   "settings_revoking": "Revoking…",
   "settings_revoke": "Revoke",
+  "settings_this_device": "This device",
+  "settings_revoke_current_session_confirm": "This is your current device. Revoking it may sign you out immediately. Continue?",
   "settings_oauth_sessions_header": "Active OAuth sessions",
   "settings_loading_sessions": "Loading sessions…",
   "settings_no_sessions": "No active OAuth sessions.",

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -47,6 +47,7 @@
   "auth_title": "Sign in to Daynest",
   "auth_subtitle": "Use your account to sync Today, Calendar, and future planning modules.",
   "auth_sign_in": "Sign in",
+  "auth_error_title": "Sign-in failed",
   "auth_loading": "Loading…",
   "router_loading_session": "Loading session...",
   "router_completing_sign_in": "Completing sign in…",

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -52,6 +52,7 @@
   "today_subtitle": "Medication, routines, chores, and planned tasks — everything due or active today.",
   "today_loading": "Loading today...",
   "today_nothing_scheduled": "Nothing scheduled for today yet.",
+  "today_create_first_chore": "Create your first chore",
   "today_summary_overdue": "Overdue",
   "today_summary_due_today": "Due Today",
   "today_summary_medication_due": "Medication Due",

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -460,7 +460,10 @@
   "settings_delete_account_description": "Permanently delete your Daynest account and personal data, including medication, planning, calendar, push notification, session, and integration data. Household-shared chores must be deleted, transferred, or left before account deletion.",
   "settings_delete_account_button": "Delete my account",
   "settings_delete_account_deleting": "Deleting…",
-  "settings_delete_account_confirm": "This permanently deletes your Daynest account and personal data. This cannot be undone. Continue?",
+  "settings_delete_account_confirm": "This permanently deletes your Daynest account and personal data. This cannot be undone. Type {email} to confirm.",
+  "settings_delete_account_email_label": "Type your email address to confirm",
+  "settings_delete_account_email_placeholder": "Enter {email}",
+  "settings_delete_account_mismatch": "Enter your email address exactly to enable account deletion.",
   "settings_delete_account_error": "Failed to delete account.",
   "nav_menu": "Menu"
 }

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -52,6 +52,7 @@
   "router_completing_sign_in": "Completing sign in…",
   "today_subtitle": "Medication, routines, chores, and planned tasks — everything due or active today.",
   "today_loading": "Loading today...",
+  "today_live_updates_interrupted": "Live Today updates were interrupted. Reconnecting with the latest session…",
   "today_nothing_scheduled": "Nothing scheduled for today yet.",
   "today_create_first_chore": "Create your first chore",
   "today_summary_overdue": "Overdue",

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -30,6 +30,7 @@
   "app_offline_queued": "{count} action(s) will sync when reconnected.",
   "app_syncing_queued": "Syncing {count} queued action(s)…",
   "app_server_unavailable": "Cannot connect to Daynest server. Please check your connection and try again.",
+  "app_session_retry_banner": "We could not refresh your account details. Your session is still active; try again to reconnect.",
   "app_theme_switch_to_light": "Switch to light mode",
   "app_theme_switch_to_dark": "Switch to dark mode",
   "app_theme_switch_to_auto": "Switch to auto mode",

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -459,5 +459,6 @@
   "settings_delete_account_button": "Delete my account",
   "settings_delete_account_deleting": "Deleting…",
   "settings_delete_account_confirm": "This permanently deletes your Daynest account and personal data. This cannot be undone. Continue?",
-  "settings_delete_account_error": "Failed to delete account."
+  "settings_delete_account_error": "Failed to delete account.",
+  "nav_menu": "Menu"
 }

--- a/frontend/messages/nl.json
+++ b/frontend/messages/nl.json
@@ -52,6 +52,7 @@
   "router_completing_sign_in": "Aanmelding voltooien…",
   "today_subtitle": "Medicatie, routines, klusjes en geplande taken — alles dat vandaag vervalt of actief is.",
   "today_loading": "Vandaag laden...",
+  "today_live_updates_interrupted": "Live updates voor Vandaag zijn onderbroken. Opnieuw verbinden met de nieuwste sessie…",
   "today_nothing_scheduled": "Nog niets ingepland voor vandaag.",
   "today_create_first_chore": "Maak je eerste klusje",
   "today_summary_overdue": "Achterstallig",

--- a/frontend/messages/nl.json
+++ b/frontend/messages/nl.json
@@ -459,5 +459,6 @@
   "settings_delete_account_button": "Mijn account verwijderen",
   "settings_delete_account_deleting": "Verwijderen…",
   "settings_delete_account_confirm": "Dit verwijdert je Daynest-account en persoonlijke gegevens permanent. Dit kan niet ongedaan worden gemaakt. Doorgaan?",
-  "settings_delete_account_error": "Account verwijderen mislukt."
+  "settings_delete_account_error": "Account verwijderen mislukt.",
+  "nav_menu": "Menu"
 }

--- a/frontend/messages/nl.json
+++ b/frontend/messages/nl.json
@@ -460,7 +460,10 @@
   "settings_delete_account_description": "Verwijder je Daynest-account en persoonlijke gegevens permanent, inclusief medicatie-, planning-, kalender-, pushmelding-, sessie- en integratiegegevens. Huishoudelijke gedeelde klusjes moeten eerst worden verwijderd, overgedragen of verlaten.",
   "settings_delete_account_button": "Mijn account verwijderen",
   "settings_delete_account_deleting": "Verwijderen…",
-  "settings_delete_account_confirm": "Dit verwijdert je Daynest-account en persoonlijke gegevens permanent. Dit kan niet ongedaan worden gemaakt. Doorgaan?",
+  "settings_delete_account_confirm": "Dit verwijdert je Daynest-account en persoonlijke gegevens permanent. Dit kan niet ongedaan worden gemaakt. Typ {email} om te bevestigen.",
+  "settings_delete_account_email_label": "Typ je e-mailadres om te bevestigen",
+  "settings_delete_account_email_placeholder": "Voer {email} in",
+  "settings_delete_account_mismatch": "Voer je e-mailadres exact in om accountverwijdering in te schakelen.",
   "settings_delete_account_error": "Account verwijderen mislukt.",
   "nav_menu": "Menu"
 }

--- a/frontend/messages/nl.json
+++ b/frontend/messages/nl.json
@@ -47,6 +47,7 @@
   "auth_title": "Aanmelden bij Daynest",
   "auth_subtitle": "Gebruik uw account om Vandaag, Kalender en toekomstige planningsmodules te synchroniseren.",
   "auth_sign_in": "Aanmelden",
+  "auth_error_title": "Aanmelden mislukt",
   "auth_loading": "Laden…",
   "router_loading_session": "Sessie laden...",
   "router_completing_sign_in": "Aanmelding voltooien…",

--- a/frontend/messages/nl.json
+++ b/frontend/messages/nl.json
@@ -337,6 +337,8 @@
   "settings_rotate_secret": "Geheim roteren",
   "settings_revoking": "Intrekken…",
   "settings_revoke": "Intrekken",
+  "settings_this_device": "Dit apparaat",
+  "settings_revoke_current_session_confirm": "Dit is je huidige apparaat. Als je deze sessie intrekt, word je mogelijk meteen afgemeld. Doorgaan?",
   "settings_oauth_sessions_header": "Actieve OAuth-sessies",
   "settings_loading_sessions": "Sessies laden…",
   "settings_no_sessions": "Geen actieve OAuth-sessies.",

--- a/frontend/messages/nl.json
+++ b/frontend/messages/nl.json
@@ -52,6 +52,7 @@
   "today_subtitle": "Medicatie, routines, klusjes en geplande taken — alles dat vandaag vervalt of actief is.",
   "today_loading": "Vandaag laden...",
   "today_nothing_scheduled": "Nog niets ingepland voor vandaag.",
+  "today_create_first_chore": "Maak je eerste klusje",
   "today_summary_overdue": "Achterstallig",
   "today_summary_due_today": "Vandaag te doen",
   "today_summary_medication_due": "Medicatie te nemen",

--- a/frontend/messages/nl.json
+++ b/frontend/messages/nl.json
@@ -30,6 +30,7 @@
   "app_offline_queued": "{count} actie(s) worden gesynchroniseerd zodra de verbinding is hersteld.",
   "app_syncing_queued": "{count} wachtende actie(s) synchroniseren…",
   "app_server_unavailable": "Kan geen verbinding maken met de Daynest-server. Controleer uw verbinding en probeer het opnieuw.",
+  "app_session_retry_banner": "We konden uw accountgegevens niet vernieuwen. Uw sessie is nog actief; probeer opnieuw om opnieuw te verbinden.",
   "app_theme_switch_to_light": "Overschakelen naar lichte modus",
   "app_theme_switch_to_dark": "Overschakelen naar donkere modus",
   "app_theme_switch_to_auto": "Overschakelen naar automatische modus",

--- a/frontend/src/app/layout/AppLayout.tsx
+++ b/frontend/src/app/layout/AppLayout.tsx
@@ -8,10 +8,11 @@ import { drain as drainOfflineQueue, getQueuedCount } from "@/lib/offlineQueue";
 import { SearchOverlay } from "@/features/search/SearchOverlay";
 
 export function AppLayout() {
-  const { isAuthenticated, isLoading, logout, user } = useAuth();
+  const { isAuthenticated, isLoading, logout, refreshUser, sessionError, user } = useAuth();
   const { theme, toggleTheme } = useTheme();
   const isOnline = useOnlineStatus();
   const [queuedCount, setQueuedCount] = React.useState(() => getQueuedCount());
+  const [isRetryingSession, setIsRetryingSession] = React.useState(false);
   const [searchOpen, setSearchOpen] = React.useState(false);
   const [mobileNavOpen, setMobileNavOpen] = React.useState(false);
 
@@ -125,6 +126,26 @@ export function AppLayout() {
           {m.app_syncing_queued({ count: queuedCount })}
         </div>
       ) : null}
+      {sessionError ? (
+        <div className="alert alert-danger py-2 mb-3 d-flex justify-content-between align-items-center gap-2 flex-wrap">
+          <span>{m.app_session_retry_banner()}</span>
+          <button
+            type="button"
+            className="btn btn-sm btn-outline-danger"
+            disabled={isRetryingSession}
+            onClick={async () => {
+              setIsRetryingSession(true);
+              try {
+                await refreshUser();
+              } finally {
+                setIsRetryingSession(false);
+              }
+            }}
+          >
+            {m.action_retry()}
+          </button>
+        </div>
+      ) : null}
       {searchOpen && isAuthenticated ? (
         <SearchOverlay onClose={() => setSearchOpen(false)} />
       ) : null}
@@ -158,12 +179,14 @@ export function AppLayout() {
                 aria-hidden="true"
               />
             </button>
-            {isAuthenticated && user ? (
+            {isAuthenticated ? (
               <div className="d-flex flex-column flex-sm-row align-items-start align-items-sm-center gap-2">
-                <div className="small text-muted text-sm-end">
-                  <div className="fw-semibold text-body">{user.full_name}</div>
-                  <div>{user.email}</div>
-                </div>
+                {user ? (
+                  <div className="small text-muted text-sm-end">
+                    <div className="fw-semibold text-body">{user.full_name}</div>
+                    <div>{user.email}</div>
+                  </div>
+                ) : null}
                 <button type="button" className="btn btn-outline-secondary btn-sm" onClick={logout}>
                   {m.app_logout()}
                 </button>

--- a/frontend/src/app/layout/AppLayout.tsx
+++ b/frontend/src/app/layout/AppLayout.tsx
@@ -13,6 +13,7 @@ export function AppLayout() {
   const isOnline = useOnlineStatus();
   const [queuedCount, setQueuedCount] = React.useState(() => getQueuedCount());
   const [searchOpen, setSearchOpen] = React.useState(false);
+  const [mobileNavOpen, setMobileNavOpen] = React.useState(false);
 
   React.useEffect(() => {
     if (isOnline && getQueuedCount() > 0) {
@@ -66,6 +67,46 @@ export function AppLayout() {
       : theme === "light"
         ? m.app_theme_light()
         : m.app_theme_dark();
+
+  const navLinks = [
+    { to: "/today", label: m.nav_today() },
+    { to: "/calendar", label: m.nav_calendar() },
+    { to: "/medication", label: m.nav_medication() },
+    { to: "/meal-plan", label: m.nav_meal_plan() },
+    { to: "/shopping", label: m.nav_shopping() },
+    { to: "/shopping/recurring", label: m.nav_recurring_groceries() },
+    { to: "/templates", label: m.nav_templates() },
+    { to: "/stats", label: m.nav_stats() },
+    { to: "/settings", label: m.nav_settings() },
+  ] as const;
+
+  const renderNavLinks = (onNavigate?: () => void) =>
+    navLinks.map((link) => (
+      <Link
+        key={link.to}
+        to={link.to}
+        activeProps={{ className: "nav-link active" }}
+        inactiveProps={{ className: "nav-link" }}
+        onClick={(event) => {
+          if (
+            event.defaultPrevented ||
+            event.button !== 0 ||
+            event.metaKey ||
+            event.ctrlKey ||
+            event.shiftKey ||
+            event.altKey
+          ) {
+            return;
+          }
+
+          if (mobileNavOpen) {
+            onNavigate?.();
+          }
+        }}
+      >
+        {link.label}
+      </Link>
+    ));
 
   return (
     <>
@@ -139,71 +180,28 @@ export function AppLayout() {
           </div>
         </div>
         {isAuthenticated ? (
-          <nav className="nav nav-pills gap-2">
-            <Link
-              to="/today"
-              activeProps={{ className: "nav-link active" }}
-              inactiveProps={{ className: "nav-link" }}
+          <div className="d-flex flex-column gap-2">
+            <button
+              type="button"
+              className="btn btn-outline-primary d-md-none align-self-start"
+              aria-controls="primary-navigation"
+              aria-expanded={mobileNavOpen}
+              onClick={() => setMobileNavOpen((isOpen) => !isOpen)}
             >
-              {m.nav_today()}
-            </Link>
-            <Link
-              to="/calendar"
-              activeProps={{ className: "nav-link active" }}
-              inactiveProps={{ className: "nav-link" }}
+              <i
+                className={`bi ${mobileNavOpen ? "bi-x-lg" : "bi-list"} me-2`}
+                aria-hidden="true"
+              />
+              {m.nav_menu()}
+            </button>
+            <nav
+              id="primary-navigation"
+              className={`${mobileNavOpen ? "d-flex" : "d-none"} d-md-flex nav nav-pills flex-column flex-md-row gap-2`}
+              aria-label={m.nav_menu()}
             >
-              {m.nav_calendar()}
-            </Link>
-            <Link
-              to="/medication"
-              activeProps={{ className: "nav-link active" }}
-              inactiveProps={{ className: "nav-link" }}
-            >
-              {m.nav_medication()}
-            </Link>
-            <Link
-              to="/meal-plan"
-              activeProps={{ className: "nav-link active" }}
-              inactiveProps={{ className: "nav-link" }}
-            >
-              {m.nav_meal_plan()}
-            </Link>
-            <Link
-              to="/shopping"
-              activeProps={{ className: "nav-link active" }}
-              inactiveProps={{ className: "nav-link" }}
-            >
-              {m.nav_shopping()}
-            </Link>
-            <Link
-              to="/shopping/recurring"
-              activeProps={{ className: "nav-link active" }}
-              inactiveProps={{ className: "nav-link" }}
-            >
-              {m.nav_recurring_groceries()}
-            </Link>
-            <Link
-              to="/templates"
-              activeProps={{ className: "nav-link active" }}
-              inactiveProps={{ className: "nav-link" }}
-            >
-              {m.nav_templates()}
-            </Link>
-            <Link
-              to="/stats"
-              activeProps={{ className: "nav-link active" }}
-              inactiveProps={{ className: "nav-link" }}
-            >
-              {m.nav_stats()}
-            </Link>
-            <Link
-              to="/settings"
-              activeProps={{ className: "nav-link active" }}
-              inactiveProps={{ className: "nav-link" }}
-            >
-              {m.nav_settings()}
-            </Link>
-          </nav>
+              {renderNavLinks(() => setMobileNavOpen(false))}
+            </nav>
+          </div>
         ) : null}
       </header>
       <Outlet />

--- a/frontend/src/app/providers/AuthProvider.tsx
+++ b/frontend/src/app/providers/AuthProvider.tsx
@@ -1,6 +1,6 @@
 import { createContext, useContext, useEffect, useMemo, useState } from "react";
 import { useAuth as useOidcAuth } from "react-oidc-context";
-import { fetchMe, type AuthUser } from "@/lib/api/auth";
+import { AuthApiError, fetchMe, type AuthUser } from "@/lib/api/auth";
 import { setOidcAccessToken } from "@/lib/auth/session";
 import { AUTH_ROUTE_PATHS } from "@/config/oidc";
 
@@ -19,6 +19,7 @@ type AuthContextValue = {
   login: () => void;
   logout: () => void;
   refreshUser: () => Promise<void>;
+  sessionError: string | null;
 };
 
 export const AuthContext = createContext<AuthContextValue | null>(null);
@@ -27,6 +28,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   const oidc = useOidcAuth();
   const [user, setUser] = useState<AuthUser | null>(null);
   const [isFetching, setIsFetching] = useState(false);
+  const [sessionError, setSessionError] = useState<string | null>(null);
 
   useEffect(() => {
     setOidcAccessToken(oidc.user?.access_token);
@@ -38,6 +40,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     if (!oidc.isAuthenticated || !accessToken) {
       setIsFetching(false);
       setUser(null);
+      setSessionError(null);
       return;
     }
 
@@ -46,10 +49,21 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
 
     fetchMe(accessToken)
       .then((nextUser) => {
-        if (!cancelled) setUser(nextUser);
+        if (!cancelled) {
+          setUser(nextUser);
+          setSessionError(null);
+        }
       })
-      .catch(() => {
-        if (!cancelled) setUser(null);
+      .catch((error: unknown) => {
+        if (cancelled) return;
+
+        if (error instanceof AuthApiError && error.status === 401) {
+          setUser(null);
+          setSessionError(null);
+          return;
+        }
+
+        setSessionError(error instanceof Error ? error.message : "Unable to load session");
       })
       .finally(() => {
         if (!cancelled) setIsFetching(false);
@@ -64,7 +78,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     () => ({
       user,
       isLoading: oidc.isLoading || isFetching,
-      isAuthenticated: oidc.isAuthenticated && user !== null,
+      isAuthenticated: oidc.isAuthenticated && (user !== null || sessionError !== null),
       login: () => {
         void oidc.signinRedirect({ state: { returnTo: getLoginReturnTo() } });
       },
@@ -77,12 +91,20 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
         try {
           const nextUser = await fetchMe(accessToken);
           setUser(nextUser);
-        } catch {
-          setUser(null);
+          setSessionError(null);
+        } catch (error: unknown) {
+          if (error instanceof AuthApiError && error.status === 401) {
+            setUser(null);
+            setSessionError(null);
+            return;
+          }
+
+          setSessionError(error instanceof Error ? error.message : "Unable to load session");
         }
       },
+      sessionError,
     }),
-    [user, oidc, isFetching],
+    [user, oidc, isFetching, sessionError],
   );
 
   return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;

--- a/frontend/src/app/providers/AuthProvider.tsx
+++ b/frontend/src/app/providers/AuthProvider.tsx
@@ -4,6 +4,17 @@ import { AuthApiError, fetchMe, type AuthUser } from "@/lib/api/auth";
 import { setOidcAccessToken } from "@/lib/auth/session";
 import { AUTH_ROUTE_PATHS } from "@/config/oidc";
 
+function getOidcErrorMessage(error: unknown) {
+  if (!error) return null;
+
+  if (error instanceof Error && error.message) {
+    return error.message;
+  }
+
+  const fallbackMessage = String(error);
+  return fallbackMessage || "Unable to complete sign in";
+}
+
 function getLoginReturnTo() {
   if (AUTH_ROUTE_PATHS.has(window.location.pathname)) {
     return "/today";
@@ -20,6 +31,7 @@ type AuthContextValue = {
   logout: () => void;
   refreshUser: () => Promise<void>;
   sessionError: string | null;
+  oidcError: string | null;
 };
 
 export const AuthContext = createContext<AuthContextValue | null>(null);
@@ -103,6 +115,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
         }
       },
       sessionError,
+      oidcError: getOidcErrorMessage(oidc.error),
     }),
     [user, oidc, isFetching, sessionError],
   );

--- a/frontend/src/features/auth/AuthPage.tsx
+++ b/frontend/src/features/auth/AuthPage.tsx
@@ -13,7 +13,7 @@ function buildRedirectPath(value: unknown): string {
 }
 
 export function AuthPage() {
-  const { isAuthenticated, isLoading, login } = useAuth();
+  const { isAuthenticated, isLoading, login, oidcError } = useAuth();
   const search = useSearch({ from: "/auth" });
   const redirectTo = buildRedirectPath(search.from);
 
@@ -26,15 +26,14 @@ export function AuthPage() {
       <div className="card shadow-sm">
         <div className="card-body p-4 text-center">
           <h2 className="h4 mb-1">{m.auth_title()}</h2>
-          <p className="text-muted mb-3">
-            {m.auth_subtitle()}
-          </p>
-          <button
-            type="button"
-            className="btn btn-primary"
-            onClick={login}
-            disabled={isLoading}
-          >
+          <p className="text-muted mb-3">{m.auth_subtitle()}</p>
+          {oidcError ? (
+            <div className="alert alert-danger text-start" role="alert">
+              <p className="fw-semibold mb-1">{m.auth_error_title()}</p>
+              <p className="mb-0">{oidcError}</p>
+            </div>
+          ) : null}
+          <button type="button" className="btn btn-primary" onClick={login} disabled={isLoading}>
             {isLoading ? m.auth_loading() : m.auth_sign_in()}
           </button>
         </div>

--- a/frontend/src/features/settings/sections/AccountDeletionSection.tsx
+++ b/frontend/src/features/settings/sections/AccountDeletionSection.tsx
@@ -5,12 +5,27 @@ import { deleteAccount } from "@/lib/api/settings";
 
 export function AccountDeletionSection() {
   const auth = useContext(AuthContext);
+  const userEmail = auth?.user?.email ?? "";
   const [isDeleting, setIsDeleting] = useState(false);
   const [isConfirming, setIsConfirming] = useState(false);
+  const [confirmationEmail, setConfirmationEmail] = useState("");
   const [error, setError] = useState<string | null>(null);
+  const canDelete = userEmail.length > 0 && confirmationEmail.trim() === userEmail;
+
+  const resetConfirmation = () => {
+    setIsConfirming(false);
+    setConfirmationEmail("");
+    setError(null);
+  };
 
   const handleDelete = async () => {
     setError(null);
+
+    if (!canDelete) {
+      setError(m.settings_delete_account_mismatch());
+      return;
+    }
+
     setIsDeleting(true);
     try {
       await deleteAccount();
@@ -30,7 +45,27 @@ export function AccountDeletionSection() {
         <p className="text-muted small mb-2">{m.settings_delete_account_description()}</p>
         {isConfirming ? (
           <div className="alert alert-danger py-2 small mb-2">
-            {m.settings_delete_account_confirm()}
+            {m.settings_delete_account_confirm({ email: userEmail })}
+          </div>
+        ) : null}
+        {isConfirming ? (
+          <div className="mb-2">
+            <label className="form-label small mb-1" htmlFor="delete-account-email-confirmation">
+              {m.settings_delete_account_email_label()}
+            </label>
+            <input
+              type="email"
+              className="form-control form-control-sm"
+              id="delete-account-email-confirmation"
+              value={confirmationEmail}
+              onChange={(event) => {
+                setConfirmationEmail(event.target.value);
+                setError(null);
+              }}
+              placeholder={m.settings_delete_account_email_placeholder({ email: userEmail })}
+              autoComplete="off"
+              disabled={isDeleting}
+            />
           </div>
         ) : null}
         {error ? <div className="alert alert-danger py-2 small mb-2">{error}</div> : null}
@@ -40,17 +75,14 @@ export function AccountDeletionSection() {
               type="button"
               className="btn btn-danger btn-sm"
               onClick={handleDelete}
-              disabled={isDeleting}
+              disabled={isDeleting || !canDelete}
             >
               {isDeleting ? m.settings_delete_account_deleting() : m.action_confirm()}
             </button>
             <button
               type="button"
               className="btn btn-outline-secondary btn-sm"
-              onClick={() => {
-                setIsConfirming(false);
-                setError(null);
-              }}
+              onClick={resetConfirmation}
               disabled={isDeleting}
             >
               {m.action_cancel()}
@@ -62,9 +94,10 @@ export function AccountDeletionSection() {
             className="btn btn-outline-danger btn-sm"
             onClick={() => {
               setError(null);
+              setConfirmationEmail("");
               setIsConfirming(true);
             }}
-            disabled={isDeleting}
+            disabled={isDeleting || userEmail.length === 0}
           >
             {m.settings_delete_account_button()}
           </button>

--- a/frontend/src/features/settings/sections/AccountDeletionSection.tsx
+++ b/frontend/src/features/settings/sections/AccountDeletionSection.tsx
@@ -6,13 +6,11 @@ import { deleteAccount } from "@/lib/api/settings";
 export function AccountDeletionSection() {
   const auth = useContext(AuthContext);
   const [isDeleting, setIsDeleting] = useState(false);
+  const [isConfirming, setIsConfirming] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
   const handleDelete = async () => {
     setError(null);
-    const confirmed = window.confirm(m.settings_delete_account_confirm());
-    if (!confirmed) return;
-
     setIsDeleting(true);
     try {
       await deleteAccount();
@@ -25,13 +23,52 @@ export function AccountDeletionSection() {
 
   return (
     <div className="card mt-3 border-danger">
-      <div className="card-header fw-semibold py-2 text-danger">{m.settings_delete_account_header()}</div>
+      <div className="card-header fw-semibold py-2 text-danger">
+        {m.settings_delete_account_header()}
+      </div>
       <div className="card-body py-2">
         <p className="text-muted small mb-2">{m.settings_delete_account_description()}</p>
+        {isConfirming ? (
+          <div className="alert alert-danger py-2 small mb-2">
+            {m.settings_delete_account_confirm()}
+          </div>
+        ) : null}
         {error ? <div className="alert alert-danger py-2 small mb-2">{error}</div> : null}
-        <button type="button" className="btn btn-outline-danger btn-sm" onClick={handleDelete} disabled={isDeleting}>
-          {isDeleting ? m.settings_delete_account_deleting() : m.settings_delete_account_button()}
-        </button>
+        {isConfirming ? (
+          <div className="d-flex gap-1">
+            <button
+              type="button"
+              className="btn btn-danger btn-sm"
+              onClick={handleDelete}
+              disabled={isDeleting}
+            >
+              {isDeleting ? m.settings_delete_account_deleting() : m.action_confirm()}
+            </button>
+            <button
+              type="button"
+              className="btn btn-outline-secondary btn-sm"
+              onClick={() => {
+                setIsConfirming(false);
+                setError(null);
+              }}
+              disabled={isDeleting}
+            >
+              {m.action_cancel()}
+            </button>
+          </div>
+        ) : (
+          <button
+            type="button"
+            className="btn btn-outline-danger btn-sm"
+            onClick={() => {
+              setError(null);
+              setIsConfirming(true);
+            }}
+            disabled={isDeleting}
+          >
+            {m.settings_delete_account_button()}
+          </button>
+        )}
       </div>
     </div>
   );

--- a/frontend/src/features/settings/sections/OAuthSessionsSection.tsx
+++ b/frontend/src/features/settings/sections/OAuthSessionsSection.tsx
@@ -32,7 +32,12 @@ export function OAuthSessionsSection() {
     }
   };
 
-  const onRevokeSession = async (sessionId: string) => {
+  const onRevokeSession = async (session: OAuthSession) => {
+    if (session.is_current && !window.confirm(m.settings_revoke_current_session_confirm())) {
+      return;
+    }
+
+    const sessionId = session.id;
     setRevokingSession(sessionId);
     setRevokeError(null);
     try {
@@ -86,8 +91,13 @@ export function OAuthSessionsSection() {
                 <li key={session.id} className="list-group-item py-2">
                   <div className="d-flex justify-content-between align-items-start gap-3">
                     <div>
-                      <div className="fw-semibold">
-                        {clientNames.length > 0 ? clientNames.join(", ") : m.settings_unknown_client()}
+                      <div className="fw-semibold d-flex align-items-center flex-wrap gap-2">
+                        <span>
+                          {clientNames.length > 0 ? clientNames.join(", ") : m.settings_unknown_client()}
+                        </span>
+                        {session.is_current ? (
+                          <span className="badge text-bg-primary">{m.settings_this_device()}</span>
+                        ) : null}
                       </div>
                       {metaParts.length > 0 ? (
                         <small className="text-muted d-block">{metaParts.join(" • ")}</small>
@@ -97,7 +107,7 @@ export function OAuthSessionsSection() {
                       type="button"
                       className="btn btn-outline-danger btn-sm flex-shrink-0"
                       disabled={revokingSession === session.id}
-                      onClick={() => void onRevokeSession(session.id)}
+                      onClick={() => void onRevokeSession(session)}
                     >
                       {revokingSession === session.id ? m.settings_revoking() : m.settings_revoke()}
                     </button>

--- a/frontend/src/features/templates/TemplatesPage.tsx
+++ b/frontend/src/features/templates/TemplatesPage.tsx
@@ -32,6 +32,7 @@ export function TemplatesPage() {
   const chores = choresQuery.data ?? [];
   const analytics = analyticsQuery.data ?? null;
   const loading = routinesQuery.isPending || choresQuery.isPending || analyticsQuery.isPending;
+  const refreshing = (routinesQuery.isFetching || choresQuery.isFetching || analyticsQuery.isFetching) && !loading;
   const queryError = routinesQuery.error ?? choresQuery.error ?? analyticsQuery.error;
   const error = queryError instanceof Error ? queryError.message : queryError ? "Unable to load template data." : null;
   const canRetry = queryError ? isRetryableApiError(queryError) : false;
@@ -199,9 +200,12 @@ export function TemplatesPage() {
         <button
           type="button"
           className="btn btn-outline-primary btn-sm"
-          disabled={loading}
+          disabled={loading || refreshing}
           onClick={() => void loadTemplates()}
         >
+          {refreshing ? (
+            <span className="spinner-border spinner-border-sm me-1" role="status" aria-hidden="true" />
+          ) : null}
           {m.action_refresh()}
         </button>
       </div>

--- a/frontend/src/features/templates/TemplatesPage.tsx
+++ b/frontend/src/features/templates/TemplatesPage.tsx
@@ -16,9 +16,11 @@ import {
 } from "@/features/templates/useTemplateQueries";
 
 export function TemplatesPage() {
-  const [submitError, setSubmitError] = useState<string | null>(null);
+  const [routineSubmitError, setRoutineSubmitError] = useState<string | null>(null);
+  const [choreSubmitError, setChoreSubmitError] = useState<string | null>(null);
   const [successMessage, setSuccessMessage] = useState<string | null>(null);
-  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [isRoutineSubmitting, setIsRoutineSubmitting] = useState(false);
+  const [isChoreSubmitting, setIsChoreSubmitting] = useState(false);
   const routinesQuery = useRoutineTemplatesQuery();
   const choresQuery = useChoreTemplatesQuery();
   const analyticsQuery = useTemplateAnalyticsQuery();
@@ -32,9 +34,15 @@ export function TemplatesPage() {
   const chores = choresQuery.data ?? [];
   const analytics = analyticsQuery.data ?? null;
   const loading = routinesQuery.isPending || choresQuery.isPending || analyticsQuery.isPending;
-  const refreshing = (routinesQuery.isFetching || choresQuery.isFetching || analyticsQuery.isFetching) && !loading;
+  const refreshing =
+    (routinesQuery.isFetching || choresQuery.isFetching || analyticsQuery.isFetching) && !loading;
   const queryError = routinesQuery.error ?? choresQuery.error ?? analyticsQuery.error;
-  const error = queryError instanceof Error ? queryError.message : queryError ? "Unable to load template data." : null;
+  const error =
+    queryError instanceof Error
+      ? queryError.message
+      : queryError
+        ? "Unable to load template data."
+        : null;
   const canRetry = queryError ? isRetryableApiError(queryError) : false;
 
   const routineStreakMap = useMemo(
@@ -88,16 +96,16 @@ export function TemplatesPage() {
 
   const submitRoutine = async () => {
     if (!routineName.trim()) {
-      setSubmitError(m.templates_routine_name_required());
+      setRoutineSubmitError(m.templates_routine_name_required());
       return;
     }
     const everyNDaysRoutine = parseInt(routineEveryNDays, 10);
     if (!Number.isInteger(everyNDaysRoutine) || everyNDaysRoutine < 1) {
-      setSubmitError(m.templates_every_n_error());
+      setRoutineSubmitError(m.templates_every_n_error());
       return;
     }
-    setIsSubmitting(true);
-    setSubmitError(null);
+    setIsRoutineSubmitting(true);
+    setRoutineSubmitError(null);
     setSuccessMessage(null);
     try {
       const payload = {
@@ -109,7 +117,10 @@ export function TemplatesPage() {
         is_active: routineActive,
       };
       if (editingRoutineId !== null) {
-        await updateRoutineMutation.mutateAsync({ routineTemplateId: editingRoutineId, input: payload });
+        await updateRoutineMutation.mutateAsync({
+          routineTemplateId: editingRoutineId,
+          input: payload,
+        });
       } else {
         await createRoutineMutation.mutateAsync(payload);
       }
@@ -118,24 +129,24 @@ export function TemplatesPage() {
         editingRoutineId !== null ? m.templates_routine_updated() : m.templates_routine_created(),
       );
     } catch (err) {
-      setSubmitError(err instanceof Error ? err.message : m.templates_routine_save_failed());
+      setRoutineSubmitError(err instanceof Error ? err.message : m.templates_routine_save_failed());
     } finally {
-      setIsSubmitting(false);
+      setIsRoutineSubmitting(false);
     }
   };
 
   const submitChore = async () => {
     if (!choreName.trim()) {
-      setSubmitError(m.templates_chore_name_required());
+      setChoreSubmitError(m.templates_chore_name_required());
       return;
     }
     const everyNDaysChore = parseInt(choreEveryNDays, 10);
     if (!Number.isInteger(everyNDaysChore) || everyNDaysChore < 1) {
-      setSubmitError(m.templates_every_n_error());
+      setChoreSubmitError(m.templates_every_n_error());
       return;
     }
-    setIsSubmitting(true);
-    setSubmitError(null);
+    setIsChoreSubmitting(true);
+    setChoreSubmitError(null);
     setSuccessMessage(null);
     try {
       const payload = {
@@ -155,41 +166,43 @@ export function TemplatesPage() {
         editingChoreId !== null ? m.templates_chore_updated() : m.templates_chore_created(),
       );
     } catch (err) {
-      setSubmitError(err instanceof Error ? err.message : m.templates_chore_save_failed());
+      setChoreSubmitError(err instanceof Error ? err.message : m.templates_chore_save_failed());
     } finally {
-      setIsSubmitting(false);
+      setIsChoreSubmitting(false);
     }
   };
 
   const handleDeleteRoutine = async (routineId: number) => {
     setConfirmDeleteRoutineId(null);
-    setIsSubmitting(true);
-    setSubmitError(null);
+    setIsRoutineSubmitting(true);
+    setRoutineSubmitError(null);
     setSuccessMessage(null);
     try {
       await deleteRoutineMutation.mutateAsync(routineId);
       if (editingRoutineId === routineId) resetRoutineForm();
       setSuccessMessage(m.templates_routine_deleted());
     } catch (err) {
-      setSubmitError(err instanceof Error ? err.message : m.templates_routine_delete_failed());
+      setRoutineSubmitError(
+        err instanceof Error ? err.message : m.templates_routine_delete_failed(),
+      );
     } finally {
-      setIsSubmitting(false);
+      setIsRoutineSubmitting(false);
     }
   };
 
   const handleDeleteChore = async (choreId: number) => {
     setConfirmDeleteChoreId(null);
-    setIsSubmitting(true);
-    setSubmitError(null);
+    setIsChoreSubmitting(true);
+    setChoreSubmitError(null);
     setSuccessMessage(null);
     try {
       await deleteChoreMutation.mutateAsync(choreId);
       if (editingChoreId === choreId) resetChoreForm();
       setSuccessMessage(m.templates_chore_deleted());
     } catch (err) {
-      setSubmitError(err instanceof Error ? err.message : m.templates_chore_delete_failed());
+      setChoreSubmitError(err instanceof Error ? err.message : m.templates_chore_delete_failed());
     } finally {
-      setIsSubmitting(false);
+      setIsChoreSubmitting(false);
     }
   };
 
@@ -204,14 +217,16 @@ export function TemplatesPage() {
           onClick={() => void loadTemplates()}
         >
           {refreshing ? (
-            <span className="spinner-border spinner-border-sm me-1" role="status" aria-hidden="true" />
+            <span
+              className="spinner-border spinner-border-sm me-1"
+              role="status"
+              aria-hidden="true"
+            />
           ) : null}
           {m.action_refresh()}
         </button>
       </div>
-      <p className="text-muted mb-3">
-        {m.templates_subtitle()}
-      </p>
+      <p className="text-muted mb-3">{m.templates_subtitle()}</p>
 
       <FeedbackBanner message={loading ? m.templates_loading() : null} tone="info" />
       {error ? (
@@ -228,14 +243,22 @@ export function TemplatesPage() {
           ) : null}
         </div>
       ) : null}
-      <FeedbackBanner message={submitError} tone="danger" onDismiss={() => setSubmitError(null)} />
-      <FeedbackBanner message={successMessage} tone="success" onDismiss={() => setSuccessMessage(null)} />
+      <FeedbackBanner
+        message={successMessage}
+        tone="success"
+        onDismiss={() => setSuccessMessage(null)}
+      />
 
       <div className="row g-3">
         <div className="col-xl-6">
           <div className="card mb-3">
             <div className="card-header fw-semibold py-2">{m.templates_routine_form_header()}</div>
             <div className="card-body d-grid gap-2">
+              <FeedbackBanner
+                message={routineSubmitError}
+                tone="danger"
+                onDismiss={() => setRoutineSubmitError(null)}
+              />
               <input
                 className="form-control"
                 value={routineName}
@@ -251,7 +274,9 @@ export function TemplatesPage() {
               />
               <div className="row g-2">
                 <div className="col-sm-6">
-                  <label className="form-label small fw-semibold mb-1">{m.templates_start_date_label()}</label>
+                  <label className="form-label small fw-semibold mb-1">
+                    {m.templates_start_date_label()}
+                  </label>
                   <input
                     className="form-control"
                     type="date"
@@ -260,7 +285,9 @@ export function TemplatesPage() {
                   />
                 </div>
                 <div className="col-sm-6">
-                  <label className="form-label small fw-semibold mb-1">{m.templates_every_n_days_label()}</label>
+                  <label className="form-label small fw-semibold mb-1">
+                    {m.templates_every_n_days_label()}
+                  </label>
                   <input
                     className="form-control"
                     type="number"
@@ -271,7 +298,9 @@ export function TemplatesPage() {
                 </div>
               </div>
               <div>
-                <label className="form-label small fw-semibold mb-1">{m.templates_due_time_label()}</label>
+                <label className="form-label small fw-semibold mb-1">
+                  {m.templates_due_time_label()}
+                </label>
                 <input
                   className="form-control"
                   type="time"
@@ -292,10 +321,10 @@ export function TemplatesPage() {
                 <button
                   type="button"
                   className="btn btn-primary"
-                  disabled={isSubmitting}
+                  disabled={isRoutineSubmitting}
                   onClick={() => void submitRoutine()}
                 >
-                  {isSubmitting
+                  {isRoutineSubmitting
                     ? editingRoutineId !== null
                       ? m.action_saving()
                       : m.action_creating()
@@ -307,7 +336,7 @@ export function TemplatesPage() {
                   <button
                     type="button"
                     className="btn btn-outline-secondary"
-                    disabled={isSubmitting}
+                    disabled={isRoutineSubmitting}
                     onClick={resetRoutineForm}
                   >
                     {m.templates_cancel_edit()}
@@ -351,7 +380,10 @@ export function TemplatesPage() {
                         {(() => {
                           const streak = routineStreakMap.get(routine.id);
                           return streak && streak.current_streak > 0 ? (
-                            <span className="badge text-bg-warning" title={`Best: ${streak.longest_streak}`}>
+                            <span
+                              className="badge text-bg-warning"
+                              title={`Best: ${streak.longest_streak}`}
+                            >
                               🔥 {streak.current_streak}
                             </span>
                           ) : null;
@@ -368,7 +400,8 @@ export function TemplatesPage() {
                             setRoutineDueTime(routine.due_time ? routine.due_time.slice(0, 5) : "");
                             setRoutineActive(routine.is_active);
                             setConfirmDeleteRoutineId(null);
-                            setSubmitError(null);
+                            setRoutineSubmitError(null);
+                            setSuccessMessage(null);
                           }}
                         >
                           {m.action_edit()}
@@ -378,7 +411,7 @@ export function TemplatesPage() {
                             <button
                               type="button"
                               className="btn btn-danger btn-sm"
-                              disabled={isSubmitting}
+                              disabled={isRoutineSubmitting}
                               onClick={() => void handleDeleteRoutine(routine.id)}
                             >
                               {m.action_confirm()}
@@ -386,7 +419,7 @@ export function TemplatesPage() {
                             <button
                               type="button"
                               className="btn btn-outline-secondary btn-sm"
-                              disabled={isSubmitting}
+                              disabled={isRoutineSubmitting}
                               onClick={() => setConfirmDeleteRoutineId(null)}
                             >
                               {m.action_cancel()}
@@ -414,6 +447,11 @@ export function TemplatesPage() {
           <div className="card mb-3">
             <div className="card-header fw-semibold py-2">{m.templates_chore_form_header()}</div>
             <div className="card-body d-grid gap-2">
+              <FeedbackBanner
+                message={choreSubmitError}
+                tone="danger"
+                onDismiss={() => setChoreSubmitError(null)}
+              />
               <input
                 className="form-control"
                 value={choreName}
@@ -429,7 +467,9 @@ export function TemplatesPage() {
               />
               <div className="row g-2">
                 <div className="col-sm-6">
-                  <label className="form-label small fw-semibold mb-1">{m.templates_start_date_label()}</label>
+                  <label className="form-label small fw-semibold mb-1">
+                    {m.templates_start_date_label()}
+                  </label>
                   <input
                     className="form-control"
                     type="date"
@@ -438,7 +478,9 @@ export function TemplatesPage() {
                   />
                 </div>
                 <div className="col-sm-6">
-                  <label className="form-label small fw-semibold mb-1">{m.templates_every_n_days_label()}</label>
+                  <label className="form-label small fw-semibold mb-1">
+                    {m.templates_every_n_days_label()}
+                  </label>
                   <input
                     className="form-control"
                     type="number"
@@ -461,10 +503,10 @@ export function TemplatesPage() {
                 <button
                   type="button"
                   className="btn btn-primary"
-                  disabled={isSubmitting}
+                  disabled={isChoreSubmitting}
                   onClick={() => void submitChore()}
                 >
-                  {isSubmitting
+                  {isChoreSubmitting
                     ? editingChoreId !== null
                       ? m.action_saving()
                       : m.action_creating()
@@ -476,7 +518,7 @@ export function TemplatesPage() {
                   <button
                     type="button"
                     className="btn btn-outline-secondary"
-                    disabled={isSubmitting}
+                    disabled={isChoreSubmitting}
                     onClick={resetChoreForm}
                   >
                     {m.templates_cancel_edit()}
@@ -516,7 +558,10 @@ export function TemplatesPage() {
                         {(() => {
                           const streak = choreStreakMap.get(chore.id);
                           return streak && streak.current_streak > 0 ? (
-                            <span className="badge text-bg-warning" title={`Best: ${streak.longest_streak}`}>
+                            <span
+                              className="badge text-bg-warning"
+                              title={`Best: ${streak.longest_streak}`}
+                            >
                               🔥 {streak.current_streak}
                             </span>
                           ) : null;
@@ -532,7 +577,8 @@ export function TemplatesPage() {
                             setChoreEveryNDays(String(chore.every_n_days));
                             setChoreActive(chore.is_active);
                             setConfirmDeleteChoreId(null);
-                            setSubmitError(null);
+                            setChoreSubmitError(null);
+                            setSuccessMessage(null);
                           }}
                         >
                           {m.action_edit()}
@@ -542,7 +588,7 @@ export function TemplatesPage() {
                             <button
                               type="button"
                               className="btn btn-danger btn-sm"
-                              disabled={isSubmitting}
+                              disabled={isChoreSubmitting}
                               onClick={() => void handleDeleteChore(chore.id)}
                             >
                               {m.action_confirm()}
@@ -550,7 +596,7 @@ export function TemplatesPage() {
                             <button
                               type="button"
                               className="btn btn-outline-secondary btn-sm"
-                              disabled={isSubmitting}
+                              disabled={isChoreSubmitting}
                               onClick={() => setConfirmDeleteChoreId(null)}
                             >
                               {m.action_cancel()}

--- a/frontend/src/features/today/TodayPage.tsx
+++ b/frontend/src/features/today/TodayPage.tsx
@@ -26,12 +26,16 @@ import { useTodayLiveUpdates } from "@/features/today/useTodayLiveUpdates";
 import { useTodayQuery } from "@/features/today/useTodayQuery";
 
 export function TodayPage() {
-  useTodayLiveUpdates();
+  const liveUpdatesError = useTodayLiveUpdates();
   const todayQuery = useTodayQuery();
   const today = todayQuery.data ?? null;
   const isLoading = todayQuery.isLoading;
   const isRefreshing = todayQuery.isFetching && !isLoading;
-  const error = todayQuery.error ? (todayQuery.error instanceof Error ? todayQuery.error.message : "Unable to load today payload.") : null;
+  const error = todayQuery.error
+    ? todayQuery.error instanceof Error
+      ? todayQuery.error.message
+      : "Unable to load today payload."
+    : null;
   const canRetry = todayQuery.error ? isRetryableApiError(todayQuery.error) : false;
   const loadToday = useCallback(async () => {
     await todayQuery.refetch();
@@ -57,7 +61,8 @@ export function TodayPage() {
         label: m.action_done(),
         buttonClassName: "btn-success",
         isAvailable: (item) => Boolean(item.taskInstanceId && isItemActionable(item)),
-        run: (item) => actions.completeRoutineTask(item.taskInstanceId as number, { refresh: false }),
+        run: (item) =>
+          actions.completeRoutineTask(item.taskInstanceId as number, { refresh: false }),
       },
       {
         key: "routine-skip",
@@ -182,17 +187,20 @@ export function TodayPage() {
             onClick={() => void loadToday()}
           >
             {isRefreshing ? (
-              <span className="spinner-border spinner-border-sm me-1" role="status" aria-hidden="true" />
+              <span
+                className="spinner-border spinner-border-sm me-1"
+                role="status"
+                aria-hidden="true"
+              />
             ) : null}
             {m.action_refresh()}
           </button>
         </div>
       </div>
-      <p className="text-muted mb-3">
-        {m.today_subtitle()}
-      </p>
+      <p className="text-muted mb-3">{m.today_subtitle()}</p>
 
       <FeedbackBanner message={isLoading ? m.today_loading() : null} tone="info" />
+      <FeedbackBanner message={liveUpdatesError} tone="warning" />
       {!isLoading && error ? (
         <div className="alert alert-danger py-2 d-flex justify-content-between align-items-center gap-2 flex-wrap">
           <span>{error}</span>
@@ -219,11 +227,31 @@ export function TodayPage() {
       {!isLoading && !error && today ? (
         <>
           <div className="row g-3 mb-3">
-            <SummaryCard label={m.today_summary_overdue()} value={today.overdue.length} tone="danger" />
-            <SummaryCard label={m.today_summary_due_today()} value={today.due_today.length} tone="warning" />
-            <SummaryCard label={m.today_summary_medication_due()} value={scheduledMedicationCount} tone="info" />
-            <SummaryCard label={m.today_summary_open_plans()} value={openPlannedCount} tone="primary" />
-            <SummaryCard label={m.today_summary_open_routines()} value={routineOpenCount} tone="secondary" />
+            <SummaryCard
+              label={m.today_summary_overdue()}
+              value={today.overdue.length}
+              tone="danger"
+            />
+            <SummaryCard
+              label={m.today_summary_due_today()}
+              value={today.due_today.length}
+              tone="warning"
+            />
+            <SummaryCard
+              label={m.today_summary_medication_due()}
+              value={scheduledMedicationCount}
+              tone="info"
+            />
+            <SummaryCard
+              label={m.today_summary_open_plans()}
+              value={openPlannedCount}
+              tone="primary"
+            />
+            <SummaryCard
+              label={m.today_summary_open_routines()}
+              value={routineOpenCount}
+              tone="secondary"
+            />
           </div>
           <WebFocusPanel sections={sections} />
           <PlannedSection
@@ -231,16 +259,18 @@ export function TodayPage() {
             onRefresh={loadToday}
             bulkActions={plannedBulkActions}
           />
-          {sections.filter((section) => section.key !== "planned").map((section) => (
-            <SectionCard
-              key={section.key}
-              sectionId={section.key}
-              heading={section.heading}
-              items={section.items}
-              onRefresh={loadToday}
-              bulkActions={section.bulkActions}
-            />
-          ))}
+          {sections
+            .filter((section) => section.key !== "planned")
+            .map((section) => (
+              <SectionCard
+                key={section.key}
+                sectionId={section.key}
+                heading={section.heading}
+                items={section.items}
+                onRefresh={loadToday}
+                bulkActions={section.bulkActions}
+              />
+            ))}
         </>
       ) : null}
     </section>

--- a/frontend/src/features/today/TodayPage.tsx
+++ b/frontend/src/features/today/TodayPage.tsx
@@ -1,3 +1,4 @@
+import { Link } from "@tanstack/react-router";
 import confetti from "canvas-confetti";
 import { useCallback, useEffect, useMemo, useRef } from "react";
 import * as m from "@/paraglide/messages";
@@ -202,10 +203,18 @@ export function TodayPage() {
           ) : null}
         </div>
       ) : null}
-      <FeedbackBanner
-        message={!isLoading && !error && today && !hasAnyItems ? m.today_nothing_scheduled() : null}
-        tone="secondary"
-      />
+      {!isLoading && !error && today && !hasAnyItems ? (
+        <div
+          className="alert alert-secondary py-2 d-flex justify-content-between align-items-center gap-2 flex-wrap"
+          role="status"
+          aria-live="polite"
+        >
+          <span>{m.today_nothing_scheduled()}</span>
+          <Link to="/templates" className="btn btn-primary btn-sm">
+            {m.today_create_first_chore()}
+          </Link>
+        </div>
+      ) : null}
 
       {!isLoading && !error && today ? (
         <>

--- a/frontend/src/features/today/TodayPage.tsx
+++ b/frontend/src/features/today/TodayPage.tsx
@@ -204,11 +204,7 @@ export function TodayPage() {
         </div>
       ) : null}
       {!isLoading && !error && today && !hasAnyItems ? (
-        <div
-          className="alert alert-secondary py-2 d-flex justify-content-between align-items-center gap-2 flex-wrap"
-          role="status"
-          aria-live="polite"
-        >
+        <div className="alert alert-secondary py-2 d-flex justify-content-between align-items-center gap-2 flex-wrap">
           <span>{m.today_nothing_scheduled()}</span>
           <Link to="/templates" className="btn btn-primary btn-sm">
             {m.today_create_first_chore()}

--- a/frontend/src/features/today/TodayPage.tsx
+++ b/frontend/src/features/today/TodayPage.tsx
@@ -30,6 +30,7 @@ export function TodayPage() {
   const todayQuery = useTodayQuery();
   const today = todayQuery.data ?? null;
   const isLoading = todayQuery.isLoading;
+  const isRefreshing = todayQuery.isFetching && !isLoading;
   const error = todayQuery.error ? (todayQuery.error instanceof Error ? todayQuery.error.message : "Unable to load today payload.") : null;
   const canRetry = todayQuery.error ? isRetryableApiError(todayQuery.error) : false;
   const loadToday = useCallback(async () => {
@@ -177,9 +178,12 @@ export function TodayPage() {
           <button
             className="btn btn-outline-primary btn-sm flex-md-grow-0"
             type="button"
-            disabled={isLoading}
+            disabled={isLoading || isRefreshing}
             onClick={() => void loadToday()}
           >
+            {isRefreshing ? (
+              <span className="spinner-border spinner-border-sm me-1" role="status" aria-hidden="true" />
+            ) : null}
             {m.action_refresh()}
           </button>
         </div>

--- a/frontend/src/features/today/TodaySections.tsx
+++ b/frontend/src/features/today/TodaySections.tsx
@@ -14,6 +14,7 @@ import {
   type UpcomingTodayItem,
 } from "@/lib/api/today";
 import { capitalize, formatDate, formatDateTime, formatTime } from "@/lib/dateUtils";
+import { FeedbackBanner } from "@/components/common/FeedbackBanner";
 import { useTodayActions } from "@/features/today/useTodayActions";
 
 export type BulkAction = {
@@ -602,14 +603,12 @@ export function SectionCard({
   const allSelected = selectableItems.length > 0 && selectedIds.length === selectableItems.length;
 
   const toggleSelected = (itemId: string) => {
-    setBulkFeedback(null);
     setSelectedIds((current) =>
       current.includes(itemId) ? current.filter((id) => id !== itemId) : [...current, itemId],
     );
   };
 
   const toggleAllSelected = () => {
-    setBulkFeedback(null);
     setSelectedIds(allSelected ? [] : selectableItems.map((item) => item.id));
   };
 
@@ -685,9 +684,11 @@ export function SectionCard({
                   );
                 })}
               </div>
-              {bulkFeedback ? (
-                <small className={`text-${bulkFeedback.tone}`}>{bulkFeedback.text}</small>
-              ) : null}
+              <FeedbackBanner
+                message={bulkFeedback?.text ?? null}
+                tone={bulkFeedback?.tone}
+                onDismiss={() => setBulkFeedback(null)}
+              />
             </div>
           ) : null}
         </div>

--- a/frontend/src/features/today/useTodayLiveUpdates.ts
+++ b/frontend/src/features/today/useTodayLiveUpdates.ts
@@ -1,14 +1,18 @@
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import { useQueryClient } from "@tanstack/react-query";
+import * as m from "@/paraglide/messages";
 import { buildApiUrl } from "@/lib/api/serverConfig";
-import { getOidcAccessToken } from "@/lib/auth/session";
+import { useOidcAccessToken } from "@/lib/auth/session";
 import { queryKeys } from "@/lib/query/queryKeys";
 
-export function useTodayLiveUpdates(): void {
+export function useTodayLiveUpdates(): string | null {
   const queryClient = useQueryClient();
-  const token = getOidcAccessToken();
+  const token = useOidcAccessToken();
+  const [connectionError, setConnectionError] = useState<string | null>(null);
 
   useEffect(() => {
+    setConnectionError(null);
+
     if (typeof EventSource === "undefined") return;
     if (!token) return;
 
@@ -17,6 +21,8 @@ export function useTodayLiveUpdates(): void {
     let connected = false;
 
     es.addEventListener("open", () => {
+      setConnectionError(null);
+
       if (connected) {
         // Reconnect after a drop — missed events won't be replayed, so refetch.
         void queryClient.invalidateQueries({ queryKey: queryKeys.today.read() });
@@ -25,11 +31,18 @@ export function useTodayLiveUpdates(): void {
     });
 
     es.addEventListener("today_updated", () => {
+      setConnectionError(null);
       void queryClient.invalidateQueries({ queryKey: queryKeys.today.read() });
+    });
+
+    es.addEventListener("error", () => {
+      setConnectionError(m.today_live_updates_interrupted());
     });
 
     return () => {
       es.close();
     };
   }, [queryClient, token]);
+
+  return connectionError;
 }

--- a/frontend/src/lib/api/auth.ts
+++ b/frontend/src/lib/api/auth.ts
@@ -24,6 +24,7 @@ export interface OAuthSession {
   last_access: number | null;
   expires: number | null;
   clients: OAuthSessionClient[];
+  is_current: boolean;
 }
 
 export class AuthApiError extends Error {

--- a/frontend/src/lib/auth/session.ts
+++ b/frontend/src/lib/auth/session.ts
@@ -1,13 +1,30 @@
+import { useSyncExternalStore } from "react";
+
 /**
  * Module-level OIDC access token bridge.
  * AuthProvider writes the current token here so non-React modules can read it.
  */
 let _oidcAccessToken: string | undefined;
+const listeners = new Set<() => void>();
 
 export function setOidcAccessToken(token: string | undefined): void {
+  if (_oidcAccessToken === token) return;
+
   _oidcAccessToken = token;
+  listeners.forEach((listener) => listener());
 }
 
 export function getOidcAccessToken(): string | undefined {
   return _oidcAccessToken;
+}
+
+function subscribeOidcAccessToken(listener: () => void): () => void {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+export function useOidcAccessToken(): string | undefined {
+  return useSyncExternalStore(subscribeOidcAccessToken, getOidcAccessToken, getOidcAccessToken);
 }

--- a/frontend/src/mocks/MockAuthProvider.tsx
+++ b/frontend/src/mocks/MockAuthProvider.tsx
@@ -25,6 +25,7 @@ export function MockAuthProvider({ children }: { children: React.ReactNode }) {
         logout: () => {},
         refreshUser: async () => {},
         sessionError: null,
+        oidcError: null,
       }}
     >
       {children}

--- a/frontend/src/mocks/MockAuthProvider.tsx
+++ b/frontend/src/mocks/MockAuthProvider.tsx
@@ -24,6 +24,7 @@ export function MockAuthProvider({ children }: { children: React.ReactNode }) {
         login: () => {},
         logout: () => {},
         refreshUser: async () => {},
+        sessionError: null,
       }}
     >
       {children}

--- a/frontend/tests/features/auth/AuthPage.test.tsx
+++ b/frontend/tests/features/auth/AuthPage.test.tsx
@@ -17,6 +17,7 @@ vi.mock("@/app/providers/AuthProvider", () => ({
     login: authMock.loginStub,
     logout: authMock.logoutStub,
     refreshUser: authMock.refreshUserStub,
+    sessionError: null,
     user: null,
   }),
 }));

--- a/frontend/tests/features/auth/AuthPage.test.tsx
+++ b/frontend/tests/features/auth/AuthPage.test.tsx
@@ -8,6 +8,7 @@ const authMock = vi.hoisted(() => ({
   loginStub: vi.fn(),
   logoutStub: vi.fn(),
   refreshUserStub: vi.fn(),
+  oidcError: null as string | null,
 }));
 
 vi.mock("@/app/providers/AuthProvider", () => ({
@@ -18,6 +19,7 @@ vi.mock("@/app/providers/AuthProvider", () => ({
     logout: authMock.logoutStub,
     refreshUser: authMock.refreshUserStub,
     sessionError: null,
+    oidcError: authMock.oidcError,
     user: null,
   }),
 }));
@@ -34,6 +36,7 @@ describe("AuthPage", () => {
     authMock.loginStub.mockReset();
     authMock.logoutStub.mockReset();
     authMock.refreshUserStub.mockReset();
+    authMock.oidcError = null;
   });
 
   it("renders the sign-in heading", async () => {
@@ -50,6 +53,15 @@ describe("AuthPage", () => {
     const { container } = renderAuthPage();
     expect(container.querySelector('input[type="email"]')).not.toBeInTheDocument();
     expect(container.querySelector('input[type="password"]')).not.toBeInTheDocument();
+  });
+
+  it("renders an OIDC error when sign-in fails after redirect", async () => {
+    authMock.oidcError = "State mismatch";
+
+    renderAuthPage();
+
+    expect(await screen.findByRole("alert")).toHaveTextContent(/sign-in failed/i);
+    expect(screen.getByText("State mismatch")).toBeInTheDocument();
   });
 
   it("calls login() when the sign-in button is clicked", async () => {

--- a/frontend/tests/features/auth/AuthProvider.test.tsx
+++ b/frontend/tests/features/auth/AuthProvider.test.tsx
@@ -11,6 +11,7 @@ const authMock = vi.hoisted(() => ({
     isAuthenticated: false,
     signinRedirect: vi.fn(),
     signoutRedirect: vi.fn(),
+    error: undefined as unknown,
   },
 }));
 
@@ -31,9 +32,15 @@ function LoginButton() {
   return <button onClick={login}>Sign in</button>;
 }
 
+function OidcErrorMessage() {
+  const { oidcError } = useAuth();
+  return <div>{oidcError}</div>;
+}
+
 describe("AuthProvider login returnTo", () => {
   beforeEach(() => {
     authMock.oidc.signinRedirect.mockReset();
+    authMock.oidc.error = undefined;
   });
 
   it("uses /today when login starts on /auth", async () => {
@@ -51,6 +58,18 @@ describe("AuthProvider login returnTo", () => {
     expect(authMock.oidc.signinRedirect).toHaveBeenCalledWith({
       state: { returnTo: "/today" },
     });
+  });
+
+  it("falls back to the OIDC error string when message is empty", () => {
+    authMock.oidc.error = { message: "", toString: () => "State mismatch" };
+
+    render(
+      <AuthProvider>
+        <OidcErrorMessage />
+      </AuthProvider>,
+    );
+
+    expect(screen.getByText("State mismatch")).toBeInTheDocument();
   });
 
   it("preserves path, search, and hash for app routes", async () => {

--- a/frontend/tests/features/router/AppRouter.test.tsx
+++ b/frontend/tests/features/router/AppRouter.test.tsx
@@ -8,7 +8,7 @@ vi.mock("react-oidc-context", () => ({
 }));
 
 vi.mock("@/app/providers/AuthProvider", () => ({
-  useAuth: () => ({ isAuthenticated: true, isLoading: false, user: null, login: vi.fn(), logout: vi.fn(), refreshUser: vi.fn() }),
+  useAuth: () => ({ isAuthenticated: true, isLoading: false, user: null, login: vi.fn(), logout: vi.fn(), refreshUser: vi.fn(), sessionError: null }),
 }));
 
 vi.mock("@/paraglide/messages", () => ({

--- a/frontend/tests/features/settings/AccountDeletionSection.test.tsx
+++ b/frontend/tests/features/settings/AccountDeletionSection.test.tsx
@@ -46,37 +46,58 @@ describe("AccountDeletionSection", () => {
     vi.restoreAllMocks();
   });
 
-  it("does not delete the account when confirmation is cancelled", async () => {
+  it("does not delete the account when inline confirmation is cancelled", async () => {
     const user = userEvent.setup();
-    vi.spyOn(window, "confirm").mockReturnValue(false);
+    const confirmSpy = vi.spyOn(window, "confirm");
     renderSection();
 
     await user.click(screen.getByRole("button", { name: /delete my account/i }));
+    expect(screen.getByText(/this permanently deletes your daynest account/i)).toBeInTheDocument();
 
+    await user.click(screen.getByRole("button", { name: /cancel/i }));
+
+    expect(confirmSpy).not.toHaveBeenCalled();
     expect(apiMock.deleteAccount).not.toHaveBeenCalled();
   });
 
   it("deletes the account and logs out after confirmation", async () => {
     const user = userEvent.setup();
     const { logout } = renderSection();
-    vi.spyOn(window, "confirm").mockReturnValue(true);
+    const confirmSpy = vi.spyOn(window, "confirm");
     apiMock.deleteAccount.mockResolvedValue(undefined);
 
     await user.click(screen.getByRole("button", { name: /delete my account/i }));
+    await user.click(screen.getByRole("button", { name: /confirm/i }));
 
+    expect(confirmSpy).not.toHaveBeenCalled();
     await waitFor(() => {
       expect(apiMock.deleteAccount).toHaveBeenCalledTimes(1);
       expect(logout).toHaveBeenCalledTimes(1);
     });
   });
 
-  it("shows the server error when deletion is blocked", async () => {
+  it("clears server errors when inline confirmation is cancelled", async () => {
     const user = userEvent.setup();
-    const { logout } = renderSection();
-    vi.spyOn(window, "confirm").mockReturnValue(true);
+    renderSection();
     apiMock.deleteAccount.mockRejectedValue(new Error("Delete shared chores first."));
 
     await user.click(screen.getByRole("button", { name: /delete my account/i }));
+    await user.click(screen.getByRole("button", { name: /confirm/i }));
+
+    expect(await screen.findByText("Delete shared chores first.")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: /cancel/i }));
+
+    expect(screen.queryByText("Delete shared chores first.")).not.toBeInTheDocument();
+  });
+
+  it("shows the server error when deletion is blocked", async () => {
+    const user = userEvent.setup();
+    const { logout } = renderSection();
+    apiMock.deleteAccount.mockRejectedValue(new Error("Delete shared chores first."));
+
+    await user.click(screen.getByRole("button", { name: /delete my account/i }));
+    await user.click(screen.getByRole("button", { name: /confirm/i }));
 
     expect(await screen.findByText("Delete shared chores first.")).toBeInTheDocument();
     expect(logout).not.toHaveBeenCalled();

--- a/frontend/tests/features/settings/AccountDeletionSection.test.tsx
+++ b/frontend/tests/features/settings/AccountDeletionSection.test.tsx
@@ -68,6 +68,10 @@ describe("AccountDeletionSection", () => {
     apiMock.deleteAccount.mockResolvedValue(undefined);
 
     await user.click(screen.getByRole("button", { name: /delete my account/i }));
+    await user.type(
+      screen.getByLabelText(/type your email address to confirm/i),
+      "user@example.com",
+    );
     await user.click(screen.getByRole("button", { name: /confirm/i }));
 
     expect(confirmSpy).not.toHaveBeenCalled();
@@ -83,6 +87,10 @@ describe("AccountDeletionSection", () => {
     apiMock.deleteAccount.mockRejectedValue(new Error("Delete shared chores first."));
 
     await user.click(screen.getByRole("button", { name: /delete my account/i }));
+    await user.type(
+      screen.getByLabelText(/type your email address to confirm/i),
+      "user@example.com",
+    );
     await user.click(screen.getByRole("button", { name: /confirm/i }));
 
     expect(await screen.findByText("Delete shared chores first.")).toBeInTheDocument();
@@ -98,6 +106,10 @@ describe("AccountDeletionSection", () => {
     apiMock.deleteAccount.mockRejectedValue(new Error("Delete shared chores first."));
 
     await user.click(screen.getByRole("button", { name: /delete my account/i }));
+    await user.type(
+      screen.getByLabelText(/type your email address to confirm/i),
+      "user@example.com",
+    );
     await user.click(screen.getByRole("button", { name: /confirm/i }));
 
     expect(await screen.findByText("Delete shared chores first.")).toBeInTheDocument();

--- a/frontend/tests/features/settings/AccountDeletionSection.test.tsx
+++ b/frontend/tests/features/settings/AccountDeletionSection.test.tsx
@@ -30,6 +30,7 @@ function renderSection(logout = vi.fn()) {
         logout,
         refreshUser: vi.fn(),
         sessionError: null,
+        oidcError: null,
       }}
     >
       <AccountDeletionSection />

--- a/frontend/tests/features/settings/AccountDeletionSection.test.tsx
+++ b/frontend/tests/features/settings/AccountDeletionSection.test.tsx
@@ -29,6 +29,7 @@ function renderSection(logout = vi.fn()) {
         login: vi.fn(),
         logout,
         refreshUser: vi.fn(),
+        sessionError: null,
       }}
     >
       <AccountDeletionSection />

--- a/frontend/tests/features/settings/SettingsPage.test.tsx
+++ b/frontend/tests/features/settings/SettingsPage.test.tsx
@@ -267,6 +267,34 @@ describe("SettingsPage", () => {
     });
   });
 
+  it("uses an inline confirmation before deleting an account", async () => {
+    const user = userEvent.setup();
+    const confirmSpy = vi.spyOn(window, "confirm");
+    apiMock.deleteAccount.mockResolvedValue(undefined);
+
+    try {
+      render(
+        <QueryTestProvider>
+          <SettingsPage />
+        </QueryTestProvider>,
+      );
+
+      const deleteButton = await screen.findByRole("button", { name: /delete my account/i });
+      await user.click(deleteButton);
+
+      expect(confirmSpy).not.toHaveBeenCalled();
+      expect(screen.getByText(/this permanently deletes your daynest account/i)).toBeInTheDocument();
+
+      await user.click(screen.getByRole("button", { name: /^confirm$/i }));
+
+      await waitFor(() => {
+        expect(apiMock.deleteAccount).toHaveBeenCalledTimes(1);
+      });
+    } finally {
+      confirmSpy.mockRestore();
+    }
+  });
+
   it("switches language to Dutch immediately", async () => {
     const user = userEvent.setup();
     render(

--- a/frontend/tests/features/settings/SettingsPage.test.tsx
+++ b/frontend/tests/features/settings/SettingsPage.test.tsx
@@ -2,6 +2,7 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { AuthContext } from "@/app/providers/AuthProvider";
 import { SettingsPage } from "@/features/settings/SettingsPage";
 import { LanguageProvider } from "@/i18n/LanguageProvider";
 import { setLocale } from "@/paraglide/runtime";
@@ -41,6 +42,30 @@ vi.mock("@/app/pwa/installPrompt", () => ({
   promptToInstallApp: pwaMock.promptToInstallApp,
   subscribeInstallPrompt: pwaMock.subscribeInstallPrompt,
 }));
+
+function renderSettingsPage(children: React.ReactNode) {
+  return render(
+    <AuthContext.Provider
+      value={{
+        user: {
+          id: 1,
+          email: "user@example.com",
+          full_name: "Test User",
+          is_active: true,
+          roles: [],
+        },
+        isLoading: false,
+        isAuthenticated: true,
+        login: vi.fn(),
+        logout: vi.fn(),
+        refreshUser: vi.fn(),
+        sessionError: null,
+      }}
+    >
+      {children}
+    </AuthContext.Provider>,
+  );
+}
 
 describe("SettingsPage", () => {
   beforeEach(() => {
@@ -211,7 +236,9 @@ describe("SettingsPage", () => {
     await user.click(overdueToggle);
 
     await waitFor(() => {
-      expect(apiMock.updateUserSettings).toHaveBeenCalledWith({ push_overdue_chores_enabled: false });
+      expect(apiMock.updateUserSettings).toHaveBeenCalledWith({
+        push_overdue_chores_enabled: false,
+      });
     });
   });
 
@@ -219,7 +246,10 @@ describe("SettingsPage", () => {
     const user = userEvent.setup();
     let resolveFirst!: (v: unknown) => void;
     apiMock.updateUserSettings.mockImplementationOnce(
-      () => new Promise((r) => { resolveFirst = r; }),
+      () =>
+        new Promise((r) => {
+          resolveFirst = r;
+        }),
     );
     render(
       <QueryTestProvider>
@@ -273,7 +303,7 @@ describe("SettingsPage", () => {
     apiMock.deleteAccount.mockResolvedValue(undefined);
 
     try {
-      render(
+      renderSettingsPage(
         <QueryTestProvider>
           <SettingsPage />
         </QueryTestProvider>,
@@ -283,8 +313,14 @@ describe("SettingsPage", () => {
       await user.click(deleteButton);
 
       expect(confirmSpy).not.toHaveBeenCalled();
-      expect(screen.getByText(/this permanently deletes your daynest account/i)).toBeInTheDocument();
+      expect(
+        screen.getByText(/this permanently deletes your daynest account/i),
+      ).toBeInTheDocument();
 
+      await user.type(
+        screen.getByLabelText(/type your email address to confirm/i),
+        "user@example.com",
+      );
       await user.click(screen.getByRole("button", { name: /^confirm$/i }));
 
       await waitFor(() => {
@@ -299,13 +335,17 @@ describe("SettingsPage", () => {
     const user = userEvent.setup();
     render(
       <QueryTestProvider>
-        <LanguageProvider><SettingsPage /></LanguageProvider>
+        <LanguageProvider>
+          <SettingsPage />
+        </LanguageProvider>
       </QueryTestProvider>,
     );
 
     const languageSelect = await screen.findByRole("combobox", { name: /language/i });
     await user.selectOptions(languageSelect, "nl");
 
-    expect(await screen.findByRole("heading", { level: 2, name: /instellingen/i })).toBeInTheDocument();
+    expect(
+      await screen.findByRole("heading", { level: 2, name: /instellingen/i }),
+    ).toBeInTheDocument();
   });
 });

--- a/frontend/tests/features/settings/SettingsPage.test.tsx
+++ b/frontend/tests/features/settings/SettingsPage.test.tsx
@@ -60,6 +60,7 @@ function renderSettingsPage(children: React.ReactNode) {
         logout: vi.fn(),
         refreshUser: vi.fn(),
         sessionError: null,
+        oidcError: null,
       }}
     >
       {children}

--- a/frontend/tests/features/today/TodaySections.test.tsx
+++ b/frontend/tests/features/today/TodaySections.test.tsx
@@ -211,6 +211,64 @@ describe("Today section components", () => {
     expect(screen.getByText("Bulk Done updated 1 item and failed for 1.")).toBeInTheDocument();
   });
 
+  it("keeps bulk partial-failure feedback visible after items refresh", async () => {
+    const user = userEvent.setup();
+    const onRefresh = vi.fn().mockResolvedValue(undefined);
+    const runBulkDone = vi
+      .fn()
+      .mockResolvedValueOnce(undefined)
+      .mockRejectedValueOnce(new Error("boom"));
+    const initialItems: SectionItem[] = [
+      { id: "item-1", title: "Water plants", choreInstanceId: 1, choreStatus: "pending" },
+      { id: "item-2", title: "Laundry", choreInstanceId: 2, choreStatus: "pending" },
+    ];
+    const refreshedItems: SectionItem[] = [
+      { id: "item-2", title: "Laundry", choreInstanceId: 2, choreStatus: "pending" },
+    ];
+    const bulkActions: BulkAction[] = [
+      {
+        key: "bulk-done",
+        label: "Bulk Done",
+        buttonClassName: "btn-success",
+        isAvailable: () => true,
+        run: runBulkDone,
+      },
+    ];
+
+    const { rerender } = render(
+      <QueryTestProvider>
+        <SectionCard
+          sectionId="due-today"
+          heading="Due Today"
+          items={initialItems}
+          onRefresh={onRefresh}
+          bulkActions={bulkActions}
+        />
+      </QueryTestProvider>,
+    );
+
+    await user.click(screen.getByLabelText("Select Water plants"));
+    await user.click(screen.getByLabelText("Select Laundry"));
+    await user.click(screen.getByRole("button", { name: "Bulk Done" }));
+
+    await screen.findByText("Bulk Done updated 1 item and failed for 1.");
+
+    rerender(
+      <QueryTestProvider>
+        <SectionCard
+          sectionId="due-today"
+          heading="Due Today"
+          items={refreshedItems}
+          onRefresh={onRefresh}
+          bulkActions={bulkActions}
+        />
+      </QueryTestProvider>,
+    );
+
+    expect(screen.getByText("Bulk Done updated 1 item and failed for 1.")).toBeInTheDocument();
+    expect(screen.getByRole("status")).toHaveTextContent("Bulk Done updated 1 item and failed for 1.");
+  });
+
   it("selects all items via the select-all checkbox", async () => {
     const user = userEvent.setup();
     const onRefresh = vi.fn().mockResolvedValue(undefined);

--- a/frontend/tests/features/today/useTodayLiveUpdates.test.ts
+++ b/frontend/tests/features/today/useTodayLiveUpdates.test.ts
@@ -3,6 +3,7 @@ import { QueryClientProvider } from "@tanstack/react-query";
 import { createElement } from "react";
 import type { ReactNode } from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import * as m from "@/paraglide/messages";
 import { useTodayLiveUpdates } from "@/features/today/useTodayLiveUpdates";
 import { queryKeys } from "@/lib/query/queryKeys";
 import * as session from "@/lib/auth/session";
@@ -38,6 +39,7 @@ function wrapper({ children }: { children: ReactNode }) {
 
 describe("useTodayLiveUpdates", () => {
   afterEach(() => {
+    session.setOidcAccessToken(undefined);
     vi.restoreAllMocks();
     vi.unstubAllGlobals();
   });
@@ -53,13 +55,14 @@ describe("useTodayLiveUpdates", () => {
         }
       },
     );
-    vi.spyOn(session, "getOidcAccessToken").mockReturnValue("test-token");
+    session.setOidcAccessToken("test-token");
 
     const queryClient = createQueryTestClient();
     const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
 
     renderHook(() => useTodayLiveUpdates(), {
-      wrapper: ({ children }) => createElement(QueryClientProvider, { client: queryClient }, children),
+      wrapper: ({ children }) =>
+        createElement(QueryClientProvider, { client: queryClient }, children),
     });
 
     expect(capturedEs).toBeDefined();
@@ -74,7 +77,7 @@ describe("useTodayLiveUpdates", () => {
   it("does not open EventSource when there is no access token", () => {
     const constructorSpy = vi.fn();
     vi.stubGlobal("EventSource", constructorSpy);
-    vi.spyOn(session, "getOidcAccessToken").mockReturnValue(undefined);
+    session.setOidcAccessToken(undefined);
 
     renderHook(() => useTodayLiveUpdates(), { wrapper });
 
@@ -92,7 +95,7 @@ describe("useTodayLiveUpdates", () => {
         }
       },
     );
-    vi.spyOn(session, "getOidcAccessToken").mockReturnValue("test-token");
+    session.setOidcAccessToken("test-token");
 
     const { unmount } = renderHook(() => useTodayLiveUpdates(), { wrapper });
 
@@ -112,13 +115,14 @@ describe("useTodayLiveUpdates", () => {
         }
       },
     );
-    vi.spyOn(session, "getOidcAccessToken").mockReturnValue("test-token");
+    session.setOidcAccessToken("test-token");
 
     const queryClient = createQueryTestClient();
     const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
 
     renderHook(() => useTodayLiveUpdates(), {
-      wrapper: ({ children }) => createElement(QueryClientProvider, { client: queryClient }, children),
+      wrapper: ({ children }) =>
+        createElement(QueryClientProvider, { client: queryClient }, children),
     });
 
     // Initial connect — should NOT invalidate.
@@ -145,19 +149,46 @@ describe("useTodayLiveUpdates", () => {
         }
       },
     );
-    const tokenSpy = vi.spyOn(session, "getOidcAccessToken").mockReturnValue("token-a");
+    session.setOidcAccessToken("token-a");
 
-    const { rerender } = renderHook(() => useTodayLiveUpdates(), { wrapper });
+    renderHook(() => useTodayLiveUpdates(), { wrapper });
     expect(instances).toHaveLength(1);
     const first = instances[0]!;
     expect(first.url).toContain("token=token-a");
 
-    tokenSpy.mockReturnValue("token-b");
-    rerender();
+    act(() => {
+      session.setOidcAccessToken("token-b");
+    });
 
     expect(first.closed).toBe(true);
     expect(instances).toHaveLength(2);
     expect(instances[1]!.url).toContain("token=token-b");
+  });
+
+  it("reports and clears connection errors", async () => {
+    let capturedEs: MockEventSource | undefined;
+    vi.stubGlobal(
+      "EventSource",
+      class extends MockEventSource {
+        constructor(url: string) {
+          super(url);
+          capturedEs = this;
+        }
+      },
+    );
+    session.setOidcAccessToken("test-token");
+
+    const { result } = renderHook(() => useTodayLiveUpdates(), { wrapper });
+
+    await act(async () => {
+      capturedEs!.emit("error", "");
+    });
+    expect(result.current).toBe(m.today_live_updates_interrupted());
+
+    await act(async () => {
+      capturedEs!.emit("open", "");
+    });
+    expect(result.current).toBeNull();
   });
 
   it("opens EventSource with the token in the URL", () => {
@@ -171,7 +202,7 @@ describe("useTodayLiveUpdates", () => {
         }
       },
     );
-    vi.spyOn(session, "getOidcAccessToken").mockReturnValue("my-token");
+    session.setOidcAccessToken("my-token");
 
     renderHook(() => useTodayLiveUpdates(), { wrapper });
 

--- a/frontend/tests/msw/today.test.tsx
+++ b/frontend/tests/msw/today.test.tsx
@@ -19,6 +19,7 @@ vi.mock("@/app/providers/AuthProvider", async (importOriginal) => {
       login: () => {},
       logout: () => {},
       refreshUser: async () => {},
+      sessionError: null,
     }),
   };
 });


### PR DESCRIPTION
### Motivation
- Provide a clearer onboarding path from an empty Today view by replacing the text-only banner with an actionable CTA that takes users to the Templates page.
- Prevent client-side issues when handling server-sent event streams in the mock service worker by avoiding cloning of event-stream responses.

### Description
- Replace the Today empty-state `FeedbackBanner` with a Bootstrap alert that shows `m.today_nothing_scheduled()` and a primary `Link` to `/templates`, and add `import { Link } from "@tanstack/react-router"` in `frontend/src/features/today/TodayPage.tsx`.
- Add new localized copy key `today_create_first_chore` to `frontend/messages/en.json` and `frontend/messages/nl.json` and surface it in the new CTA.
- Update `frontend/public/mockServiceWorker.js` to bump the bundled worker version and to omit cloning responses whose `content-type` starts with `text/event-stream`, avoiding buffering/clone-related stream cancellation issues.

### Testing
- Ran lint via `pnpm --dir frontend lint` which completed with existing code-style warnings only.
- Ran unit tests via `pnpm --dir frontend test -- --runInBand` where all tests passed (`24 files, 131 tests` reported as passed).
- Ran a production build via `pnpm --dir frontend build` which completed successfully.
- Started the mock dev server via `pnpm --dir frontend dev:mock` successfully, and an automated screenshot attempt using Playwright failed because the container is missing native libraries (`libatk-1.0.so.0`), preventing Chromium from launching.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a521cbe1760832e8a3daedf30a5fce5)