### PR TITLE
Handle cancelled Android sign-in separately

### DIFF
--- a/android/app/src/main/java/com/daynest/android/core/auth/OidcAuthService.kt
+++ b/android/app/src/main/java/com/daynest/android/core/auth/OidcAuthService.kt
@@ -65,9 +65,12 @@ constructor(
         val exception = data?.let { AuthorizationException.fromIntent(it) }
 
         return when {
-            exception == AuthorizationException.GeneralErrors.USER_CANCELED_AUTH_FLOW -> AuthorizationResult.Cancelled
+            resultCode == Activity.RESULT_CANCELED ||
+                exception == AuthorizationException.GeneralErrors.USER_CANCELED_AUTH_FLOW -> {
+                AuthorizationResult.Cancelled
+            }
             !isOk || response == null || exception != null -> {
-                if (data == null) AuthorizationResult.Cancelled else AuthorizationResult.Failed
+                AuthorizationResult.Failed
             }
             else -> {
                 suspendCancellableCoroutine { cont ->

--- a/android/app/src/main/java/com/daynest/android/core/auth/OidcAuthService.kt
+++ b/android/app/src/main/java/com/daynest/android/core/auth/OidcAuthService.kt
@@ -63,20 +63,26 @@ constructor(
         val isOk = resultCode == Activity.RESULT_OK && data != null
         val response = data?.let { AuthorizationResponse.fromIntent(it) }
         val exception = data?.let { AuthorizationException.fromIntent(it) }
-        if (exception == AuthorizationException.GeneralErrors.USER_CANCELED_AUTH_FLOW) {
-            return AuthorizationResult.Cancelled
-        }
-        if (!isOk || response == null || exception != null) {
-            return if (data == null) AuthorizationResult.Cancelled else AuthorizationResult.Failed
-        }
-        return suspendCancellableCoroutine { cont ->
-            authorizationService.performTokenRequest(response.createTokenExchangeRequest()) { tokenResponse, ex ->
-                if (tokenResponse != null) {
-                    val newState = AuthState(response, null).apply { update(tokenResponse, ex) }
-                    persistState(newState)
-                    cont.resume(AuthorizationResult.Authorized)
-                } else {
-                    cont.resume(AuthorizationResult.Failed)
+
+        return when {
+            exception == AuthorizationException.GeneralErrors.USER_CANCELED_AUTH_FLOW -> AuthorizationResult.Cancelled
+            !isOk || response == null || exception != null -> {
+                if (data == null) AuthorizationResult.Cancelled else AuthorizationResult.Failed
+            }
+            else -> {
+                suspendCancellableCoroutine { cont ->
+                    authorizationService.performTokenRequest(
+                        response.createTokenExchangeRequest()
+                    ) { tokenResponse, ex ->
+                        when (tokenResponse) {
+                            null -> cont.resume(AuthorizationResult.Failed)
+                            else -> {
+                                val newState = AuthState(response, null).apply { update(tokenResponse, ex) }
+                                persistState(newState)
+                                cont.resume(AuthorizationResult.Authorized)
+                            }
+                        }
+                    }
                 }
             }
         }

--- a/android/app/src/main/java/com/daynest/android/core/auth/OidcAuthService.kt
+++ b/android/app/src/main/java/com/daynest/android/core/auth/OidcAuthService.kt
@@ -59,21 +59,24 @@ constructor(
         return authorizationService.getAuthorizationRequestIntent(request)
     }
 
-    suspend fun handleAuthorizationResult(resultCode: Int, data: Intent?): Boolean {
+    suspend fun handleAuthorizationResult(resultCode: Int, data: Intent?): AuthorizationResult {
         val isOk = resultCode == Activity.RESULT_OK && data != null
         val response = data?.let { AuthorizationResponse.fromIntent(it) }
         val exception = data?.let { AuthorizationException.fromIntent(it) }
+        if (exception == AuthorizationException.GeneralErrors.USER_CANCELED_AUTH_FLOW) {
+            return AuthorizationResult.Cancelled
+        }
         if (!isOk || response == null || exception != null) {
-            return false
+            return if (data == null) AuthorizationResult.Cancelled else AuthorizationResult.Failed
         }
         return suspendCancellableCoroutine { cont ->
             authorizationService.performTokenRequest(response.createTokenExchangeRequest()) { tokenResponse, ex ->
                 if (tokenResponse != null) {
                     val newState = AuthState(response, null).apply { update(tokenResponse, ex) }
                     persistState(newState)
-                    cont.resume(true)
+                    cont.resume(AuthorizationResult.Authorized)
                 } else {
-                    cont.resume(false)
+                    cont.resume(AuthorizationResult.Failed)
                 }
             }
         }
@@ -137,4 +140,10 @@ constructor(
         authState = AuthState()
         secureSessionStore.clear()
     }
+}
+
+enum class AuthorizationResult {
+    Authorized,
+    Cancelled,
+    Failed
 }

--- a/android/app/src/main/java/com/daynest/android/feature/auth/AuthViewModel.kt
+++ b/android/app/src/main/java/com/daynest/android/feature/auth/AuthViewModel.kt
@@ -76,7 +76,7 @@ constructor(
             _uiState.update { it.copy(isLoading = true, error = null) }
             val authorizationResult = oidcAuthService.handleAuthorizationResult(resultCode, data)
             if (authorizationResult == AuthorizationResult.Authorized) {
-                runCatching { pushRegistrationManager.registerIfEnabled() }
+                launch { runCatching { pushRegistrationManager.registerIfEnabled() } }
             }
             _uiState.update {
                 it.copy(

--- a/android/app/src/main/java/com/daynest/android/feature/auth/AuthViewModel.kt
+++ b/android/app/src/main/java/com/daynest/android/feature/auth/AuthViewModel.kt
@@ -4,6 +4,7 @@ import android.content.Intent
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.daynest.android.BuildConfig
+import com.daynest.android.core.auth.AuthorizationResult
 import com.daynest.android.core.auth.OidcAuthService
 import com.daynest.android.core.storage.ApiBaseUrlOverrideStore
 import com.daynest.android.data.push.PushRegistrationManager
@@ -73,15 +74,15 @@ constructor(
     fun handleAuthorizationResult(resultCode: Int, data: Intent?) {
         viewModelScope.launch {
             _uiState.update { it.copy(isLoading = true, error = null) }
-            val succeeded = oidcAuthService.handleAuthorizationResult(resultCode, data)
-            if (succeeded) {
+            val authorizationResult = oidcAuthService.handleAuthorizationResult(resultCode, data)
+            if (authorizationResult == AuthorizationResult.Authorized) {
                 runCatching { pushRegistrationManager.registerIfEnabled() }
             }
             _uiState.update {
                 it.copy(
                     isLoading = false,
-                    isSignedIn = succeeded,
-                    error = if (succeeded) null else AuthError.SignInFailed
+                    isSignedIn = authorizationResult == AuthorizationResult.Authorized,
+                    error = if (authorizationResult == AuthorizationResult.Failed) AuthError.SignInFailed else null
                 )
             }
         }


### PR DESCRIPTION
### Motivation
- Prevent user-initiated sign-in cancellations from being treated as sign-in failures so the UI does not surface an error when the user cancels the flow.

### Description
- Change `OidcAuthService.handleAuthorizationResult` to return a typed `AuthorizationResult` enum (`Authorized`, `Cancelled`, `Failed`) instead of a `Boolean`.
- Treat AppAuth `AuthorizationException.GeneralErrors.USER_CANCELED_AUTH_FLOW` and missing result `data` as `AuthorizationResult.Cancelled`, and map token-exchange outcomes to `Authorized` or `Failed` as appropriate.
- Update `AuthViewModel.handleAuthorizationResult` to consume the new `AuthorizationResult`, only call `pushRegistrationManager.registerIfEnabled()` on `Authorized`, only set `isSignedIn` when `Authorized`, and only show `AuthError.SignInFailed` for `Failed` results.
- Files changed: `android/app/src/main/java/com/daynest/android/core/auth/OidcAuthService.kt` and `android/app/src/main/java/com/daynest/android/feature/auth/AuthViewModel.kt`.

### Testing
- Ran `./gradlew :app:ktlintCheck` which completed successfully.
- Attempted `./gradlew :app:compileDebugKotlin` but it failed due to the Android SDK location not being configured in this environment (missing `ANDROID_HOME` or `android/local.properties` `sdk.dir`).
- Verified `ktlint` checks after code edits and fixed local variable naming to satisfy linting.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a535cb4ca38832eaa5efb8edf4e10de)