### PR TITLE
Replace window.confirm account deletion with inline Confirm/Cancel prompt

### DIFF
--- a/frontend/src/features/settings/sections/AccountDeletionSection.tsx
+++ b/frontend/src/features/settings/sections/AccountDeletionSection.tsx
@@ -47,7 +47,10 @@ export function AccountDeletionSection() {
             <button
               type="button"
               className="btn btn-outline-secondary btn-sm"
-              onClick={() => setIsConfirming(false)}
+              onClick={() => {
+                setIsConfirming(false);
+                setError(null);
+              }}
               disabled={isDeleting}
             >
               {m.action_cancel()}

--- a/frontend/src/features/settings/sections/AccountDeletionSection.tsx
+++ b/frontend/src/features/settings/sections/AccountDeletionSection.tsx
@@ -6,13 +6,11 @@ import { deleteAccount } from "@/lib/api/settings";
 export function AccountDeletionSection() {
   const auth = useContext(AuthContext);
   const [isDeleting, setIsDeleting] = useState(false);
+  const [isConfirming, setIsConfirming] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
   const handleDelete = async () => {
     setError(null);
-    const confirmed = window.confirm(m.settings_delete_account_confirm());
-    if (!confirmed) return;
-
     setIsDeleting(true);
     try {
       await deleteAccount();
@@ -25,13 +23,49 @@ export function AccountDeletionSection() {
 
   return (
     <div className="card mt-3 border-danger">
-      <div className="card-header fw-semibold py-2 text-danger">{m.settings_delete_account_header()}</div>
+      <div className="card-header fw-semibold py-2 text-danger">
+        {m.settings_delete_account_header()}
+      </div>
       <div className="card-body py-2">
         <p className="text-muted small mb-2">{m.settings_delete_account_description()}</p>
+        {isConfirming ? (
+          <div className="alert alert-danger py-2 small mb-2">
+            {m.settings_delete_account_confirm()}
+          </div>
+        ) : null}
         {error ? <div className="alert alert-danger py-2 small mb-2">{error}</div> : null}
-        <button type="button" className="btn btn-outline-danger btn-sm" onClick={handleDelete} disabled={isDeleting}>
-          {isDeleting ? m.settings_delete_account_deleting() : m.settings_delete_account_button()}
-        </button>
+        {isConfirming ? (
+          <div className="d-flex gap-1">
+            <button
+              type="button"
+              className="btn btn-danger btn-sm"
+              onClick={handleDelete}
+              disabled={isDeleting}
+            >
+              {isDeleting ? m.settings_delete_account_deleting() : m.action_confirm()}
+            </button>
+            <button
+              type="button"
+              className="btn btn-outline-secondary btn-sm"
+              onClick={() => setIsConfirming(false)}
+              disabled={isDeleting}
+            >
+              {m.action_cancel()}
+            </button>
+          </div>
+        ) : (
+          <button
+            type="button"
+            className="btn btn-outline-danger btn-sm"
+            onClick={() => {
+              setError(null);
+              setIsConfirming(true);
+            }}
+            disabled={isDeleting}
+          >
+            {m.settings_delete_account_button()}
+          </button>
+        )}
       </div>
     </div>
   );

--- a/frontend/tests/features/settings/AccountDeletionSection.test.tsx
+++ b/frontend/tests/features/settings/AccountDeletionSection.test.tsx
@@ -76,6 +76,21 @@ describe("AccountDeletionSection", () => {
     });
   });
 
+  it("clears server errors when inline confirmation is cancelled", async () => {
+    const user = userEvent.setup();
+    renderSection();
+    apiMock.deleteAccount.mockRejectedValue(new Error("Delete shared chores first."));
+
+    await user.click(screen.getByRole("button", { name: /delete my account/i }));
+    await user.click(screen.getByRole("button", { name: /confirm/i }));
+
+    expect(await screen.findByText("Delete shared chores first.")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: /cancel/i }));
+
+    expect(screen.queryByText("Delete shared chores first.")).not.toBeInTheDocument();
+  });
+
   it("shows the server error when deletion is blocked", async () => {
     const user = userEvent.setup();
     const { logout } = renderSection();

--- a/frontend/tests/features/settings/AccountDeletionSection.test.tsx
+++ b/frontend/tests/features/settings/AccountDeletionSection.test.tsx
@@ -46,24 +46,30 @@ describe("AccountDeletionSection", () => {
     vi.restoreAllMocks();
   });
 
-  it("does not delete the account when confirmation is cancelled", async () => {
+  it("does not delete the account when inline confirmation is cancelled", async () => {
     const user = userEvent.setup();
-    vi.spyOn(window, "confirm").mockReturnValue(false);
+    const confirmSpy = vi.spyOn(window, "confirm");
     renderSection();
 
     await user.click(screen.getByRole("button", { name: /delete my account/i }));
+    expect(screen.getByText(/this permanently deletes your daynest account/i)).toBeInTheDocument();
 
+    await user.click(screen.getByRole("button", { name: /cancel/i }));
+
+    expect(confirmSpy).not.toHaveBeenCalled();
     expect(apiMock.deleteAccount).not.toHaveBeenCalled();
   });
 
   it("deletes the account and logs out after confirmation", async () => {
     const user = userEvent.setup();
     const { logout } = renderSection();
-    vi.spyOn(window, "confirm").mockReturnValue(true);
+    const confirmSpy = vi.spyOn(window, "confirm");
     apiMock.deleteAccount.mockResolvedValue(undefined);
 
     await user.click(screen.getByRole("button", { name: /delete my account/i }));
+    await user.click(screen.getByRole("button", { name: /confirm/i }));
 
+    expect(confirmSpy).not.toHaveBeenCalled();
     await waitFor(() => {
       expect(apiMock.deleteAccount).toHaveBeenCalledTimes(1);
       expect(logout).toHaveBeenCalledTimes(1);
@@ -73,10 +79,10 @@ describe("AccountDeletionSection", () => {
   it("shows the server error when deletion is blocked", async () => {
     const user = userEvent.setup();
     const { logout } = renderSection();
-    vi.spyOn(window, "confirm").mockReturnValue(true);
     apiMock.deleteAccount.mockRejectedValue(new Error("Delete shared chores first."));
 
     await user.click(screen.getByRole("button", { name: /delete my account/i }));
+    await user.click(screen.getByRole("button", { name: /confirm/i }));
 
     expect(await screen.findByText("Delete shared chores first.")).toBeInTheDocument();
     expect(logout).not.toHaveBeenCalled();

--- a/frontend/tests/features/settings/SettingsPage.test.tsx
+++ b/frontend/tests/features/settings/SettingsPage.test.tsx
@@ -267,6 +267,34 @@ describe("SettingsPage", () => {
     });
   });
 
+  it("uses an inline confirmation before deleting an account", async () => {
+    const user = userEvent.setup();
+    const confirmSpy = vi.spyOn(window, "confirm");
+    apiMock.deleteAccount.mockResolvedValue(undefined);
+
+    try {
+      render(
+        <QueryTestProvider>
+          <SettingsPage />
+        </QueryTestProvider>,
+      );
+
+      const deleteButton = await screen.findByRole("button", { name: /delete my account/i });
+      await user.click(deleteButton);
+
+      expect(confirmSpy).not.toHaveBeenCalled();
+      expect(screen.getByText(/this permanently deletes your daynest account/i)).toBeInTheDocument();
+
+      await user.click(screen.getByRole("button", { name: /^confirm$/i }));
+
+      await waitFor(() => {
+        expect(apiMock.deleteAccount).toHaveBeenCalledTimes(1);
+      });
+    } finally {
+      confirmSpy.mockRestore();
+    }
+  });
+
   it("switches language to Dutch immediately", async () => {
     const user = userEvent.setup();
     render(


### PR DESCRIPTION
### Motivation
- Replace the blocking native `window.confirm` flow with an inline confirmation UI to improve UX and make the deletion flow testable and consistent with other danger patterns.
- Update tests to assert the new inline flow and to ensure the code no longer relies on `window.confirm` for deletion.

### Description
- Add an `isConfirming` state and render an inline danger alert plus Confirm/Cancel buttons in `frontend/src/features/settings/sections/AccountDeletionSection.tsx`, removing the `window.confirm` prompt.
- Keep `handleDelete` as the single deletion handler that calls `deleteAccount()` and calls `auth.logout()` on success while surfacing server errors in the UI.
- Update tests in `frontend/tests/features/settings/AccountDeletionSection.test.tsx` and `frontend/tests/features/settings/SettingsPage.test.tsx` to exercise the inline confirmation, assert that `window.confirm` is not called, and verify success and server-error behavior.
- Ensure formatting and test adjustments so the updated components integrate cleanly into the settings page flow.

### Testing
- Ran `pnpm --dir frontend test -- tests/features/settings/AccountDeletionSection.test.tsx tests/features/settings/SettingsPage.test.tsx`, which passed after the test updates.
- Ran the frontend test suite (`pnpm --dir frontend test`) and observed all tests passing (24 files, 132 tests).
- Ran the linter with `pnpm --dir frontend lint`, which completed successfully but reported unrelated warnings in existing test files.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a522e22d9f0832ea5a8ae437faaeadb)