### PR TITLE
Keep bulk action feedback visible

### DIFF
--- a/frontend/src/features/today/TodaySections.tsx
+++ b/frontend/src/features/today/TodaySections.tsx
@@ -14,6 +14,7 @@ import {
   type UpcomingTodayItem,
 } from "@/lib/api/today";
 import { capitalize, formatDate, formatDateTime, formatTime } from "@/lib/dateUtils";
+import { FeedbackBanner } from "@/components/common/FeedbackBanner";
 import { useTodayActions } from "@/features/today/useTodayActions";
 
 export type BulkAction = {
@@ -602,14 +603,12 @@ export function SectionCard({
   const allSelected = selectableItems.length > 0 && selectedIds.length === selectableItems.length;
 
   const toggleSelected = (itemId: string) => {
-    setBulkFeedback(null);
     setSelectedIds((current) =>
       current.includes(itemId) ? current.filter((id) => id !== itemId) : [...current, itemId],
     );
   };
 
   const toggleAllSelected = () => {
-    setBulkFeedback(null);
     setSelectedIds(allSelected ? [] : selectableItems.map((item) => item.id));
   };
 
@@ -685,9 +684,11 @@ export function SectionCard({
                   );
                 })}
               </div>
-              {bulkFeedback ? (
-                <small className={`text-${bulkFeedback.tone}`}>{bulkFeedback.text}</small>
-              ) : null}
+              <FeedbackBanner
+                message={bulkFeedback?.text ?? null}
+                tone={bulkFeedback?.tone}
+                onDismiss={() => setBulkFeedback(null)}
+              />
             </div>
           ) : null}
         </div>

--- a/frontend/tests/features/today/TodaySections.test.tsx
+++ b/frontend/tests/features/today/TodaySections.test.tsx
@@ -211,6 +211,64 @@ describe("Today section components", () => {
     expect(screen.getByText("Bulk Done updated 1 item and failed for 1.")).toBeInTheDocument();
   });
 
+  it("keeps bulk partial-failure feedback visible after items refresh", async () => {
+    const user = userEvent.setup();
+    const onRefresh = vi.fn().mockResolvedValue(undefined);
+    const runBulkDone = vi
+      .fn()
+      .mockResolvedValueOnce(undefined)
+      .mockRejectedValueOnce(new Error("boom"));
+    const initialItems: SectionItem[] = [
+      { id: "item-1", title: "Water plants", choreInstanceId: 1, choreStatus: "pending" },
+      { id: "item-2", title: "Laundry", choreInstanceId: 2, choreStatus: "pending" },
+    ];
+    const refreshedItems: SectionItem[] = [
+      { id: "item-2", title: "Laundry", choreInstanceId: 2, choreStatus: "pending" },
+    ];
+    const bulkActions: BulkAction[] = [
+      {
+        key: "bulk-done",
+        label: "Bulk Done",
+        buttonClassName: "btn-success",
+        isAvailable: () => true,
+        run: runBulkDone,
+      },
+    ];
+
+    const { rerender } = render(
+      <QueryTestProvider>
+        <SectionCard
+          sectionId="due-today"
+          heading="Due Today"
+          items={initialItems}
+          onRefresh={onRefresh}
+          bulkActions={bulkActions}
+        />
+      </QueryTestProvider>,
+    );
+
+    await user.click(screen.getByLabelText("Select Water plants"));
+    await user.click(screen.getByLabelText("Select Laundry"));
+    await user.click(screen.getByRole("button", { name: "Bulk Done" }));
+
+    await screen.findByText("Bulk Done updated 1 item and failed for 1.");
+
+    rerender(
+      <QueryTestProvider>
+        <SectionCard
+          sectionId="due-today"
+          heading="Due Today"
+          items={refreshedItems}
+          onRefresh={onRefresh}
+          bulkActions={bulkActions}
+        />
+      </QueryTestProvider>,
+    );
+
+    expect(screen.getByText("Bulk Done updated 1 item and failed for 1.")).toBeInTheDocument();
+    expect(screen.getByRole("status")).toHaveTextContent("Bulk Done updated 1 item and failed for 1.");
+  });
+
   it("selects all items via the select-all checkbox", async () => {
     const user = userEvent.setup();
     const onRefresh = vi.fn().mockResolvedValue(undefined);


### PR DESCRIPTION
### Motivation
- Make bulk-action feedback persistent and dismissible so success/failure/partial messages remain visible until the user dismisses them or a new bulk action runs.
- Avoid clearing feedback when users toggle individual checkboxes or the select-all control so messages aren’t lost during selection changes.
- Add regression coverage to ensure partial-failure feedback survives a refresh of the section’s `items` prop.

### Description
- Import and render the shared `FeedbackBanner` in `SectionCard` instead of the transient inline `<small>` feedback element.
- Stop calling `setBulkFeedback(null)` from `toggleSelected` and `toggleAllSelected`, while still clearing feedback when a new bulk action starts in `runBulkAction`.
- Add the test `keeps bulk partial-failure feedback visible after items refresh` to `frontend/tests/features/today/TodaySections.test.tsx` to cover the regression.
- Note that unrelated local changes to `frontend/public/mockServiceWorker.js` were present and intentionally not included in this change.

### Testing
- Ran `pnpm --dir frontend test TodaySections.test.tsx -- --runInBand` and the test file passed (38 tests passed).
- Ran `pnpm --dir frontend lint` and lint completed successfully with pre-existing warnings in tests.
- Ran `pnpm --dir frontend build` and the build completed successfully (Vite reported existing large-chunk warnings).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a52a71e26a4832eb001598d0756efb1)