### PR TITLE
ci: bump CodeQL Kotlin support gate to 2.4.0

### DIFF
--- a/.github/workflows/codeql-android.yml
+++ b/.github/workflows/codeql-android.yml
@@ -37,7 +37,7 @@ jobs:
         run: |
           set -euo pipefail
           kotlin_version="$(awk -F '"' '/^kotlin = / { print $2 }' android/gradle/libs.versions.toml)"
-          max_supported="2.3.29"
+          max_supported="2.4.0"
           if printf '%s\n%s\n' "${kotlin_version}" "${max_supported}" | sort -V -C; then
             echo "supported=true" >> "$GITHUB_OUTPUT"
           else

--- a/.github/workflows/codeql-android.yml
+++ b/.github/workflows/codeql-android.yml
@@ -42,7 +42,7 @@ jobs:
             echo "supported=true" >> "$GITHUB_OUTPUT"
           else
             echo "supported=false" >> "$GITHUB_OUTPUT"
-            echo "::notice::Skipping CodeQL java-kotlin analysis: Kotlin ${kotlin_version} is newer than CodeQL's current Kotlin support."
+            echo "::warning::Skipping CodeQL java-kotlin analysis: Kotlin ${kotlin_version} is newer than CodeQL's current Kotlin support."
           fi
 
       - name: Initialize CodeQL


### PR DESCRIPTION
## Summary
- CodeQL 2.26.0 [adds Kotlin 2.4.0 support](``https://github.blog/changelog/2026-07-10-codeql-2-26-0-adds-kotlin-2-4-0-support-and-ai-prompt-injection-detection/``)
- `android/gradle/libs.versions.toml` already pins Kotlin `2.4.0`, but `codeql-android.yml`'s version gate (`max_supported="2.3.29"`) was skipping CodeQL java-kotlin analysis as a result
- Bumped the gate to `2.4.0` so CodeQL analysis runs again on the `android` module

## Test plan
- [x] Verified `android/gradle/libs.versions.toml` pins `kotlin = "2.4.0"`
- [x] Confirmed the `CodeQL Android` workflow runs the `java-kotlin` analysis (not skipped) on this PR — [job succeeded](https://github.com/tjorim/daynest/actions/runs/29261852364/job/86856916391)

Fixes #647
