### PR TITLE
Preserve OIDC session on /api/auth/me failures and show retry banner

### DIFF
--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -30,6 +30,7 @@
   "app_offline_queued": "{count} action(s) will sync when reconnected.",
   "app_syncing_queued": "Syncing {count} queued action(s)…",
   "app_server_unavailable": "Cannot connect to Daynest server. Please check your connection and try again.",
+  "app_session_retry_banner": "We could not refresh your account details. Your session is still active; try again to reconnect.",
   "app_theme_switch_to_light": "Switch to light mode",
   "app_theme_switch_to_dark": "Switch to dark mode",
   "app_theme_switch_to_auto": "Switch to auto mode",

--- a/frontend/messages/nl.json
+++ b/frontend/messages/nl.json
@@ -30,6 +30,7 @@
   "app_offline_queued": "{count} actie(s) worden gesynchroniseerd zodra de verbinding is hersteld.",
   "app_syncing_queued": "{count} wachtende actie(s) synchroniseren…",
   "app_server_unavailable": "Kan geen verbinding maken met de Daynest-server. Controleer uw verbinding en probeer het opnieuw.",
+  "app_session_retry_banner": "We konden uw accountgegevens niet vernieuwen. Uw sessie is nog actief; probeer opnieuw om opnieuw te verbinden.",
   "app_theme_switch_to_light": "Overschakelen naar lichte modus",
   "app_theme_switch_to_dark": "Overschakelen naar donkere modus",
   "app_theme_switch_to_auto": "Overschakelen naar automatische modus",

--- a/frontend/src/app/layout/AppLayout.tsx
+++ b/frontend/src/app/layout/AppLayout.tsx
@@ -8,7 +8,7 @@ import { drain as drainOfflineQueue, getQueuedCount } from "@/lib/offlineQueue";
 import { SearchOverlay } from "@/features/search/SearchOverlay";
 
 export function AppLayout() {
-  const { isAuthenticated, isLoading, logout, user } = useAuth();
+  const { isAuthenticated, isLoading, logout, refreshUser, sessionError, user } = useAuth();
   const { theme, toggleTheme } = useTheme();
   const isOnline = useOnlineStatus();
   const [queuedCount, setQueuedCount] = React.useState(() => getQueuedCount());
@@ -123,6 +123,18 @@ export function AppLayout() {
       ) : queuedCount > 0 ? (
         <div className="alert alert-info py-2 mb-3">
           {m.app_syncing_queued({ count: queuedCount })}
+        </div>
+      ) : null}
+      {sessionError ? (
+        <div className="alert alert-danger py-2 mb-3 d-flex justify-content-between align-items-center gap-2 flex-wrap">
+          <span>{m.app_session_retry_banner()}</span>
+          <button
+            type="button"
+            className="btn btn-sm btn-outline-danger"
+            onClick={() => void refreshUser()}
+          >
+            {m.action_retry()}
+          </button>
         </div>
       ) : null}
       {searchOpen && isAuthenticated ? (

--- a/frontend/src/app/layout/AppLayout.tsx
+++ b/frontend/src/app/layout/AppLayout.tsx
@@ -12,6 +12,7 @@ export function AppLayout() {
   const { theme, toggleTheme } = useTheme();
   const isOnline = useOnlineStatus();
   const [queuedCount, setQueuedCount] = React.useState(() => getQueuedCount());
+  const [isRetryingSession, setIsRetryingSession] = React.useState(false);
   const [searchOpen, setSearchOpen] = React.useState(false);
   const [mobileNavOpen, setMobileNavOpen] = React.useState(false);
 
@@ -131,7 +132,15 @@ export function AppLayout() {
           <button
             type="button"
             className="btn btn-sm btn-outline-danger"
-            onClick={() => void refreshUser()}
+            disabled={isRetryingSession}
+            onClick={async () => {
+              setIsRetryingSession(true);
+              try {
+                await refreshUser();
+              } finally {
+                setIsRetryingSession(false);
+              }
+            }}
           >
             {m.action_retry()}
           </button>
@@ -170,12 +179,14 @@ export function AppLayout() {
                 aria-hidden="true"
               />
             </button>
-            {isAuthenticated && user ? (
+            {isAuthenticated ? (
               <div className="d-flex flex-column flex-sm-row align-items-start align-items-sm-center gap-2">
-                <div className="small text-muted text-sm-end">
-                  <div className="fw-semibold text-body">{user.full_name}</div>
-                  <div>{user.email}</div>
-                </div>
+                {user ? (
+                  <div className="small text-muted text-sm-end">
+                    <div className="fw-semibold text-body">{user.full_name}</div>
+                    <div>{user.email}</div>
+                  </div>
+                ) : null}
                 <button type="button" className="btn btn-outline-secondary btn-sm" onClick={logout}>
                   {m.app_logout()}
                 </button>

--- a/frontend/src/app/providers/AuthProvider.tsx
+++ b/frontend/src/app/providers/AuthProvider.tsx
@@ -1,6 +1,6 @@
 import { createContext, useContext, useEffect, useMemo, useState } from "react";
 import { useAuth as useOidcAuth } from "react-oidc-context";
-import { fetchMe, type AuthUser } from "@/lib/api/auth";
+import { AuthApiError, fetchMe, type AuthUser } from "@/lib/api/auth";
 import { setOidcAccessToken } from "@/lib/auth/session";
 import { AUTH_ROUTE_PATHS } from "@/config/oidc";
 
@@ -19,6 +19,7 @@ type AuthContextValue = {
   login: () => void;
   logout: () => void;
   refreshUser: () => Promise<void>;
+  sessionError: string | null;
 };
 
 export const AuthContext = createContext<AuthContextValue | null>(null);
@@ -27,6 +28,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   const oidc = useOidcAuth();
   const [user, setUser] = useState<AuthUser | null>(null);
   const [isFetching, setIsFetching] = useState(false);
+  const [sessionError, setSessionError] = useState<string | null>(null);
 
   useEffect(() => {
     setOidcAccessToken(oidc.user?.access_token);
@@ -38,6 +40,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     if (!oidc.isAuthenticated || !accessToken) {
       setIsFetching(false);
       setUser(null);
+      setSessionError(null);
       return;
     }
 
@@ -46,10 +49,21 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
 
     fetchMe(accessToken)
       .then((nextUser) => {
-        if (!cancelled) setUser(nextUser);
+        if (!cancelled) {
+          setUser(nextUser);
+          setSessionError(null);
+        }
       })
-      .catch(() => {
-        if (!cancelled) setUser(null);
+      .catch((error: unknown) => {
+        if (cancelled) return;
+
+        if (error instanceof AuthApiError && error.status === 401) {
+          setUser(null);
+          setSessionError(null);
+          return;
+        }
+
+        setSessionError(error instanceof Error ? error.message : "Unable to load session");
       })
       .finally(() => {
         if (!cancelled) setIsFetching(false);
@@ -64,7 +78,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     () => ({
       user,
       isLoading: oidc.isLoading || isFetching,
-      isAuthenticated: oidc.isAuthenticated && user !== null,
+      isAuthenticated: oidc.isAuthenticated && (user !== null || sessionError !== null),
       login: () => {
         void oidc.signinRedirect({ state: { returnTo: getLoginReturnTo() } });
       },
@@ -77,12 +91,20 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
         try {
           const nextUser = await fetchMe(accessToken);
           setUser(nextUser);
-        } catch {
-          setUser(null);
+          setSessionError(null);
+        } catch (error: unknown) {
+          if (error instanceof AuthApiError && error.status === 401) {
+            setUser(null);
+            setSessionError(null);
+            return;
+          }
+
+          setSessionError(error instanceof Error ? error.message : "Unable to load session");
         }
       },
+      sessionError,
     }),
-    [user, oidc, isFetching],
+    [user, oidc, isFetching, sessionError],
   );
 
   return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;

--- a/frontend/src/mocks/MockAuthProvider.tsx
+++ b/frontend/src/mocks/MockAuthProvider.tsx
@@ -24,6 +24,7 @@ export function MockAuthProvider({ children }: { children: React.ReactNode }) {
         login: () => {},
         logout: () => {},
         refreshUser: async () => {},
+        sessionError: null,
       }}
     >
       {children}

--- a/frontend/tests/features/auth/AuthPage.test.tsx
+++ b/frontend/tests/features/auth/AuthPage.test.tsx
@@ -17,6 +17,7 @@ vi.mock("@/app/providers/AuthProvider", () => ({
     login: authMock.loginStub,
     logout: authMock.logoutStub,
     refreshUser: authMock.refreshUserStub,
+    sessionError: null,
     user: null,
   }),
 }));

--- a/frontend/tests/features/router/AppRouter.test.tsx
+++ b/frontend/tests/features/router/AppRouter.test.tsx
@@ -8,7 +8,7 @@ vi.mock("react-oidc-context", () => ({
 }));
 
 vi.mock("@/app/providers/AuthProvider", () => ({
-  useAuth: () => ({ isAuthenticated: true, isLoading: false, user: null, login: vi.fn(), logout: vi.fn(), refreshUser: vi.fn() }),
+  useAuth: () => ({ isAuthenticated: true, isLoading: false, user: null, login: vi.fn(), logout: vi.fn(), refreshUser: vi.fn(), sessionError: null }),
 }));
 
 vi.mock("@/paraglide/messages", () => ({

--- a/frontend/tests/features/settings/AccountDeletionSection.test.tsx
+++ b/frontend/tests/features/settings/AccountDeletionSection.test.tsx
@@ -29,6 +29,7 @@ function renderSection(logout = vi.fn()) {
         login: vi.fn(),
         logout,
         refreshUser: vi.fn(),
+        sessionError: null,
       }}
     >
       <AccountDeletionSection />

--- a/frontend/tests/msw/today.test.tsx
+++ b/frontend/tests/msw/today.test.tsx
@@ -19,6 +19,7 @@ vi.mock("@/app/providers/AuthProvider", async (importOriginal) => {
       login: () => {},
       logout: () => {},
       refreshUser: async () => {},
+      sessionError: null,
     }),
   };
 });


### PR DESCRIPTION
### Motivation

- Avoid forcing users back to the login flow when `GET /api/auth/me` fails due to transient/server/network errors by preserving the OIDC-authenticated state. 
- Surface a clear, retryable UI when the app cannot refresh account details so users can manually retry instead of being silently signed out. 

### Description

- Add a new `sessionError: string | null` field to the `AuthContext` and expose it via `useAuth`. 
- Update `AuthProvider` so `fetchMe` only clears local user state for explicit `401` responses and sets `sessionError` for other errors while keeping the OIDC token in place. 
- Add a retryable session banner to `AppLayout` that displays `m.app_session_retry_banner` and calls `refreshUser()` when retried. 
- Add localized banner text to `frontend/messages/en.json` and `frontend/messages/nl.json` and update mock/test auth providers and tests to include the new `sessionError` field. 

### Testing

- Ran `pnpm --dir frontend lint`, which completed successfully with existing warnings in `tests/features/today/useTodayLiveUpdates.test.ts`. 
- Built the frontend with `pnpm --dir frontend build`, which completed successfully (Vite reported the existing large-chunk warning). 
- Type-check and test-related fixes were applied to updated test mocks so the codebase compiles and tests referencing `AuthContext` include `sessionError`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a52a0ab6aa4832eb8a8c3a9220d1fd9)