### PR TITLE
fix(frontend): repair broken pnpm lockfile failing e2e install

### DIFF
--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -10,7 +10,7 @@ importers:
     dependencies:
       '@inlang/paraglide-js':
         specifier: ^2.22.0
-        version: 2.22.0(typescript@7.0.2)(vite@8.1.4(@types/node@26.1.1))
+        version: 2.22.0(typescript@7.0.2)(vite@8.1.5(@types/node@26.1.1))
       '@inlang/plugin-m-function-matcher':
         specifier: ^2.2.9
         version: 2.2.9
@@ -2285,7 +2285,7 @@ snapshots:
 
   '@exodus/bytes@1.15.0': {}
 
-  '@inlang/paraglide-js@2.22.0(typescript@7.0.2)(vite@8.1.4(@types/node@26.1.1))':
+  '@inlang/paraglide-js@2.22.0(typescript@7.0.2)(vite@8.1.5(@types/node@26.1.1))':
     dependencies:
       '@inlang/recommend-sherlock': 0.2.1
       '@inlang/sdk': 2.10.2
@@ -2296,7 +2296,7 @@ snapshots:
       urlpattern-polyfill: 10.1.0
     optionalDependencies:
       typescript: 7.0.2
-      vite: 8.1.4(@types/node@26.1.1)
+      vite: 8.1.5(@types/node@26.1.1)
     transitivePeerDependencies:
       - babel-plugin-macros
 

--- a/frontend/public/mockServiceWorker.js
+++ b/frontend/public/mockServiceWorker.js
@@ -7,8 +7,8 @@
  * - Please do NOT modify this file.
  */
 
-const PACKAGE_VERSION = '2.14.6'
-const INTEGRITY_CHECKSUM = '4db4a41e972cec1b64cc569c66952d82'
+const PACKAGE_VERSION = '2.15.0'
+const INTEGRITY_CHECKSUM = '03cb67ac84128e63d7cd722a6e5b7f1e'
 const IS_MOCKED_RESPONSE = Symbol('isMockedResponse')
 const activeClientIds = new Set()
 
@@ -137,8 +137,18 @@ async function handleRequest(event, requestId, requestInterceptedAt) {
   if (client && activeClientIds.has(client.id)) {
     const serializedRequest = await serializeRequest(requestCloneForEvents)
 
+    // Omit the body of server-sent event stream responses.
+    // Cloning such responses would prevent client-side stream cancelations
+    // from reaching the original stream (a teed stream only cancels its
+    // source once both of its branches cancel) and would buffer the
+    // entire stream into the unconsumed clone indefinitely.
+    const isEventStreamResponse = response.headers
+      .get('content-type')
+      ?.toLowerCase()
+      .startsWith('text/event-stream')
+
     // Clone the response so both the client and the library could consume it.
-    const responseClone = response.clone()
+    const responseClone = isEventStreamResponse ? null : response.clone()
 
     sendToClient(
       client,
@@ -151,15 +161,17 @@ async function handleRequest(event, requestId, requestInterceptedAt) {
             ...serializedRequest,
           },
           response: {
-            type: responseClone.type,
-            status: responseClone.status,
-            statusText: responseClone.statusText,
-            headers: Object.fromEntries(responseClone.headers.entries()),
-            body: responseClone.body,
+            type: response.type,
+            status: response.status,
+            statusText: response.statusText,
+            headers: Object.fromEntries(response.headers.entries()),
+            body: responseClone ? responseClone.body : null,
           },
         },
       },
-      responseClone.body ? [serializedRequest.body, responseClone.body] : [],
+      responseClone && responseClone.body
+        ? [serializedRequest.body, responseClone.body]
+        : [],
     )
   }
 


### PR DESCRIPTION
## Summary

The e2e workflow has been failing on every branch (including `main`, and dependabot PRs like #659) at the "Install frontend dependencies" step:

```
ERR_PNPM_LOCKFILE_MISSING_DEPENDENCY  Broken lockfile: no entry for 'vite@8.1.4(@types/node@26.1.1)' in pnpm-lock.yaml
```

The lockfile's `@inlang/paraglide-js` snapshot still referenced `vite@8.1.4` after vite was bumped to 8.1.5, leaving a dangling reference that `pnpm install --frozen-lockfile` rejects — the result of mismerged dependency bumps.

## Changes

- Regenerated `frontend/pnpm-lock.yaml` with `pnpm install --no-frozen-lockfile`, which only updates the stale `vite@8.1.4` references in the paraglide-js snapshot to `8.1.5` (3 lines).
- Committed the `frontend/public/mockServiceWorker.js` regenerated by the `msw init` postinstall: the checked-in worker was still from msw 2.14.6 while the lockfile already has 2.15.0.

## Verification

- `pnpm install --frozen-lockfile` now succeeds (this is the exact command the e2e workflow runs).
- `pnpm build` succeeds.

Once merged, #659 and other dependabot PRs should pass e2e after a rebase/re-run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QVp8J7MyZKy4cJzgQaCKg3

---
_Generated by [Claude Code](https://claude.ai/code/session_01QVp8J7MyZKy4cJzgQaCKg3)_