### PR TITLE
Support OIDC end_session discovery and Android logout flow

### DIFF
--- a/android/app/src/main/java/com/daynest/android/core/auth/OidcAuthService.kt
+++ b/android/app/src/main/java/com/daynest/android/core/auth/OidcAuthService.kt
@@ -21,6 +21,7 @@ import net.openid.appauth.AuthorizationRequest
 import net.openid.appauth.AuthorizationResponse
 import net.openid.appauth.AuthorizationService
 import net.openid.appauth.AuthorizationServiceConfiguration
+import net.openid.appauth.EndSessionRequest
 import net.openid.appauth.ResponseTypeValues
 
 @Singleton
@@ -90,6 +91,21 @@ constructor(
                 }
             }
         }
+    }
+
+    suspend fun buildSignOutIntent(): Intent? {
+        val idToken = authState.idToken
+        val config = discoverServiceConfiguration()
+        clearState()
+        if (config.endSessionEndpoint == null) return null
+        val requestBuilder =
+            EndSessionRequest
+                .Builder(config)
+                .setPostLogoutRedirectUri(oidcConfig.redirectUri)
+        if (idToken != null) {
+            requestBuilder.setIdTokenHint(idToken)
+        }
+        return authorizationService.getEndSessionRequestIntent(requestBuilder.build())
     }
 
     fun signOut() = clearState()

--- a/android/app/src/main/java/com/daynest/android/core/auth/OidcAuthService.kt
+++ b/android/app/src/main/java/com/daynest/android/core/auth/OidcAuthService.kt
@@ -96,16 +96,18 @@ constructor(
     suspend fun buildSignOutIntent(): Intent? {
         val idToken = authState.idToken
         val config = discoverServiceConfiguration()
-        clearState()
-        if (config.endSessionEndpoint == null) return null
-        val requestBuilder =
-            EndSessionRequest
-                .Builder(config)
-                .setPostLogoutRedirectUri(oidcConfig.redirectUri)
-        if (idToken != null) {
-            requestBuilder.setIdTokenHint(idToken)
+        return if (idToken != null && config.endSessionEndpoint != null) {
+            clearState()
+            val request =
+                EndSessionRequest
+                    .Builder(config)
+                    .setPostLogoutRedirectUri(oidcConfig.redirectUri)
+                    .setIdTokenHint(idToken)
+                    .build()
+            authorizationService.getEndSessionRequestIntent(request)
+        } else {
+            null
         }
-        return authorizationService.getEndSessionRequestIntent(requestBuilder.build())
     }
 
     fun signOut() = clearState()

--- a/android/app/src/main/java/com/daynest/android/core/auth/OidcServiceConfigurationDiscovery.kt
+++ b/android/app/src/main/java/com/daynest/android/core/auth/OidcServiceConfigurationDiscovery.kt
@@ -40,7 +40,9 @@ constructor(
         val json = JSONObject(body)
         AuthorizationServiceConfiguration(
             Uri.parse(json.getString("authorization_url")),
-            Uri.parse(json.getString("token_url"))
+            Uri.parse(json.getString("token_url")),
+            null,
+            json.optString("end_session_endpoint").takeIf { it.isNotBlank() }?.let { Uri.parse(it) }
         )
     } catch (e: JSONException) {
         throw IOException("Failed to parse OIDC config response", e)

--- a/android/app/src/main/java/com/daynest/android/feature/settings/SettingsRoute.kt
+++ b/android/app/src/main/java/com/daynest/android/feature/settings/SettingsRoute.kt
@@ -54,6 +54,17 @@ fun SettingsRoute(
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
 
+    val signOutLauncher =
+        rememberLauncherForActivityResult(
+            contract = ActivityResultContracts.StartActivityForResult()
+        ) { }
+
+    LaunchedEffect(Unit) {
+        viewModel.signOutIntent.collect { intent ->
+            signOutLauncher.launch(intent)
+        }
+    }
+
     LaunchedEffect(uiState) {
         if (uiState is SettingsUiState.SignedOut) {
             onSignedOut?.invoke()

--- a/android/app/src/main/java/com/daynest/android/feature/settings/SettingsSignOutHandler.kt
+++ b/android/app/src/main/java/com/daynest/android/feature/settings/SettingsSignOutHandler.kt
@@ -3,6 +3,7 @@ package com.daynest.android.feature.settings
 import android.content.Intent
 import com.daynest.android.core.auth.OidcAuthService
 import com.daynest.android.data.push.PushRegistrationManager
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -15,12 +16,23 @@ internal class SettingsSignOutHandler(
     private val uiState: MutableStateFlow<SettingsUiState>,
     private val signOutIntent: MutableSharedFlow<Intent>
 ) {
+    @Suppress("TooGenericExceptionCaught")
     fun signOut(unregisterPushEndpoints: Boolean = true) {
         scope.launch {
             if (unregisterPushEndpoints) {
-                runCatching { pushRegistrationManager.unregisterAllKnownEndpoints() }
+                try {
+                    pushRegistrationManager.unregisterAllKnownEndpoints()
+                } catch (e: Exception) {
+                    if (e is CancellationException) throw e
+                }
             }
-            val endSessionIntent = runCatching { oidcAuthService.buildSignOutIntent() }.getOrNull()
+            val endSessionIntent =
+                try {
+                    oidcAuthService.buildSignOutIntent()
+                } catch (e: Exception) {
+                    if (e is CancellationException) throw e
+                    null
+                }
             if (endSessionIntent != null) {
                 signOutIntent.emit(endSessionIntent)
             } else {

--- a/android/app/src/main/java/com/daynest/android/feature/settings/SettingsSignOutHandler.kt
+++ b/android/app/src/main/java/com/daynest/android/feature/settings/SettingsSignOutHandler.kt
@@ -1,0 +1,32 @@
+package com.daynest.android.feature.settings
+
+import android.content.Intent
+import com.daynest.android.core.auth.OidcAuthService
+import com.daynest.android.data.push.PushRegistrationManager
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.launch
+
+internal class SettingsSignOutHandler(
+    private val scope: CoroutineScope,
+    private val oidcAuthService: OidcAuthService,
+    private val pushRegistrationManager: PushRegistrationManager,
+    private val uiState: MutableStateFlow<SettingsUiState>,
+    private val signOutIntent: MutableSharedFlow<Intent>
+) {
+    fun signOut(unregisterPushEndpoints: Boolean = true) {
+        scope.launch {
+            if (unregisterPushEndpoints) {
+                runCatching { pushRegistrationManager.unregisterAllKnownEndpoints() }
+            }
+            val endSessionIntent = runCatching { oidcAuthService.buildSignOutIntent() }.getOrNull()
+            if (endSessionIntent != null) {
+                signOutIntent.emit(endSessionIntent)
+            } else {
+                oidcAuthService.signOut()
+            }
+            uiState.value = SettingsUiState.SignedOut
+        }
+    }
+}

--- a/android/app/src/main/java/com/daynest/android/feature/settings/SettingsViewModel.kt
+++ b/android/app/src/main/java/com/daynest/android/feature/settings/SettingsViewModel.kt
@@ -49,6 +49,15 @@ constructor(
     private val _signOutIntent = MutableSharedFlow<Intent>(extraBufferCapacity = 1)
     val signOutIntent: SharedFlow<Intent> = _signOutIntent.asSharedFlow()
 
+    private val signOutHandler =
+        SettingsSignOutHandler(
+            scope = viewModelScope,
+            oidcAuthService = oidcAuthService,
+            pushRegistrationManager = pushRegistrationManager,
+            uiState = _uiState,
+            signOutIntent = _signOutIntent
+        )
+
     private val deviceCalendarHandler =
         SettingsDeviceCalendarHandler(
             scope = viewModelScope,
@@ -72,7 +81,7 @@ constructor(
     fun onEvent(event: SettingsUiEvent) {
         when (event) {
             SettingsUiEvent.RetryClicked -> load()
-            SettingsUiEvent.SignOutClicked -> signOut()
+            SettingsUiEvent.SignOutClicked -> signOutHandler.signOut()
             SettingsUiEvent.ShowCreateClientForm -> updateContent { it.copy(showCreateForm = true) }
             SettingsUiEvent.DismissCreateClientForm -> updateContent { it.copy(showCreateForm = false) }
             SettingsUiEvent.DismissNewKeyDialog -> updateContent { it.copy(newApiKey = null) }
@@ -254,28 +263,13 @@ constructor(
         }
     }
 
-    private fun signOut() {
-        viewModelScope.launch { performSignOut() }
-    }
-
-    private suspend fun performSignOut() {
-        runCatching { pushRegistrationManager.unregisterAllKnownEndpoints() }
-        val endSessionIntent = runCatching { oidcAuthService.buildSignOutIntent() }.getOrNull()
-        if (endSessionIntent != null) {
-            _signOutIntent.emit(endSessionIntent)
-        } else {
-            oidcAuthService.signOut()
-        }
-        _uiState.value = SettingsUiState.SignedOut
-    }
-
     private fun deleteCurrentAccount() {
         viewModelScope.launch {
             updateContent { it.copy(isDeletingAccount = true, accountDeletionError = null) }
             pushRegistrationManager.unregisterAllKnownEndpoints()
             settingsRepository.deleteCurrentUser()
                 .onSuccess {
-                    performSignOut()
+                    signOutHandler.signOut(unregisterPushEndpoints = false)
                 }
                 .onFailure { error ->
                     updateContent {

--- a/android/app/src/main/java/com/daynest/android/feature/settings/SettingsViewModel.kt
+++ b/android/app/src/main/java/com/daynest/android/feature/settings/SettingsViewModel.kt
@@ -1,6 +1,7 @@
 package com.daynest.android.feature.settings
 
 import android.content.Context
+import android.content.Intent
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.daynest.android.BuildConfig
@@ -20,8 +21,11 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
 import javax.inject.Inject
 import kotlinx.coroutines.async
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.update
@@ -41,6 +45,9 @@ constructor(
 ) : ViewModel() {
     private val _uiState = MutableStateFlow<SettingsUiState>(SettingsUiState.Loading)
     val uiState: StateFlow<SettingsUiState> = _uiState.asStateFlow()
+
+    private val _signOutIntent = MutableSharedFlow<Intent>(extraBufferCapacity = 1)
+    val signOutIntent: SharedFlow<Intent> = _signOutIntent.asSharedFlow()
 
     private val deviceCalendarHandler =
         SettingsDeviceCalendarHandler(
@@ -65,11 +72,7 @@ constructor(
     fun onEvent(event: SettingsUiEvent) {
         when (event) {
             SettingsUiEvent.RetryClicked -> load()
-            SettingsUiEvent.SignOutClicked -> {
-                viewModelScope.launch { runCatching { pushRegistrationManager.unregisterAllKnownEndpoints() } }
-                oidcAuthService.signOut()
-                _uiState.value = SettingsUiState.SignedOut
-            }
+            SettingsUiEvent.SignOutClicked -> signOut()
             SettingsUiEvent.ShowCreateClientForm -> updateContent { it.copy(showCreateForm = true) }
             SettingsUiEvent.DismissCreateClientForm -> updateContent { it.copy(showCreateForm = false) }
             SettingsUiEvent.DismissNewKeyDialog -> updateContent { it.copy(newApiKey = null) }
@@ -251,14 +254,28 @@ constructor(
         }
     }
 
+    private fun signOut() {
+        viewModelScope.launch { performSignOut() }
+    }
+
+    private suspend fun performSignOut() {
+        runCatching { pushRegistrationManager.unregisterAllKnownEndpoints() }
+        val endSessionIntent = runCatching { oidcAuthService.buildSignOutIntent() }.getOrNull()
+        if (endSessionIntent != null) {
+            _signOutIntent.emit(endSessionIntent)
+        } else {
+            oidcAuthService.signOut()
+        }
+        _uiState.value = SettingsUiState.SignedOut
+    }
+
     private fun deleteCurrentAccount() {
         viewModelScope.launch {
             updateContent { it.copy(isDeletingAccount = true, accountDeletionError = null) }
             pushRegistrationManager.unregisterAllKnownEndpoints()
             settingsRepository.deleteCurrentUser()
                 .onSuccess {
-                    oidcAuthService.signOut()
-                    _uiState.value = SettingsUiState.SignedOut
+                    performSignOut()
                 }
                 .onFailure { error ->
                     updateContent {

--- a/android/app/src/test/java/com/daynest/android/core/auth/OidcServiceConfigurationDiscoveryTest.kt
+++ b/android/app/src/test/java/com/daynest/android/core/auth/OidcServiceConfigurationDiscoveryTest.kt
@@ -48,7 +48,8 @@ class OidcServiceConfigurationDiscoveryTest {
                 {
                   "issuer": "https://auth.example.test/realms/daynest",
                   "authorization_url": "https://auth.example.test/realms/daynest/protocol/openid-connect/auth",
-                  "token_url": "https://auth.example.test/realms/daynest/protocol/openid-connect/token"
+                  "token_url": "https://auth.example.test/realms/daynest/protocol/openid-connect/token",
+                  "end_session_endpoint": "https://auth.example.test/realms/daynest/protocol/openid-connect/logout"
                 }
                 """.trimIndent()
             )
@@ -66,6 +67,10 @@ class OidcServiceConfigurationDiscoveryTest {
         assertEquals(
             "https://auth.example.test/realms/daynest/protocol/openid-connect/token",
             config.tokenEndpoint.toString()
+        )
+        assertEquals(
+            "https://auth.example.test/realms/daynest/protocol/openid-connect/logout",
+            config.endSessionEndpoint.toString()
         )
     }
 

--- a/backend/app/api/routes/auth.py
+++ b/backend/app/api/routes/auth.py
@@ -75,6 +75,7 @@ async def discover_oidc_endpoints() -> OidcDiscoveryConfig:
                 "issuer": data.get("issuer", issuer),
                 "authorization_url": data["authorization_endpoint"],
                 "token_url": data["token_endpoint"],
+                "end_session_endpoint": data.get("end_session_endpoint"),
             }
         )
     except (KeyError, ValueError) as exc:

--- a/backend/app/schemas/auth.py
+++ b/backend/app/schemas/auth.py
@@ -29,6 +29,7 @@ class OidcDiscoveryConfig(BaseModel):
     issuer: HttpUrl
     authorization_url: HttpUrl
     token_url: HttpUrl
+    end_session_endpoint: HttpUrl | None = None
 
 
 class OAuthSessionClient(BaseModel):

--- a/backend/tests/test_auth_routes.py
+++ b/backend/tests/test_auth_routes.py
@@ -62,6 +62,7 @@ class TestOidcConfigEndpoint:
                 "issuer": issuer,
                 "authorization_endpoint": f"{issuer}/protocol/openid-connect/auth",
                 "token_endpoint": f"{issuer}/protocol/openid-connect/token",
+                "end_session_endpoint": f"{issuer}/protocol/openid-connect/logout",
             }),
         )
 
@@ -71,6 +72,7 @@ class TestOidcConfigEndpoint:
         assert str(config.issuer) == issuer
         assert str(config.authorization_url) == f"{issuer}/protocol/openid-connect/auth"
         assert str(config.token_url) == f"{issuer}/protocol/openid-connect/token"
+        assert str(config.end_session_endpoint) == f"{issuer}/protocol/openid-connect/logout"
 
     def test_oidc_config_caches_discovery(self, monkeypatch: pytest.MonkeyPatch) -> None:
         issuer = "https://auth.example.test/application/o/daynest"


### PR DESCRIPTION
### Motivation
- Ensure clients can discover the provider's end-session endpoint so logouts can be performed using the provider's browser flow. 
- Let the Android app initiate an AppAuth end-session request (including `id_token_hint` and `post_logout_redirect_uri`) when available instead of only clearing local state.
- Preserve existing behavior when the provider does not advertise an end-session endpoint by falling back to local sign-out.

### Description
- Add `end_session_endpoint` to the backend `OidcDiscoveryConfig` and populate it from the provider discovery document in `discover_oidc_endpoints` so the backend exposes the logout endpoint at `/api/v1/auth/oidc-config`.
- Parse the optional `end_session_endpoint` in the Android `OidcServiceConfigurationDiscovery` and include it in the `AuthorizationServiceConfiguration` returned to the app.
- Add `OidcAuthService.buildSignOutIntent()` using AppAuth's `EndSessionRequest` to build an end-session intent with `id_token_hint` when available and the configured post-logout redirect URI, while keeping `signOut()` which clears local state.
- Wire a one-shot `signOutIntent` flow from `SettingsViewModel` (via a `MutableSharedFlow<Intent>`) and launch it from `SettingsRoute` so the Android logout browser flow is executed before transitioning to `SignedOut` in the UI.
- Update unit tests to assert the new `end_session_endpoint` is parsed and exposed in both the Android discovery test and backend discovery tests.

### Testing
- Ran `git diff --check`, which succeeded with no whitespace errors.
- Attempted Android unit test `./gradlew testDebugUnitTest --tests 'com.daynest.android.core.auth.OidcServiceConfigurationDiscoveryTest'`, but the build failed because the Android SDK is not configured (`ANDROID_HOME`/`sdk.dir` missing), so the Android test could not be executed.
- Attempted backend tests `pytest backend/tests/test_auth_routes.py -q`, but execution failed due to missing Python dependencies (`ModuleNotFoundError: No module named 'fastapi'`), so the backend test could not be executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a52a87d4f04832ebe757ca05a21c31e)