### PR TITLE
Add refresh loading feedback

### DIFF
--- a/frontend/src/features/templates/TemplatesPage.tsx
+++ b/frontend/src/features/templates/TemplatesPage.tsx
@@ -32,7 +32,7 @@ export function TemplatesPage() {
   const chores = choresQuery.data ?? [];
   const analytics = analyticsQuery.data ?? null;
   const loading = routinesQuery.isPending || choresQuery.isPending || analyticsQuery.isPending;
-  const refreshing = routinesQuery.isFetching || choresQuery.isFetching || analyticsQuery.isFetching;
+  const refreshing = (routinesQuery.isFetching || choresQuery.isFetching || analyticsQuery.isFetching) && !loading;
   const queryError = routinesQuery.error ?? choresQuery.error ?? analyticsQuery.error;
   const error = queryError instanceof Error ? queryError.message : queryError ? "Unable to load template data." : null;
   const canRetry = queryError ? isRetryableApiError(queryError) : false;
@@ -200,7 +200,7 @@ export function TemplatesPage() {
         <button
           type="button"
           className="btn btn-outline-primary btn-sm"
-          disabled={refreshing}
+          disabled={loading || refreshing}
           onClick={() => void loadTemplates()}
         >
           {refreshing ? (

--- a/frontend/src/features/templates/TemplatesPage.tsx
+++ b/frontend/src/features/templates/TemplatesPage.tsx
@@ -32,6 +32,7 @@ export function TemplatesPage() {
   const chores = choresQuery.data ?? [];
   const analytics = analyticsQuery.data ?? null;
   const loading = routinesQuery.isPending || choresQuery.isPending || analyticsQuery.isPending;
+  const refreshing = routinesQuery.isFetching || choresQuery.isFetching || analyticsQuery.isFetching;
   const queryError = routinesQuery.error ?? choresQuery.error ?? analyticsQuery.error;
   const error = queryError instanceof Error ? queryError.message : queryError ? "Unable to load template data." : null;
   const canRetry = queryError ? isRetryableApiError(queryError) : false;
@@ -199,9 +200,12 @@ export function TemplatesPage() {
         <button
           type="button"
           className="btn btn-outline-primary btn-sm"
-          disabled={loading}
+          disabled={refreshing}
           onClick={() => void loadTemplates()}
         >
+          {refreshing ? (
+            <span className="spinner-border spinner-border-sm me-1" role="status" aria-hidden="true" />
+          ) : null}
           {m.action_refresh()}
         </button>
       </div>

--- a/frontend/src/features/today/TodayPage.tsx
+++ b/frontend/src/features/today/TodayPage.tsx
@@ -30,6 +30,7 @@ export function TodayPage() {
   const todayQuery = useTodayQuery();
   const today = todayQuery.data ?? null;
   const isLoading = todayQuery.isLoading;
+  const isRefreshing = todayQuery.isFetching;
   const error = todayQuery.error ? (todayQuery.error instanceof Error ? todayQuery.error.message : "Unable to load today payload.") : null;
   const canRetry = todayQuery.error ? isRetryableApiError(todayQuery.error) : false;
   const loadToday = useCallback(async () => {
@@ -177,9 +178,12 @@ export function TodayPage() {
           <button
             className="btn btn-outline-primary btn-sm flex-md-grow-0"
             type="button"
-            disabled={isLoading}
+            disabled={isRefreshing}
             onClick={() => void loadToday()}
           >
+            {isRefreshing ? (
+              <span className="spinner-border spinner-border-sm me-1" role="status" aria-hidden="true" />
+            ) : null}
             {m.action_refresh()}
           </button>
         </div>

--- a/frontend/src/features/today/TodayPage.tsx
+++ b/frontend/src/features/today/TodayPage.tsx
@@ -30,7 +30,7 @@ export function TodayPage() {
   const todayQuery = useTodayQuery();
   const today = todayQuery.data ?? null;
   const isLoading = todayQuery.isLoading;
-  const isRefreshing = todayQuery.isFetching;
+  const isRefreshing = todayQuery.isFetching && !isLoading;
   const error = todayQuery.error ? (todayQuery.error instanceof Error ? todayQuery.error.message : "Unable to load today payload.") : null;
   const canRetry = todayQuery.error ? isRetryableApiError(todayQuery.error) : false;
   const loadToday = useCallback(async () => {
@@ -178,7 +178,7 @@ export function TodayPage() {
           <button
             className="btn btn-outline-primary btn-sm flex-md-grow-0"
             type="button"
-            disabled={isRefreshing}
+            disabled={isLoading || isRefreshing}
             onClick={() => void loadToday()}
           >
             {isRefreshing ? (


### PR DESCRIPTION
### Motivation
- Improve UX for manual refresh controls by showing active refresh state and preventing duplicate refreshes while a refetch is in flight.
- Distinguish between initial loading and background refetching so the page-level loading banners remain unchanged while a button indicates a refresh.

### Description
- Use TanStack Query `isFetching` from `useTodayQuery()` in `frontend/src/features/today/TodayPage.tsx` to drive a new `isRefreshing` flag and disable the refresh button during refetches. 
- Add an inline Bootstrap spinner inside the Today refresh button to surface active refresh feedback. 
- Compute a `refreshing` flag from `routinesQuery.isFetching`, `choresQuery.isFetching` and `analyticsQuery.isFetching` in `frontend/src/features/templates/TemplatesPage.tsx`, disable the Templates refresh button while any template queries are fetching, and add an inline spinner. 
- Changed files: `frontend/src/features/today/TodayPage.tsx` and `frontend/src/features/templates/TemplatesPage.tsx`.

### Testing
- Ran `pnpm --dir frontend lint`, which completed successfully with existing `no-this-alias` warnings. 
- Ran `pnpm --dir frontend test`, where Vitest reported all test files and specs passing (24 test files, 131 tests passed) but the run exited non-zero due to an unhandled `ReferenceError: cancelAnimationFrame is not defined` from `tests/features/calendar/CalendarPage.test.tsx`. 
- Ran `pnpm --dir frontend exec tsc -b` which completed successfully. 
- Started the dev server via `pnpm --dir frontend dev:mock --host 127.0.0.1` and attempted a Playwright screenshot, but Chromium could not be launched in the container due to a missing system library (`libatk-1.0.so.0`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5222a686c8832ebbd0b013d0d66089)