### PR TITLE
Flag current OAuth session and show "This device" badge in settings

### DIFF
--- a/backend/app/api/dependencies/auth.py
+++ b/backend/app/api/dependencies/auth.py
@@ -12,6 +12,7 @@ bearer_scheme = HTTPBearer(auto_error=False)
 def _set_request_auth_state(request: Request, user: User, claims: dict[str, object]) -> None:
     request.state.user_id = user.id
     request.state.roles = _extract_roles(claims)
+    request.state.oidc_session_id = claims.get("sid")
     request.state.auth_type = "oidc"
 
 

--- a/backend/app/api/routes/auth.py
+++ b/backend/app/api/routes/auth.py
@@ -114,6 +114,7 @@ async def update_me(
 
 @router.get("/sessions", response_model=list[OAuthSessionResponse])
 async def list_sessions(
+    request: Request,
     credentials: HTTPAuthorizationCredentials | None = Depends(bearer_scheme),
     current_user: User = Depends(get_current_user),
 ) -> list[OAuthSessionResponse]:
@@ -151,7 +152,9 @@ async def list_sessions(
             status_code=status.HTTP_502_BAD_GATEWAY,
             detail="Invalid response from OIDC provider.",
         )
-    return [
+    current_session_id = getattr(request.state, "oidc_session_id", None)
+
+    sessions = [
         OAuthSessionResponse(
             id=s["id"],
             ip_address=s.get("ipAddress"),
@@ -159,10 +162,12 @@ async def list_sessions(
             last_access=s.get("lastAccess"),
             expires=s.get("expires"),
             clients=s.get("clients") or [],
+            is_current=isinstance(current_session_id, str) and s["id"] == current_session_id,
         )
         for s in raw_sessions
         if isinstance(s, dict) and s.get("id")
     ]
+    return sorted(sessions, key=lambda session: not session.is_current)
 
 
 @router.delete("/sessions/{session_id}", status_code=status.HTTP_204_NO_CONTENT)

--- a/backend/app/schemas/auth.py
+++ b/backend/app/schemas/auth.py
@@ -51,3 +51,4 @@ class OAuthSessionResponse(BaseModel):
     last_access: int | None = None
     expires: int | None = None
     clients: list[OAuthSessionClient] = []
+    is_current: bool = False

--- a/backend/tests/test_auth_routes.py
+++ b/backend/tests/test_auth_routes.py
@@ -7,7 +7,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import httpx
 import pytest
-from fastapi import HTTPException
+from fastapi import HTTPException, Request
 from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
 
@@ -31,9 +31,10 @@ def _make_user(db: Session, *, email: str, oidc_subject: str | None = None, full
     return user
 
 
-def _override_auth(user: User):
+def _override_auth(user: User, *, oidc_session_id: str | None = None):
     """Return an async dependency that always yields *user*."""
-    async def _dep() -> User:
+    async def _dep(request: Request) -> User:
+        request.state.oidc_session_id = oidc_session_id
         return user
     app.dependency_overrides[get_current_user] = _dep
 
@@ -318,7 +319,29 @@ class TestListSessions:
             assert data[0]["id"] == "session-abc123"
             assert data[0]["ip_address"] == "192.168.1.1"
             assert data[0]["clients"] == [{"clientId": "claude-ai-mcp", "clientName": "Claude.ai MCP Connector", "userConsentRequired": False, "inUse": True, "offlineAccess": False}]
+            assert data[0]["is_current"] is False
             assert data[1]["id"] == "session-def456"
+            assert data[1]["is_current"] is False
+        finally:
+            _clear_auth()
+
+
+    def test_marks_current_session_and_sorts_it_first(
+        self, client: TestClient, db_session: Session, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        user = _make_user(db_session, email="current-session@example.com", oidc_subject="sub-current")
+        _override_auth(user, oidc_session_id="session-def456")
+        monkeypatch.setattr("app.api.routes.auth._http_client", MagicMock(
+            get=AsyncMock(return_value=_make_httpx_response(200, SAMPLE_SESSIONS))
+        ))
+        monkeypatch.setattr("app.api.routes.auth.settings.oidc_issuer_url", "http://keycloak/realms/daynest")
+        try:
+            resp = client.get("/api/auth/sessions", headers={"Authorization": "Bearer dummy-token"})
+            assert resp.status_code == 200
+            data = resp.json()
+            assert [session["id"] for session in data] == ["session-def456", "session-abc123"]
+            assert data[0]["is_current"] is True
+            assert data[1]["is_current"] is False
         finally:
             _clear_auth()
 
@@ -374,6 +397,26 @@ class TestRevokeSession:
                 headers={"Authorization": "Bearer dummy-token"},
             )
             assert resp.status_code == 204
+        finally:
+            _clear_auth()
+
+
+    def test_marks_current_session_and_sorts_it_first(
+        self, client: TestClient, db_session: Session, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        user = _make_user(db_session, email="current-session@example.com", oidc_subject="sub-current")
+        _override_auth(user, oidc_session_id="session-def456")
+        monkeypatch.setattr("app.api.routes.auth._http_client", MagicMock(
+            get=AsyncMock(return_value=_make_httpx_response(200, SAMPLE_SESSIONS))
+        ))
+        monkeypatch.setattr("app.api.routes.auth.settings.oidc_issuer_url", "http://keycloak/realms/daynest")
+        try:
+            resp = client.get("/api/auth/sessions", headers={"Authorization": "Bearer dummy-token"})
+            assert resp.status_code == 200
+            data = resp.json()
+            assert [session["id"] for session in data] == ["session-def456", "session-abc123"]
+            assert data[0]["is_current"] is True
+            assert data[1]["is_current"] is False
         finally:
             _clear_auth()
 

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -337,6 +337,8 @@
   "settings_rotate_secret": "Rotate secret",
   "settings_revoking": "Revoking…",
   "settings_revoke": "Revoke",
+  "settings_this_device": "This device",
+  "settings_revoke_current_session_confirm": "This is your current device. Revoking it may sign you out immediately. Continue?",
   "settings_oauth_sessions_header": "Active OAuth sessions",
   "settings_loading_sessions": "Loading sessions…",
   "settings_no_sessions": "No active OAuth sessions.",

--- a/frontend/messages/nl.json
+++ b/frontend/messages/nl.json
@@ -337,6 +337,8 @@
   "settings_rotate_secret": "Geheim roteren",
   "settings_revoking": "Intrekken…",
   "settings_revoke": "Intrekken",
+  "settings_this_device": "Dit apparaat",
+  "settings_revoke_current_session_confirm": "Dit is je huidige apparaat. Als je deze sessie intrekt, word je mogelijk meteen afgemeld. Doorgaan?",
   "settings_oauth_sessions_header": "Actieve OAuth-sessies",
   "settings_loading_sessions": "Sessies laden…",
   "settings_no_sessions": "Geen actieve OAuth-sessies.",

--- a/frontend/src/features/settings/sections/OAuthSessionsSection.tsx
+++ b/frontend/src/features/settings/sections/OAuthSessionsSection.tsx
@@ -32,7 +32,12 @@ export function OAuthSessionsSection() {
     }
   };
 
-  const onRevokeSession = async (sessionId: string) => {
+  const onRevokeSession = async (session: OAuthSession) => {
+    if (session.is_current && !window.confirm(m.settings_revoke_current_session_confirm())) {
+      return;
+    }
+
+    const sessionId = session.id;
     setRevokingSession(sessionId);
     setRevokeError(null);
     try {
@@ -86,8 +91,13 @@ export function OAuthSessionsSection() {
                 <li key={session.id} className="list-group-item py-2">
                   <div className="d-flex justify-content-between align-items-start gap-3">
                     <div>
-                      <div className="fw-semibold">
-                        {clientNames.length > 0 ? clientNames.join(", ") : m.settings_unknown_client()}
+                      <div className="fw-semibold d-flex align-items-center flex-wrap gap-2">
+                        <span>
+                          {clientNames.length > 0 ? clientNames.join(", ") : m.settings_unknown_client()}
+                        </span>
+                        {session.is_current ? (
+                          <span className="badge text-bg-primary">{m.settings_this_device()}</span>
+                        ) : null}
                       </div>
                       {metaParts.length > 0 ? (
                         <small className="text-muted d-block">{metaParts.join(" • ")}</small>
@@ -97,7 +107,7 @@ export function OAuthSessionsSection() {
                       type="button"
                       className="btn btn-outline-danger btn-sm flex-shrink-0"
                       disabled={revokingSession === session.id}
-                      onClick={() => void onRevokeSession(session.id)}
+                      onClick={() => void onRevokeSession(session)}
                     >
                       {revokingSession === session.id ? m.settings_revoking() : m.settings_revoke()}
                     </button>

--- a/frontend/src/lib/api/auth.ts
+++ b/frontend/src/lib/api/auth.ts
@@ -24,6 +24,7 @@ export interface OAuthSession {
   last_access: number | null;
   expires: number | null;
   clients: OAuthSessionClient[];
+  is_current: boolean;
 }
 
 export class AuthApiError extends Error {


### PR DESCRIPTION
### Motivation
- Let the server and UI identify the caller’s current OIDC session so the user can see which session corresponds to their current device. 
- Avoid accidental self-revocation by asking for confirmation when the user tries to revoke the current session.

### Description
- Capture the OIDC `sid` claim into request state as `request.state.oidc_session_id` in `app.api.dependencies.auth` and expose it to session-listing logic.
- Add an `is_current: bool` property to `OAuthSessionResponse` and mark sessions where the provider session id equals the caller's `sid` in `backend/app/api/routes/auth.py`, returning the current session first.
- Update backend tests to cover `is_current` behavior and sorting so the current session is flagged and placed first in the list (`backend/tests/test_auth_routes.py`).
- Extend the frontend API type (`frontend/src/lib/api/auth.ts`) with `is_current`, show a "This device" badge in `OAuthSessionsSection.tsx`, and prompt the user with a confirmation before revoking the current session.
- Add localized strings for the badge and confirmation to `frontend/messages/en.json` and `frontend/messages/nl.json`.

### Testing
- Ran backend lint and tests with `uv run ruff check app && uv run pytest` resulting in `252 passed` (all backend tests passed).
- Ran frontend checks and tests with `pnpm lint && pnpm test -- --runInBand` and built with `pnpm build`, with `24 test files / 135 tests passed` and successful production build.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a52d75a98a8832eb8a0c1e500158456)