### PR TITLE
Fix live Today feed token refresh handling

### DIFF
--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -52,6 +52,7 @@
   "router_completing_sign_in": "Completing sign in…",
   "today_subtitle": "Medication, routines, chores, and planned tasks — everything due or active today.",
   "today_loading": "Loading today...",
+  "today_live_updates_interrupted": "Live Today updates were interrupted. Reconnecting with the latest session…",
   "today_nothing_scheduled": "Nothing scheduled for today yet.",
   "today_create_first_chore": "Create your first chore",
   "today_summary_overdue": "Overdue",

--- a/frontend/messages/nl.json
+++ b/frontend/messages/nl.json
@@ -52,6 +52,7 @@
   "router_completing_sign_in": "Aanmelding voltooien…",
   "today_subtitle": "Medicatie, routines, klusjes en geplande taken — alles dat vandaag vervalt of actief is.",
   "today_loading": "Vandaag laden...",
+  "today_live_updates_interrupted": "Live updates voor Vandaag zijn onderbroken. Opnieuw verbinden met de nieuwste sessie…",
   "today_nothing_scheduled": "Nog niets ingepland voor vandaag.",
   "today_create_first_chore": "Maak je eerste klusje",
   "today_summary_overdue": "Achterstallig",

--- a/frontend/src/features/today/TodayPage.tsx
+++ b/frontend/src/features/today/TodayPage.tsx
@@ -26,12 +26,16 @@ import { useTodayLiveUpdates } from "@/features/today/useTodayLiveUpdates";
 import { useTodayQuery } from "@/features/today/useTodayQuery";
 
 export function TodayPage() {
-  useTodayLiveUpdates();
+  const liveUpdatesError = useTodayLiveUpdates();
   const todayQuery = useTodayQuery();
   const today = todayQuery.data ?? null;
   const isLoading = todayQuery.isLoading;
   const isRefreshing = todayQuery.isFetching && !isLoading;
-  const error = todayQuery.error ? (todayQuery.error instanceof Error ? todayQuery.error.message : "Unable to load today payload.") : null;
+  const error = todayQuery.error
+    ? todayQuery.error instanceof Error
+      ? todayQuery.error.message
+      : "Unable to load today payload."
+    : null;
   const canRetry = todayQuery.error ? isRetryableApiError(todayQuery.error) : false;
   const loadToday = useCallback(async () => {
     await todayQuery.refetch();
@@ -57,7 +61,8 @@ export function TodayPage() {
         label: m.action_done(),
         buttonClassName: "btn-success",
         isAvailable: (item) => Boolean(item.taskInstanceId && isItemActionable(item)),
-        run: (item) => actions.completeRoutineTask(item.taskInstanceId as number, { refresh: false }),
+        run: (item) =>
+          actions.completeRoutineTask(item.taskInstanceId as number, { refresh: false }),
       },
       {
         key: "routine-skip",
@@ -182,17 +187,20 @@ export function TodayPage() {
             onClick={() => void loadToday()}
           >
             {isRefreshing ? (
-              <span className="spinner-border spinner-border-sm me-1" role="status" aria-hidden="true" />
+              <span
+                className="spinner-border spinner-border-sm me-1"
+                role="status"
+                aria-hidden="true"
+              />
             ) : null}
             {m.action_refresh()}
           </button>
         </div>
       </div>
-      <p className="text-muted mb-3">
-        {m.today_subtitle()}
-      </p>
+      <p className="text-muted mb-3">{m.today_subtitle()}</p>
 
       <FeedbackBanner message={isLoading ? m.today_loading() : null} tone="info" />
+      <FeedbackBanner message={liveUpdatesError} tone="warning" />
       {!isLoading && error ? (
         <div className="alert alert-danger py-2 d-flex justify-content-between align-items-center gap-2 flex-wrap">
           <span>{error}</span>
@@ -219,11 +227,31 @@ export function TodayPage() {
       {!isLoading && !error && today ? (
         <>
           <div className="row g-3 mb-3">
-            <SummaryCard label={m.today_summary_overdue()} value={today.overdue.length} tone="danger" />
-            <SummaryCard label={m.today_summary_due_today()} value={today.due_today.length} tone="warning" />
-            <SummaryCard label={m.today_summary_medication_due()} value={scheduledMedicationCount} tone="info" />
-            <SummaryCard label={m.today_summary_open_plans()} value={openPlannedCount} tone="primary" />
-            <SummaryCard label={m.today_summary_open_routines()} value={routineOpenCount} tone="secondary" />
+            <SummaryCard
+              label={m.today_summary_overdue()}
+              value={today.overdue.length}
+              tone="danger"
+            />
+            <SummaryCard
+              label={m.today_summary_due_today()}
+              value={today.due_today.length}
+              tone="warning"
+            />
+            <SummaryCard
+              label={m.today_summary_medication_due()}
+              value={scheduledMedicationCount}
+              tone="info"
+            />
+            <SummaryCard
+              label={m.today_summary_open_plans()}
+              value={openPlannedCount}
+              tone="primary"
+            />
+            <SummaryCard
+              label={m.today_summary_open_routines()}
+              value={routineOpenCount}
+              tone="secondary"
+            />
           </div>
           <WebFocusPanel sections={sections} />
           <PlannedSection
@@ -231,16 +259,18 @@ export function TodayPage() {
             onRefresh={loadToday}
             bulkActions={plannedBulkActions}
           />
-          {sections.filter((section) => section.key !== "planned").map((section) => (
-            <SectionCard
-              key={section.key}
-              sectionId={section.key}
-              heading={section.heading}
-              items={section.items}
-              onRefresh={loadToday}
-              bulkActions={section.bulkActions}
-            />
-          ))}
+          {sections
+            .filter((section) => section.key !== "planned")
+            .map((section) => (
+              <SectionCard
+                key={section.key}
+                sectionId={section.key}
+                heading={section.heading}
+                items={section.items}
+                onRefresh={loadToday}
+                bulkActions={section.bulkActions}
+              />
+            ))}
         </>
       ) : null}
     </section>

--- a/frontend/src/features/today/useTodayLiveUpdates.ts
+++ b/frontend/src/features/today/useTodayLiveUpdates.ts
@@ -1,14 +1,17 @@
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import { useQueryClient } from "@tanstack/react-query";
 import { buildApiUrl } from "@/lib/api/serverConfig";
-import { getOidcAccessToken } from "@/lib/auth/session";
+import { useOidcAccessToken } from "@/lib/auth/session";
 import { queryKeys } from "@/lib/query/queryKeys";
 
-export function useTodayLiveUpdates(): void {
+export function useTodayLiveUpdates(): string | null {
   const queryClient = useQueryClient();
-  const token = getOidcAccessToken();
+  const token = useOidcAccessToken();
+  const [connectionError, setConnectionError] = useState<string | null>(null);
 
   useEffect(() => {
+    setConnectionError(null);
+
     if (typeof EventSource === "undefined") return;
     if (!token) return;
 
@@ -17,6 +20,8 @@ export function useTodayLiveUpdates(): void {
     let connected = false;
 
     es.addEventListener("open", () => {
+      setConnectionError(null);
+
       if (connected) {
         // Reconnect after a drop — missed events won't be replayed, so refetch.
         void queryClient.invalidateQueries({ queryKey: queryKeys.today.read() });
@@ -25,11 +30,20 @@ export function useTodayLiveUpdates(): void {
     });
 
     es.addEventListener("today_updated", () => {
+      setConnectionError(null);
       void queryClient.invalidateQueries({ queryKey: queryKeys.today.read() });
+    });
+
+    es.addEventListener("error", () => {
+      setConnectionError(
+        "Live Today updates were interrupted. Reconnecting with the latest session…",
+      );
     });
 
     return () => {
       es.close();
     };
   }, [queryClient, token]);
+
+  return connectionError;
 }

--- a/frontend/src/features/today/useTodayLiveUpdates.ts
+++ b/frontend/src/features/today/useTodayLiveUpdates.ts
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
 import { useQueryClient } from "@tanstack/react-query";
+import * as m from "@/paraglide/messages";
 import { buildApiUrl } from "@/lib/api/serverConfig";
 import { useOidcAccessToken } from "@/lib/auth/session";
 import { queryKeys } from "@/lib/query/queryKeys";
@@ -35,9 +36,7 @@ export function useTodayLiveUpdates(): string | null {
     });
 
     es.addEventListener("error", () => {
-      setConnectionError(
-        "Live Today updates were interrupted. Reconnecting with the latest session…",
-      );
+      setConnectionError(m.today_live_updates_interrupted());
     });
 
     return () => {

--- a/frontend/src/lib/auth/session.ts
+++ b/frontend/src/lib/auth/session.ts
@@ -1,13 +1,30 @@
+import { useSyncExternalStore } from "react";
+
 /**
  * Module-level OIDC access token bridge.
  * AuthProvider writes the current token here so non-React modules can read it.
  */
 let _oidcAccessToken: string | undefined;
+const listeners = new Set<() => void>();
 
 export function setOidcAccessToken(token: string | undefined): void {
+  if (_oidcAccessToken === token) return;
+
   _oidcAccessToken = token;
+  listeners.forEach((listener) => listener());
 }
 
 export function getOidcAccessToken(): string | undefined {
   return _oidcAccessToken;
+}
+
+function subscribeOidcAccessToken(listener: () => void): () => void {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+export function useOidcAccessToken(): string | undefined {
+  return useSyncExternalStore(subscribeOidcAccessToken, getOidcAccessToken, getOidcAccessToken);
 }

--- a/frontend/tests/features/today/useTodayLiveUpdates.test.ts
+++ b/frontend/tests/features/today/useTodayLiveUpdates.test.ts
@@ -3,6 +3,7 @@ import { QueryClientProvider } from "@tanstack/react-query";
 import { createElement } from "react";
 import type { ReactNode } from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import * as m from "@/paraglide/messages";
 import { useTodayLiveUpdates } from "@/features/today/useTodayLiveUpdates";
 import { queryKeys } from "@/lib/query/queryKeys";
 import * as session from "@/lib/auth/session";
@@ -182,7 +183,7 @@ describe("useTodayLiveUpdates", () => {
     await act(async () => {
       capturedEs!.emit("error", "");
     });
-    expect(result.current).toContain("Live Today updates were interrupted");
+    expect(result.current).toBe(m.today_live_updates_interrupted());
 
     await act(async () => {
       capturedEs!.emit("open", "");

--- a/frontend/tests/features/today/useTodayLiveUpdates.test.ts
+++ b/frontend/tests/features/today/useTodayLiveUpdates.test.ts
@@ -38,6 +38,7 @@ function wrapper({ children }: { children: ReactNode }) {
 
 describe("useTodayLiveUpdates", () => {
   afterEach(() => {
+    session.setOidcAccessToken(undefined);
     vi.restoreAllMocks();
     vi.unstubAllGlobals();
   });
@@ -53,13 +54,14 @@ describe("useTodayLiveUpdates", () => {
         }
       },
     );
-    vi.spyOn(session, "getOidcAccessToken").mockReturnValue("test-token");
+    session.setOidcAccessToken("test-token");
 
     const queryClient = createQueryTestClient();
     const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
 
     renderHook(() => useTodayLiveUpdates(), {
-      wrapper: ({ children }) => createElement(QueryClientProvider, { client: queryClient }, children),
+      wrapper: ({ children }) =>
+        createElement(QueryClientProvider, { client: queryClient }, children),
     });
 
     expect(capturedEs).toBeDefined();
@@ -74,7 +76,7 @@ describe("useTodayLiveUpdates", () => {
   it("does not open EventSource when there is no access token", () => {
     const constructorSpy = vi.fn();
     vi.stubGlobal("EventSource", constructorSpy);
-    vi.spyOn(session, "getOidcAccessToken").mockReturnValue(undefined);
+    session.setOidcAccessToken(undefined);
 
     renderHook(() => useTodayLiveUpdates(), { wrapper });
 
@@ -92,7 +94,7 @@ describe("useTodayLiveUpdates", () => {
         }
       },
     );
-    vi.spyOn(session, "getOidcAccessToken").mockReturnValue("test-token");
+    session.setOidcAccessToken("test-token");
 
     const { unmount } = renderHook(() => useTodayLiveUpdates(), { wrapper });
 
@@ -112,13 +114,14 @@ describe("useTodayLiveUpdates", () => {
         }
       },
     );
-    vi.spyOn(session, "getOidcAccessToken").mockReturnValue("test-token");
+    session.setOidcAccessToken("test-token");
 
     const queryClient = createQueryTestClient();
     const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
 
     renderHook(() => useTodayLiveUpdates(), {
-      wrapper: ({ children }) => createElement(QueryClientProvider, { client: queryClient }, children),
+      wrapper: ({ children }) =>
+        createElement(QueryClientProvider, { client: queryClient }, children),
     });
 
     // Initial connect — should NOT invalidate.
@@ -145,19 +148,46 @@ describe("useTodayLiveUpdates", () => {
         }
       },
     );
-    const tokenSpy = vi.spyOn(session, "getOidcAccessToken").mockReturnValue("token-a");
+    session.setOidcAccessToken("token-a");
 
-    const { rerender } = renderHook(() => useTodayLiveUpdates(), { wrapper });
+    renderHook(() => useTodayLiveUpdates(), { wrapper });
     expect(instances).toHaveLength(1);
     const first = instances[0]!;
     expect(first.url).toContain("token=token-a");
 
-    tokenSpy.mockReturnValue("token-b");
-    rerender();
+    act(() => {
+      session.setOidcAccessToken("token-b");
+    });
 
     expect(first.closed).toBe(true);
     expect(instances).toHaveLength(2);
     expect(instances[1]!.url).toContain("token=token-b");
+  });
+
+  it("reports and clears connection errors", async () => {
+    let capturedEs: MockEventSource | undefined;
+    vi.stubGlobal(
+      "EventSource",
+      class extends MockEventSource {
+        constructor(url: string) {
+          super(url);
+          capturedEs = this;
+        }
+      },
+    );
+    session.setOidcAccessToken("test-token");
+
+    const { result } = renderHook(() => useTodayLiveUpdates(), { wrapper });
+
+    await act(async () => {
+      capturedEs!.emit("error", "");
+    });
+    expect(result.current).toContain("Live Today updates were interrupted");
+
+    await act(async () => {
+      capturedEs!.emit("open", "");
+    });
+    expect(result.current).toBeNull();
   });
 
   it("opens EventSource with the token in the URL", () => {
@@ -171,7 +201,7 @@ describe("useTodayLiveUpdates", () => {
         }
       },
     );
-    vi.spyOn(session, "getOidcAccessToken").mockReturnValue("my-token");
+    session.setOidcAccessToken("my-token");
 
     renderHook(() => useTodayLiveUpdates(), { wrapper });
 


### PR DESCRIPTION
### Motivation
- Ensure the Today SSE feed is resilient to silent OIDC token renewals by rebuilding the `EventSource` when the access token changes.
- Surface a user-visible warning when the live Today stream is interrupted so users know the client is reconnecting.

### Description
- Add a reactive access-token bridge using `useSyncExternalStore` in `frontend/src/lib/auth/session.ts` and export `useOidcAccessToken` to allow hooks to subscribe to token updates.
- Update `useTodayLiveUpdates` (`frontend/src/features/today/useTodayLiveUpdates.ts`) to use `useOidcAccessToken`, recreate the `EventSource` when the token changes, track connection state, and expose a `connectionError` string when the stream errors.
- Add `error` listener and clear warnings on successful `open`/`today_updated` events in the live-update hook.
- Surface the live-update warning on the Today page by consuming the hook return value in `frontend/src/features/today/TodayPage.tsx` and rendering a `FeedbackBanner` with the message.
- Update tests in `frontend/tests/features/today/useTodayLiveUpdates.test.ts` to drive the new reactive token API (`session.setOidcAccessToken`) and to cover token-change reconnection and connection-error recovery.

### Testing
- Ran `pnpm lint` which completed (existing lint warnings in tests remain and are unchanged).
- Ran `pnpm test -- --runInBand` and all tests passed (including the updated live-update tests).
- Ran `pnpm build` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a52b3b5b8f4832ebd765f2aedc01aa5)