### PR TITLE
Require email confirmation for account deletion

### DIFF
--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -460,7 +460,10 @@
   "settings_delete_account_description": "Permanently delete your Daynest account and personal data, including medication, planning, calendar, push notification, session, and integration data. Household-shared chores must be deleted, transferred, or left before account deletion.",
   "settings_delete_account_button": "Delete my account",
   "settings_delete_account_deleting": "Deleting…",
-  "settings_delete_account_confirm": "This permanently deletes your Daynest account and personal data. This cannot be undone. Continue?",
+  "settings_delete_account_confirm": "This permanently deletes your Daynest account and personal data. This cannot be undone. Type {email} to confirm.",
+  "settings_delete_account_email_label": "Type your email address to confirm",
+  "settings_delete_account_email_placeholder": "Enter {email}",
+  "settings_delete_account_mismatch": "Enter your email address exactly to enable account deletion.",
   "settings_delete_account_error": "Failed to delete account.",
   "nav_menu": "Menu"
 }

--- a/frontend/messages/nl.json
+++ b/frontend/messages/nl.json
@@ -460,7 +460,10 @@
   "settings_delete_account_description": "Verwijder je Daynest-account en persoonlijke gegevens permanent, inclusief medicatie-, planning-, kalender-, pushmelding-, sessie- en integratiegegevens. Huishoudelijke gedeelde klusjes moeten eerst worden verwijderd, overgedragen of verlaten.",
   "settings_delete_account_button": "Mijn account verwijderen",
   "settings_delete_account_deleting": "Verwijderen…",
-  "settings_delete_account_confirm": "Dit verwijdert je Daynest-account en persoonlijke gegevens permanent. Dit kan niet ongedaan worden gemaakt. Doorgaan?",
+  "settings_delete_account_confirm": "Dit verwijdert je Daynest-account en persoonlijke gegevens permanent. Dit kan niet ongedaan worden gemaakt. Typ {email} om te bevestigen.",
+  "settings_delete_account_email_label": "Typ je e-mailadres om te bevestigen",
+  "settings_delete_account_email_placeholder": "Voer {email} in",
+  "settings_delete_account_mismatch": "Voer je e-mailadres exact in om accountverwijdering in te schakelen.",
   "settings_delete_account_error": "Account verwijderen mislukt.",
   "nav_menu": "Menu"
 }

--- a/frontend/src/features/settings/sections/AccountDeletionSection.tsx
+++ b/frontend/src/features/settings/sections/AccountDeletionSection.tsx
@@ -5,12 +5,27 @@ import { deleteAccount } from "@/lib/api/settings";
 
 export function AccountDeletionSection() {
   const auth = useContext(AuthContext);
+  const userEmail = auth?.user?.email ?? "";
   const [isDeleting, setIsDeleting] = useState(false);
   const [isConfirming, setIsConfirming] = useState(false);
+  const [confirmationEmail, setConfirmationEmail] = useState("");
   const [error, setError] = useState<string | null>(null);
+  const canDelete = userEmail.length > 0 && confirmationEmail.trim() === userEmail;
+
+  const resetConfirmation = () => {
+    setIsConfirming(false);
+    setConfirmationEmail("");
+    setError(null);
+  };
 
   const handleDelete = async () => {
     setError(null);
+
+    if (!canDelete) {
+      setError(m.settings_delete_account_mismatch());
+      return;
+    }
+
     setIsDeleting(true);
     try {
       await deleteAccount();
@@ -30,7 +45,27 @@ export function AccountDeletionSection() {
         <p className="text-muted small mb-2">{m.settings_delete_account_description()}</p>
         {isConfirming ? (
           <div className="alert alert-danger py-2 small mb-2">
-            {m.settings_delete_account_confirm()}
+            {m.settings_delete_account_confirm({ email: userEmail })}
+          </div>
+        ) : null}
+        {isConfirming ? (
+          <div className="mb-2">
+            <label className="form-label small mb-1" htmlFor="delete-account-email-confirmation">
+              {m.settings_delete_account_email_label()}
+            </label>
+            <input
+              type="email"
+              className="form-control form-control-sm"
+              id="delete-account-email-confirmation"
+              value={confirmationEmail}
+              onChange={(event) => {
+                setConfirmationEmail(event.target.value);
+                setError(null);
+              }}
+              placeholder={m.settings_delete_account_email_placeholder({ email: userEmail })}
+              autoComplete="off"
+              disabled={isDeleting}
+            />
           </div>
         ) : null}
         {error ? <div className="alert alert-danger py-2 small mb-2">{error}</div> : null}
@@ -40,17 +75,14 @@ export function AccountDeletionSection() {
               type="button"
               className="btn btn-danger btn-sm"
               onClick={handleDelete}
-              disabled={isDeleting}
+              disabled={isDeleting || !canDelete}
             >
               {isDeleting ? m.settings_delete_account_deleting() : m.action_confirm()}
             </button>
             <button
               type="button"
               className="btn btn-outline-secondary btn-sm"
-              onClick={() => {
-                setIsConfirming(false);
-                setError(null);
-              }}
+              onClick={resetConfirmation}
               disabled={isDeleting}
             >
               {m.action_cancel()}
@@ -62,9 +94,10 @@ export function AccountDeletionSection() {
             className="btn btn-outline-danger btn-sm"
             onClick={() => {
               setError(null);
+              setConfirmationEmail("");
               setIsConfirming(true);
             }}
-            disabled={isDeleting}
+            disabled={isDeleting || userEmail.length === 0}
           >
             {m.settings_delete_account_button()}
           </button>

--- a/frontend/tests/features/settings/AccountDeletionSection.test.tsx
+++ b/frontend/tests/features/settings/AccountDeletionSection.test.tsx
@@ -68,6 +68,10 @@ describe("AccountDeletionSection", () => {
     apiMock.deleteAccount.mockResolvedValue(undefined);
 
     await user.click(screen.getByRole("button", { name: /delete my account/i }));
+    await user.type(
+      screen.getByLabelText(/type your email address to confirm/i),
+      "user@example.com",
+    );
     await user.click(screen.getByRole("button", { name: /confirm/i }));
 
     expect(confirmSpy).not.toHaveBeenCalled();
@@ -83,6 +87,10 @@ describe("AccountDeletionSection", () => {
     apiMock.deleteAccount.mockRejectedValue(new Error("Delete shared chores first."));
 
     await user.click(screen.getByRole("button", { name: /delete my account/i }));
+    await user.type(
+      screen.getByLabelText(/type your email address to confirm/i),
+      "user@example.com",
+    );
     await user.click(screen.getByRole("button", { name: /confirm/i }));
 
     expect(await screen.findByText("Delete shared chores first.")).toBeInTheDocument();
@@ -98,6 +106,10 @@ describe("AccountDeletionSection", () => {
     apiMock.deleteAccount.mockRejectedValue(new Error("Delete shared chores first."));
 
     await user.click(screen.getByRole("button", { name: /delete my account/i }));
+    await user.type(
+      screen.getByLabelText(/type your email address to confirm/i),
+      "user@example.com",
+    );
     await user.click(screen.getByRole("button", { name: /confirm/i }));
 
     expect(await screen.findByText("Delete shared chores first.")).toBeInTheDocument();

--- a/frontend/tests/features/settings/SettingsPage.test.tsx
+++ b/frontend/tests/features/settings/SettingsPage.test.tsx
@@ -2,6 +2,7 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { AuthContext } from "@/app/providers/AuthProvider";
 import { SettingsPage } from "@/features/settings/SettingsPage";
 import { LanguageProvider } from "@/i18n/LanguageProvider";
 import { setLocale } from "@/paraglide/runtime";
@@ -41,6 +42,30 @@ vi.mock("@/app/pwa/installPrompt", () => ({
   promptToInstallApp: pwaMock.promptToInstallApp,
   subscribeInstallPrompt: pwaMock.subscribeInstallPrompt,
 }));
+
+function renderSettingsPage(children: React.ReactNode) {
+  return render(
+    <AuthContext.Provider
+      value={{
+        user: {
+          id: 1,
+          email: "user@example.com",
+          full_name: "Test User",
+          is_active: true,
+          roles: [],
+        },
+        isLoading: false,
+        isAuthenticated: true,
+        login: vi.fn(),
+        logout: vi.fn(),
+        refreshUser: vi.fn(),
+        sessionError: null,
+      }}
+    >
+      {children}
+    </AuthContext.Provider>,
+  );
+}
 
 describe("SettingsPage", () => {
   beforeEach(() => {
@@ -211,7 +236,9 @@ describe("SettingsPage", () => {
     await user.click(overdueToggle);
 
     await waitFor(() => {
-      expect(apiMock.updateUserSettings).toHaveBeenCalledWith({ push_overdue_chores_enabled: false });
+      expect(apiMock.updateUserSettings).toHaveBeenCalledWith({
+        push_overdue_chores_enabled: false,
+      });
     });
   });
 
@@ -219,7 +246,10 @@ describe("SettingsPage", () => {
     const user = userEvent.setup();
     let resolveFirst!: (v: unknown) => void;
     apiMock.updateUserSettings.mockImplementationOnce(
-      () => new Promise((r) => { resolveFirst = r; }),
+      () =>
+        new Promise((r) => {
+          resolveFirst = r;
+        }),
     );
     render(
       <QueryTestProvider>
@@ -273,7 +303,7 @@ describe("SettingsPage", () => {
     apiMock.deleteAccount.mockResolvedValue(undefined);
 
     try {
-      render(
+      renderSettingsPage(
         <QueryTestProvider>
           <SettingsPage />
         </QueryTestProvider>,
@@ -283,8 +313,14 @@ describe("SettingsPage", () => {
       await user.click(deleteButton);
 
       expect(confirmSpy).not.toHaveBeenCalled();
-      expect(screen.getByText(/this permanently deletes your daynest account/i)).toBeInTheDocument();
+      expect(
+        screen.getByText(/this permanently deletes your daynest account/i),
+      ).toBeInTheDocument();
 
+      await user.type(
+        screen.getByLabelText(/type your email address to confirm/i),
+        "user@example.com",
+      );
       await user.click(screen.getByRole("button", { name: /^confirm$/i }));
 
       await waitFor(() => {
@@ -299,13 +335,17 @@ describe("SettingsPage", () => {
     const user = userEvent.setup();
     render(
       <QueryTestProvider>
-        <LanguageProvider><SettingsPage /></LanguageProvider>
+        <LanguageProvider>
+          <SettingsPage />
+        </LanguageProvider>
       </QueryTestProvider>,
     );
 
     const languageSelect = await screen.findByRole("combobox", { name: /language/i });
     await user.selectOptions(languageSelect, "nl");
 
-    expect(await screen.findByRole("heading", { level: 2, name: /instellingen/i })).toBeInTheDocument();
+    expect(
+      await screen.findByRole("heading", { level: 2, name: /instellingen/i }),
+    ).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
### Motivation
- Strengthen the destructive account-deletion flow so users must explicitly re-enter their account email before a permanent delete can proceed.

### Description
- Update `frontend/src/features/settings/sections/AccountDeletionSection.tsx` to show an email input, require the typed value to exactly match the signed-in user's email, and disable the final delete button until it matches.
- Add localized copy keys to `frontend/messages/en.json` and `frontend/messages/nl.json`: `settings_delete_account_confirm`, `settings_delete_account_email_label`, `settings_delete_account_email_placeholder`, and `settings_delete_account_mismatch` to support the new UI.
- Reset the confirmation input and error state when cancelling the confirmation, and prevent opening the confirmation flow when the user email is not available.
- Preserve the existing `deleteAccount()` call and logout behavior once confirmation validation passes.

### Testing
- Ran `pnpm --dir frontend paraglide:compile` and it completed successfully.
- Ran `pnpm --dir frontend exec tsc -b` and it completed successfully.
- Ran `pnpm --dir frontend exec oxlint src/features/settings/sections/AccountDeletionSection.tsx` and it completed successfully.
- Ran `pnpm exec oxfmt --check src/features/settings/sections/AccountDeletionSection.tsx messages/en.json messages/nl.json` and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a52d17e7cac832eaa00e75bcc82e0f5)