### PR TITLE
ci: document and correct CodeQL Kotlin support gate to 2.4.9

### DIFF
--- a/.github/workflows/codeql-android.yml
+++ b/.github/workflows/codeql-android.yml
@@ -37,7 +37,11 @@ jobs:
         run: |
           set -euo pipefail
           kotlin_version="$(awk -F '"' '/^kotlin = / { print $2 }' android/gradle/libs.versions.toml)"
-          max_supported="2.4.0"
+          # CodeQL supports Kotlin versions below 2.4.10; newer versions fail the
+          # build with "Kotlin version X is too recent". Verify the supported range
+          # at https://codeql.github.com/docs/codeql-overview/supported-languages-and-frameworks/
+          # before raising this gate.
+          max_supported="2.4.9"
           if printf '%s\n%s\n' "${kotlin_version}" "${max_supported}" | sort -V -C; then
             echo "supported=true" >> "$GITHUB_OUTPUT"
           else


### PR DESCRIPTION
## Summary

Companion to #665 (Kotlin 2.4.0 → 2.4.10), mirroring the fix from tjorim/worktime#949.

CodeQL supports Kotlin versions **below 2.4.10** — newer versions fail the build with "Kotlin version X is too recent". The gate in `codeql-android.yml` already skips gracefully, but its ceiling was set to `2.4.0`, which would wrongly skip analysis for Kotlin 2.4.1–2.4.9 too.

- Raise `max_supported` from `2.4.0` to `2.4.9` so the whole actually-supported range gets analyzed
- Add a comment pointing at the CodeQL supported-languages docs so the range is verified before the gate is raised again

Note: unlike worktime, daynest's gate never broke on #665 — "Analyze (java-kotlin)" passed there because 2.4.10 already skipped. This is an accuracy/documentation improvement only.

## Verification

Gate logic checked with `sort -V`:

| Kotlin version | Result |
|---|---|
| 2.4.0 | analyze |
| 2.4.9 | analyze |
| 2.4.10 | skip |
| 2.5.0 | skip |

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y5pTGjjaxfGWa3zuALEtzT)_