### PR TITLE
Surface OIDC redirect errors on auth page

### DIFF
--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -47,6 +47,7 @@
   "auth_title": "Sign in to Daynest",
   "auth_subtitle": "Use your account to sync Today, Calendar, and future planning modules.",
   "auth_sign_in": "Sign in",
+  "auth_error_title": "Sign-in failed",
   "auth_loading": "Loading…",
   "router_loading_session": "Loading session...",
   "router_completing_sign_in": "Completing sign in…",

--- a/frontend/messages/nl.json
+++ b/frontend/messages/nl.json
@@ -47,6 +47,7 @@
   "auth_title": "Aanmelden bij Daynest",
   "auth_subtitle": "Gebruik uw account om Vandaag, Kalender en toekomstige planningsmodules te synchroniseren.",
   "auth_sign_in": "Aanmelden",
+  "auth_error_title": "Aanmelden mislukt",
   "auth_loading": "Laden…",
   "router_loading_session": "Sessie laden...",
   "router_completing_sign_in": "Aanmelding voltooien…",

--- a/frontend/src/app/providers/AuthProvider.tsx
+++ b/frontend/src/app/providers/AuthProvider.tsx
@@ -4,6 +4,17 @@ import { AuthApiError, fetchMe, type AuthUser } from "@/lib/api/auth";
 import { setOidcAccessToken } from "@/lib/auth/session";
 import { AUTH_ROUTE_PATHS } from "@/config/oidc";
 
+function getOidcErrorMessage(error: unknown) {
+  if (!error) return null;
+
+  if (error instanceof Error && error.message) {
+    return error.message;
+  }
+
+  const fallbackMessage = String(error);
+  return fallbackMessage || "Unable to complete sign in";
+}
+
 function getLoginReturnTo() {
   if (AUTH_ROUTE_PATHS.has(window.location.pathname)) {
     return "/today";
@@ -104,7 +115,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
         }
       },
       sessionError,
-      oidcError: oidc.error?.message ?? null,
+      oidcError: getOidcErrorMessage(oidc.error),
     }),
     [user, oidc, isFetching, sessionError],
   );

--- a/frontend/src/app/providers/AuthProvider.tsx
+++ b/frontend/src/app/providers/AuthProvider.tsx
@@ -20,6 +20,7 @@ type AuthContextValue = {
   logout: () => void;
   refreshUser: () => Promise<void>;
   sessionError: string | null;
+  oidcError: string | null;
 };
 
 export const AuthContext = createContext<AuthContextValue | null>(null);
@@ -103,6 +104,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
         }
       },
       sessionError,
+      oidcError: oidc.error?.message ?? null,
     }),
     [user, oidc, isFetching, sessionError],
   );

--- a/frontend/src/features/auth/AuthPage.tsx
+++ b/frontend/src/features/auth/AuthPage.tsx
@@ -13,7 +13,7 @@ function buildRedirectPath(value: unknown): string {
 }
 
 export function AuthPage() {
-  const { isAuthenticated, isLoading, login } = useAuth();
+  const { isAuthenticated, isLoading, login, oidcError } = useAuth();
   const search = useSearch({ from: "/auth" });
   const redirectTo = buildRedirectPath(search.from);
 
@@ -26,15 +26,14 @@ export function AuthPage() {
       <div className="card shadow-sm">
         <div className="card-body p-4 text-center">
           <h2 className="h4 mb-1">{m.auth_title()}</h2>
-          <p className="text-muted mb-3">
-            {m.auth_subtitle()}
-          </p>
-          <button
-            type="button"
-            className="btn btn-primary"
-            onClick={login}
-            disabled={isLoading}
-          >
+          <p className="text-muted mb-3">{m.auth_subtitle()}</p>
+          {oidcError ? (
+            <div className="alert alert-danger text-start" role="alert">
+              <p className="fw-semibold mb-1">{m.auth_error_title()}</p>
+              <p className="mb-0">{oidcError}</p>
+            </div>
+          ) : null}
+          <button type="button" className="btn btn-primary" onClick={login} disabled={isLoading}>
             {isLoading ? m.auth_loading() : m.auth_sign_in()}
           </button>
         </div>

--- a/frontend/src/mocks/MockAuthProvider.tsx
+++ b/frontend/src/mocks/MockAuthProvider.tsx
@@ -25,6 +25,7 @@ export function MockAuthProvider({ children }: { children: React.ReactNode }) {
         logout: () => {},
         refreshUser: async () => {},
         sessionError: null,
+        oidcError: null,
       }}
     >
       {children}

--- a/frontend/tests/features/auth/AuthPage.test.tsx
+++ b/frontend/tests/features/auth/AuthPage.test.tsx
@@ -8,6 +8,7 @@ const authMock = vi.hoisted(() => ({
   loginStub: vi.fn(),
   logoutStub: vi.fn(),
   refreshUserStub: vi.fn(),
+  oidcError: null as string | null,
 }));
 
 vi.mock("@/app/providers/AuthProvider", () => ({
@@ -18,6 +19,7 @@ vi.mock("@/app/providers/AuthProvider", () => ({
     logout: authMock.logoutStub,
     refreshUser: authMock.refreshUserStub,
     sessionError: null,
+    oidcError: authMock.oidcError,
     user: null,
   }),
 }));
@@ -34,6 +36,7 @@ describe("AuthPage", () => {
     authMock.loginStub.mockReset();
     authMock.logoutStub.mockReset();
     authMock.refreshUserStub.mockReset();
+    authMock.oidcError = null;
   });
 
   it("renders the sign-in heading", async () => {
@@ -50,6 +53,15 @@ describe("AuthPage", () => {
     const { container } = renderAuthPage();
     expect(container.querySelector('input[type="email"]')).not.toBeInTheDocument();
     expect(container.querySelector('input[type="password"]')).not.toBeInTheDocument();
+  });
+
+  it("renders an OIDC error when sign-in fails after redirect", async () => {
+    authMock.oidcError = "State mismatch";
+
+    renderAuthPage();
+
+    expect(await screen.findByRole("alert")).toHaveTextContent(/sign-in failed/i);
+    expect(screen.getByText("State mismatch")).toBeInTheDocument();
   });
 
   it("calls login() when the sign-in button is clicked", async () => {

--- a/frontend/tests/features/auth/AuthProvider.test.tsx
+++ b/frontend/tests/features/auth/AuthProvider.test.tsx
@@ -11,6 +11,7 @@ const authMock = vi.hoisted(() => ({
     isAuthenticated: false,
     signinRedirect: vi.fn(),
     signoutRedirect: vi.fn(),
+    error: undefined as unknown,
   },
 }));
 
@@ -31,9 +32,15 @@ function LoginButton() {
   return <button onClick={login}>Sign in</button>;
 }
 
+function OidcErrorMessage() {
+  const { oidcError } = useAuth();
+  return <div>{oidcError}</div>;
+}
+
 describe("AuthProvider login returnTo", () => {
   beforeEach(() => {
     authMock.oidc.signinRedirect.mockReset();
+    authMock.oidc.error = undefined;
   });
 
   it("uses /today when login starts on /auth", async () => {
@@ -51,6 +58,18 @@ describe("AuthProvider login returnTo", () => {
     expect(authMock.oidc.signinRedirect).toHaveBeenCalledWith({
       state: { returnTo: "/today" },
     });
+  });
+
+  it("falls back to the OIDC error string when message is empty", () => {
+    authMock.oidc.error = { message: "", toString: () => "State mismatch" };
+
+    render(
+      <AuthProvider>
+        <OidcErrorMessage />
+      </AuthProvider>,
+    );
+
+    expect(screen.getByText("State mismatch")).toBeInTheDocument();
   });
 
   it("preserves path, search, and hash for app routes", async () => {

--- a/frontend/tests/features/settings/AccountDeletionSection.test.tsx
+++ b/frontend/tests/features/settings/AccountDeletionSection.test.tsx
@@ -30,6 +30,7 @@ function renderSection(logout = vi.fn()) {
         logout,
         refreshUser: vi.fn(),
         sessionError: null,
+        oidcError: null,
       }}
     >
       <AccountDeletionSection />

--- a/frontend/tests/features/settings/SettingsPage.test.tsx
+++ b/frontend/tests/features/settings/SettingsPage.test.tsx
@@ -60,6 +60,7 @@ function renderSettingsPage(children: React.ReactNode) {
         logout: vi.fn(),
         refreshUser: vi.fn(),
         sessionError: null,
+        oidcError: null,
       }}
     >
       {children}


### PR DESCRIPTION
### Motivation
- Surface post-redirect OIDC failures from `react-oidc-context` so users see a helpful error on the sign-in page instead of a silent failure.

### Description
- Add `oidcError: string | null` to the app `AuthContext` and populate it from `oidc.error?.message` in `AuthProvider`.
- Render a localized Bootstrap danger alert with the OIDC provider message on the sign-in page in `AuthPage` when `oidcError` is present.
- Add `auth_error_title` keys to `frontend/messages/en.json` and `frontend/messages/nl.json` for the alert heading.
- Update `MockAuthProvider` and affected tests to include the new `oidcError` field and add a test case that verifies the error alert is displayed.

### Testing
- Ran unit tests with `pnpm --dir frontend test`, resulting in the full suite passing (`24 files / 136 tests passed`).
- Ran the focused test `pnpm --dir frontend test -- tests/features/auth/AuthPage.test.tsx` which passed and covers the new alert.
- Ran linter with `pnpm --dir frontend lint` which completed (existing warnings remain) and `pnpm --dir frontend build` which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a536df8f5a8832e8e268f60ab58d695)