### PR TITLE
fix(backend): resolve ruff 0.16 default rule violations

### DIFF
--- a/backend/app/api/dependencies/auth.py
+++ b/backend/app/api/dependencies/auth.py
@@ -2,7 +2,12 @@ from fastapi import Depends, HTTPException, Query, Request, status
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from sqlalchemy.orm import Session
 
-from app.core.oidc import OIDCTokenError, _extract_roles, decode_oidc_token, get_or_create_local_user
+from app.core.oidc import (
+    OIDCTokenError,
+    _extract_roles,
+    decode_oidc_token,
+    get_or_create_local_user,
+)
 from app.db.session import get_db
 from app.models.user import User
 

--- a/backend/app/api/dependencies/integration_auth.py
+++ b/backend/app/api/dependencies/integration_auth.py
@@ -1,7 +1,7 @@
 import threading
 from collections import defaultdict, deque
 from collections.abc import Callable
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 from hmac import digest
 
 import jwt
@@ -11,7 +11,12 @@ from sqlalchemy import select
 from sqlalchemy.orm import Session, joinedload
 
 from app.core.config import settings
-from app.core.oidc import OIDCTokenError, _extract_roles, decode_oidc_token, get_or_create_local_user
+from app.core.oidc import (
+    OIDCTokenError,
+    _extract_roles,
+    decode_oidc_token,
+    get_or_create_local_user,
+)
 from app.db.session import get_db
 from app.models.integration_client import IntegrationClient
 from app.models.user import User
@@ -43,7 +48,7 @@ def get_integration_client_by_token_hash(db: Session, token_hash: str) -> Integr
 
 def enforce_integration_rate_limit(client: IntegrationClient) -> None:
     with _request_log_lock:
-        now = datetime.now(timezone.utc)
+        now = datetime.now(UTC)
         cutoff = now - timedelta(minutes=1)
         bucket = _request_log[client.id]
         while bucket and bucket[0] < cutoff:

--- a/backend/app/api/routes/analytics.py
+++ b/backend/app/api/routes/analytics.py
@@ -1,4 +1,4 @@
-from datetime import date, timedelta
+from datetime import UTC, date, datetime, timedelta
 from typing import Literal
 
 from fastapi import APIRouter, Depends, Query
@@ -12,9 +12,14 @@ from app.repositories.analytics_repository import (
     get_medication_stats,
     get_planned_item_stats,
     get_routine_stats,
+)
+from app.repositories.analytics_repository import (
     get_scheduling_suggestions as build_scheduling_suggestions,
 )
-from app.schemas.analytics import AnalyticsSummaryResponse, SchedulingSuggestionsResponse
+from app.schemas.analytics import (
+    AnalyticsSummaryResponse,
+    SchedulingSuggestionsResponse,
+)
 
 router = APIRouter(prefix="/analytics", tags=["analytics"])
 
@@ -35,7 +40,7 @@ def get_analytics_summary(
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ) -> AnalyticsSummaryResponse:
-    end_date = date.today()
+    end_date = datetime.now(UTC).date()
     start_date = _period_start(end_date, period)
     return AnalyticsSummaryResponse(
         period=period,
@@ -53,6 +58,6 @@ def get_scheduling_suggestions(
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ) -> SchedulingSuggestionsResponse:
-    for_date = date.today()
+    for_date = datetime.now(UTC).date()
     suggestions = build_scheduling_suggestions(db, current_user.id, for_date)
     return SchedulingSuggestionsResponse(for_date=for_date, suggestions=suggestions)

--- a/backend/app/api/routes/auth.py
+++ b/backend/app/api/routes/auth.py
@@ -10,7 +10,12 @@ from app.api.dependencies.auth import bearer_scheme, get_current_user
 from app.core.config import settings
 from app.db.session import get_db
 from app.models.user import User
-from app.schemas.auth import OAuthSessionResponse, OidcDiscoveryConfig, UserMeResponse, UserUpdateRequest
+from app.schemas.auth import (
+    OAuthSessionResponse,
+    OidcDiscoveryConfig,
+    UserMeResponse,
+    UserUpdateRequest,
+)
 
 logger = logging.getLogger(__name__)
 

--- a/backend/app/api/routes/bulk.py
+++ b/backend/app/api/routes/bulk.py
@@ -6,7 +6,13 @@ from app.api.dependencies.auth import get_current_user
 from app.api.dependencies.events import get_event_bus
 from app.api.dependencies.today import get_today_service
 from app.models.user import User
-from app.schemas.bulk import BulkMutationItem, BulkMutationRequest, BulkMutationResponse, BulkMutationResult, MutationType
+from app.schemas.bulk import (
+    BulkMutationItem,
+    BulkMutationRequest,
+    BulkMutationResponse,
+    BulkMutationResult,
+    MutationType,
+)
 from app.services.event_bus import EventBus
 from app.services.today_service import TodayService
 

--- a/backend/app/api/routes/calendar.py
+++ b/backend/app/api/routes/calendar.py
@@ -1,4 +1,4 @@
-from datetime import date, datetime, timedelta, timezone
+from datetime import UTC, date, datetime, timedelta
 from secrets import token_urlsafe
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
@@ -58,8 +58,8 @@ def _build_ical(event_lines: list[str]) -> str:
 def _format_utc_ical_datetime(value: str) -> str:
     dt = datetime.fromisoformat(value)
     if dt.tzinfo is None:
-        dt = dt.replace(tzinfo=timezone.utc)
-    return dt.astimezone(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+        dt = dt.replace(tzinfo=UTC)
+    return dt.astimezone(UTC).strftime("%Y%m%dT%H%M%SZ")
 
 
 def _format_event(
@@ -206,7 +206,7 @@ def _build_planned_items_calendar(user: User, planned_items: list[PlannedItem]) 
     except (ZoneInfoNotFoundError, TypeError):
         tz = ZoneInfo("UTC")
 
-    dtstamp = datetime.now(timezone.utc)
+    dtstamp = datetime.now(UTC)
     for item in planned_items:
         event = Event()
         start = _planned_item_start(item, tz)
@@ -303,7 +303,7 @@ def export_ical(
 
     events = service.get_calendar_events(user_id=user.id, start_date=start_date, end_date=end_date)
     reminder_minutes = user.medication_reminder_minutes
-    dtstamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    dtstamp = datetime.now(UTC).strftime("%Y%m%dT%H%M%SZ")
 
     event_lines: list[str] = []
     for event in events:

--- a/backend/app/api/routes/health.py
+++ b/backend/app/api/routes/health.py
@@ -72,7 +72,7 @@ _jwks_readiness_lock = asyncio.Lock()
 
 
 async def _jwks_reachable() -> bool:
-    global _jwks_readiness_cache  # noqa: PLW0603
+    global _jwks_readiness_cache
     now = time.monotonic()
     if _jwks_readiness_cache is not None and now - _jwks_readiness_cache[0] < _JWKS_READINESS_CACHE_SECONDS:
         return _jwks_readiness_cache[1]

--- a/backend/app/api/routes/integrations/clients.py
+++ b/backend/app/api/routes/integrations/clients.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 from secrets import token_urlsafe
 
 import jwt
@@ -7,7 +7,10 @@ from sqlalchemy import select
 from sqlalchemy.orm import Session
 
 from app.api.dependencies.auth import get_current_user
-from app.api.dependencies.integration_auth import get_integration_client_by_token_hash, hash_integration_key
+from app.api.dependencies.integration_auth import (
+    get_integration_client_by_token_hash,
+    hash_integration_key,
+)
 from app.core.config import settings
 from app.db.session import get_db
 from app.models.integration_client import IntegrationClient
@@ -26,7 +29,7 @@ _INTEGRATION_JWT_ISSUER = "daynest-integration"
 
 
 def _create_integration_token(client: IntegrationClient) -> str:
-    now = datetime.now(timezone.utc)
+    now = datetime.now(UTC)
     payload = {
         "iss": _INTEGRATION_JWT_ISSUER,
         "sub": str(client.id),

--- a/backend/app/api/routes/integrations/home_assistant.py
+++ b/backend/app/api/routes/integrations/home_assistant.py
@@ -1,4 +1,4 @@
-from datetime import date, timedelta
+from datetime import UTC, date, datetime, timedelta
 from typing import Literal
 
 from fastapi import APIRouter, Depends, Query, Response
@@ -58,7 +58,7 @@ def home_assistant_summary(
     integration_user: User = Depends(require_integration_auth()),
     _: None = Depends(_set_ha_contract_header),
 ) -> dict[str, str | int | None]:
-    read_model = service.get_dashboard_read_model(user_id=integration_user.id, for_date=date.today())
+    read_model = service.get_dashboard_read_model(user_id=integration_user.id, for_date=datetime.now(UTC).date())
     return {
         "sensor_daynest_chores_due": read_model.due_today_count,
         "sensor_daynest_routines_open": read_model.routines_open_count,
@@ -75,7 +75,7 @@ def home_assistant_entities(
     integration_user: User = Depends(require_integration_auth()),
     _: None = Depends(_set_ha_contract_header),
 ) -> list[HomeAssistantEntity]:
-    read_model = service.get_dashboard_read_model(user_id=integration_user.id, for_date=date.today())
+    read_model = service.get_dashboard_read_model(user_id=integration_user.id, for_date=datetime.now(UTC).date())
     return [
         HomeAssistantEntity(
             entity_id="sensor.daynest_chores_due",
@@ -121,7 +121,7 @@ def home_assistant_dashboard(
     integration_user: User = Depends(require_integration_auth()),
     _: None = Depends(_set_ha_contract_header),
 ) -> DashboardReadModel:
-    return service.get_dashboard_read_model(user_id=integration_user.id, for_date=date.today())
+    return service.get_dashboard_read_model(user_id=integration_user.id, for_date=datetime.now(UTC).date())
 
 
 @router.get("/calendar", response_model=list[HACalendarEvent])
@@ -164,7 +164,7 @@ def home_assistant_snooze_task(
     integration_user: User = Depends(require_integration_auth()),
 ) -> HAActionResult:
     """Reschedule a chore instance N days into the future via Home Assistant automation."""
-    new_date = date.today() + timedelta(days=request.days)
+    new_date = datetime.now(UTC).date() + timedelta(days=request.days)
     service.reschedule_chore(user_id=integration_user.id, chore_instance_id=request.chore_instance_id, scheduled_date=new_date)
     return HAActionResult(success=True, detail=f"Task {request.chore_instance_id} rescheduled by {request.days} day(s)")
 

--- a/backend/app/api/routes/medications.py
+++ b/backend/app/api/routes/medications.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 
 from fastapi import APIRouter, Depends, HTTPException, Response, status
 from sqlalchemy.orm import Session
@@ -178,7 +178,7 @@ def medication_history(
     current_user: User = Depends(get_current_user),
 ) -> MedicationHistoryResponse:
     repository = TodayRepository(db)
-    history = repository.get_medication_history(user_id=current_user.id, before_date=datetime.now(timezone.utc).date())
+    history = repository.get_medication_history(user_id=current_user.id, before_date=datetime.now(UTC).date())
     return MedicationHistoryResponse(
         history=[
             MedicationHistoryItem(

--- a/backend/app/api/routes/shopping_lists.py
+++ b/backend/app/api/routes/shopping_lists.py
@@ -9,13 +9,13 @@ from app.db.session import get_db
 from app.models.user import User
 from app.repositories.shopping_list_repository import ShoppingListRepository
 from app.repositories.today_repository import TodayRepository
-from app.schemas.today import PlannedTodayItem
 from app.schemas.shopping_list import (
     ShoppingListCreateRequest,
     ShoppingListResponse,
     ShoppingListStatus,
     ShoppingListUpdateRequest,
 )
+from app.schemas.today import PlannedTodayItem
 from app.services.shopping_list_service import ShoppingListService
 from app.services.today_service import TodayService
 

--- a/backend/app/api/routes/today.py
+++ b/backend/app/api/routes/today.py
@@ -1,12 +1,15 @@
 import asyncio
 import json
-from datetime import date
+from datetime import UTC, date, datetime
 from typing import Literal, cast
 
 from fastapi import APIRouter, Depends, Query, Request, Response, status
 from sse_starlette import EventSourceResponse
 
-from app.api.dependencies.auth import get_current_user, get_current_user_from_query_token
+from app.api.dependencies.auth import (
+    get_current_user,
+    get_current_user_from_query_token,
+)
 from app.api.dependencies.events import get_event_bus
 from app.api.dependencies.today import get_today_service
 from app.models.user import User
@@ -33,7 +36,7 @@ def get_today(
     service: TodayService = Depends(get_today_service),
     current_user: User = Depends(get_current_user),
 ) -> TodayResponse:
-    return service.get_today(user_id=current_user.id, for_date=date.today())
+    return service.get_today(user_id=current_user.id, for_date=datetime.now(UTC).date())
 
 
 @router.get("/today/stream")

--- a/backend/app/api/routes/users.py
+++ b/backend/app/api/routes/users.py
@@ -12,7 +12,11 @@ from app.models.chore_template import ChoreTemplate
 from app.models.household_member import HouseholdMember
 from app.models.user import User
 from app.schemas.users import UserSettingsPatchRequest, UserSettingsResponse
-from app.services.export_import_service import build_user_export, import_user_export, user_export_to_csv
+from app.services.export_import_service import (
+    build_user_export,
+    import_user_export,
+    user_export_to_csv,
+)
 
 router = APIRouter(prefix="/users", tags=["users"])
 

--- a/backend/app/core/oidc.py
+++ b/backend/app/core/oidc.py
@@ -66,7 +66,7 @@ _jwks_cache: PyJWKSet | None = None
 
 async def _resolve_jwks_uri() -> str:
     """Return the JWKS URI, discovering it from the OIDC configuration document."""
-    global _jwks_uri_cache  # noqa: PLW0603
+    global _jwks_uri_cache
     if settings.oidc_jwks_uri:
         return settings.oidc_jwks_uri
     async with _jwks_uri_lock:
@@ -116,7 +116,7 @@ async def _fetch_jwks() -> PyJWKSet:
 
 
 async def _get_jwks(*, force_refresh: bool = False) -> PyJWKSet:
-    global _jwks_cache  # noqa: PLW0603
+    global _jwks_cache
     async with _jwks_lock:
         if _jwks_cache is None or force_refresh:
             _jwks_cache = await _fetch_jwks()
@@ -178,7 +178,7 @@ async def decode_oidc_token(token: str) -> dict[str, Any]:
     raise OIDCTokenError("Token validation failed after JWKS refresh")
 
 
-def get_or_create_local_user(subject: str, claims: dict[str, Any], db: Session) -> "Any":
+def get_or_create_local_user(subject: str, claims: dict[str, Any], db: Session) -> Any:
     """Return the local user for an OIDC subject, auto-provisioning when missing.
 
     Migration path: on first OIDC login, links existing local users by email so

--- a/backend/app/db/session.py
+++ b/backend/app/db/session.py
@@ -22,7 +22,7 @@ else:
 SessionLocal = sessionmaker(bind=engine, autoflush=False, autocommit=False, expire_on_commit=False)
 
 
-def get_db() -> Generator[Session, None, None]:
+def get_db() -> Generator[Session]:
     db = SessionLocal()
     try:
         yield db

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -2,7 +2,7 @@ import asyncio
 import contextlib
 import logging
 from contextlib import asynccontextmanager
-from datetime import date, datetime, timezone
+from datetime import UTC, date, datetime
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 from fastapi import FastAPI
@@ -13,26 +13,30 @@ from slowapi.errors import RateLimitExceeded
 from slowapi.middleware import SlowAPIMiddleware
 from starlette.applications import Starlette
 
+from app.api.dependencies.events import get_event_bus
+from app.api.routes.analytics import router as analytics_router
 from app.api.routes.auth import close_http_client as close_auth_http_client
 from app.api.routes.auth import router as auth_router
-from app.api.routes.analytics import router as analytics_router
 from app.api.routes.bulk import router as bulk_router
 from app.api.routes.calendar import router as calendar_router
-from app.api.routes.households import router as households_router
-from app.api.routes.search import router as search_router
-from app.api.routes.shopping_lists import router as shopping_lists_router
 from app.api.routes.health import router as system_router
+from app.api.routes.households import router as households_router
 from app.api.routes.integrations.clients import router as integration_clients_router
 from app.api.routes.integrations.home_assistant import router as home_assistant_router
-from app.api.routes.medications import router as medications_router
 from app.api.routes.meal_plans import router as meal_plans_router
+from app.api.routes.medications import router as medications_router
 from app.api.routes.push import router as push_router
+from app.api.routes.search import router as search_router
+from app.api.routes.shopping_lists import router as shopping_lists_router
 from app.api.routes.templates import router as templates_router
 from app.api.routes.today import router as today_router
 from app.api.routes.users import router as users_router
-from app.api.dependencies.events import get_event_bus
 from app.core.config import settings
-from app.core.observability import configure_error_tracking, configure_logging, observability_middleware
+from app.core.observability import (
+    configure_error_tracking,
+    configure_logging,
+    observability_middleware,
+)
 from app.db.session import SessionLocal
 from app.mcp_server import (
     MCP_PROMPT_NAMES,
@@ -45,6 +49,8 @@ from app.models.user import User
 from app.services.event_bus import EventBus
 from app.services.push_service import (
     close_http_client as close_push_http_client,
+)
+from app.services.push_service import (
     dispatch_medication_reminders,
     dispatch_missed_medications,
     dispatch_overdue_chores,
@@ -110,7 +116,7 @@ def _user_local_date(user: User, now: datetime) -> date:
     try:
         tz = ZoneInfo(user.timezone)
     except ZoneInfoNotFoundError:
-        tz = timezone.utc
+        tz = UTC
     return now.astimezone(tz).date()
 
 
@@ -121,7 +127,7 @@ def _publish_today_rollovers(
     *,
     now: datetime | None = None,
 ) -> None:
-    now = now or datetime.now(timezone.utc)
+    now = now or datetime.now(UTC)
     subscribed_user_ids = event_bus.subscribed_user_ids()
     for user_id in list(known_local_dates):
         if user_id not in subscribed_user_ids:

--- a/backend/app/mcp_server.py
+++ b/backend/app/mcp_server.py
@@ -6,7 +6,7 @@ import os
 import sys
 from collections.abc import Callable
 from contextlib import contextmanager
-from datetime import date, datetime, time
+from datetime import UTC, date, datetime, time
 from secrets import token_urlsafe
 from typing import Any, Literal, TypeVar, cast
 
@@ -31,13 +31,19 @@ from app.core.oidc import get_or_create_local_user
 from app.db.session import SessionLocal
 from app.models.integration_client import IntegrationClient
 from app.models.user import User
-from app.repositories.analytics_repository import get_scheduling_suggestions as build_scheduling_suggestions
+from app.repositories.analytics_repository import (
+    get_scheduling_suggestions as build_scheduling_suggestions,
+)
 from app.repositories.meal_plan_repository import MealPlanRepository
 from app.repositories.shopping_list_repository import ShoppingListRepository
 from app.repositories.today_repository import TodayRepository
 from app.schemas.meal_plan import MealSlotUpdate
 from app.schemas.shopping_list import ShoppingListCreateRequest, ShoppingListStatus
-from app.schemas.today import PlannedItemCreateRequest, PlannedItemModuleKey, PlannedItemUpdateRequest
+from app.schemas.today import (
+    PlannedItemCreateRequest,
+    PlannedItemModuleKey,
+    PlannedItemUpdateRequest,
+)
 from app.services.meal_plan_service import MealPlanService
 from app.services.shopping_list_service import ShoppingListService
 from app.services.today_service import TodayService
@@ -109,7 +115,7 @@ T = TypeVar("T")
 
 def _parse_date(value: str | None) -> date:
     if not value or value == "today":
-        return date.today()
+        return datetime.now(UTC).date()
     try:
         return date.fromisoformat(value)
     except ValueError:
@@ -121,7 +127,7 @@ def _parse_time(value: str | None) -> time | None:
         return None
     for fmt in ("%H:%M", "%H:%M:%S"):
         try:
-            return datetime.strptime(value, fmt).time()
+            return datetime.strptime(value, fmt).replace(tzinfo=UTC).time()
         except ValueError:
             continue
     raise ValueError(f"Invalid time '{value}'. Expected HH:MM or HH:MM:SS format.")
@@ -746,7 +752,7 @@ class DaynestMcpBackend:
                     }
                     for item in service.repository.get_medication_history(
                         user_id=user.id,
-                        before_date=datetime.now().date(),
+                        before_date=datetime.now(UTC).date(),
                         limit=capped_limit,
                         medication_plan_id=medication_plan_id,
                     )
@@ -762,7 +768,7 @@ class DaynestMcpBackend:
         return self._with_service(_operation)
 
     def get_scheduling_suggestions(self, for_date: str | None = None) -> dict[str, Any]:
-        parsed_date = _parse_date(for_date) if for_date else date.today()
+        parsed_date = _parse_date(for_date) if for_date else datetime.now(UTC).date()
         with self._session_scope() as db:
             user = self.resolve_user(db)
             suggestions = build_scheduling_suggestions(db, user.id, parsed_date)

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -4,9 +4,9 @@ from app.models.chore_template import ChoreTemplate
 from app.models.household import Household
 from app.models.household_member import HouseholdMember
 from app.models.integration_client import IntegrationClient
+from app.models.meal_plan import MealPlan, MealSlot
 from app.models.medication_dose_instance import MedicationDoseInstance
 from app.models.medication_plan import MedicationPlan
-from app.models.meal_plan import MealPlan, MealSlot
 from app.models.notification_sent import NotificationSent
 from app.models.planned_item import PlannedItem
 from app.models.push_subscription import PushSubscription
@@ -24,11 +24,11 @@ __all__ = [
     "Household",
     "HouseholdMember",
     "IntegrationClient",
+    "MealPlan",
+    "MealSlot",
     "MedicationDoseInstance",
     "MedicationDoseStatus",
     "MedicationPlan",
-    "MealPlan",
-    "MealSlot",
     "NotificationSent",
     "PlannedItem",
     "PushSubscription",

--- a/backend/app/models/chore_instance.py
+++ b/backend/app/models/chore_instance.py
@@ -39,7 +39,7 @@ class ChoreInstance(Base):
     skipped_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False, server_default=func.now())
 
-    user: Mapped["User"] = relationship(back_populates="chore_instances", foreign_keys="[ChoreInstance.user_id]")
-    assigned_to_user: Mapped["User | None"] = relationship(foreign_keys="[ChoreInstance.assigned_to]")
-    completed_by_user: Mapped["User | None"] = relationship(foreign_keys="[ChoreInstance.completed_by]")
-    chore_template: Mapped["ChoreTemplate"] = relationship(back_populates="chore_instances")
+    user: Mapped[User] = relationship(back_populates="chore_instances", foreign_keys="[ChoreInstance.user_id]")
+    assigned_to_user: Mapped[User | None] = relationship(foreign_keys="[ChoreInstance.assigned_to]")
+    completed_by_user: Mapped[User | None] = relationship(foreign_keys="[ChoreInstance.completed_by]")
+    chore_template: Mapped[ChoreTemplate] = relationship(back_populates="chore_instances")

--- a/backend/app/models/chore_template.py
+++ b/backend/app/models/chore_template.py
@@ -4,7 +4,17 @@ from datetime import date, datetime
 from typing import TYPE_CHECKING
 
 import sqlalchemy as sa
-from sqlalchemy import Boolean, Date, DateTime, ForeignKey, Integer, JSON, String, Text, func
+from sqlalchemy import (
+    JSON,
+    Boolean,
+    Date,
+    DateTime,
+    ForeignKey,
+    Integer,
+    String,
+    Text,
+    func,
+)
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from app.core.enums import Priority
@@ -41,9 +51,9 @@ class ChoreTemplate(Base):
     is_active: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True, server_default=sa.text("true"))
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False, server_default=func.now())
 
-    user: Mapped["User"] = relationship(back_populates="chore_templates")
-    household: Mapped["Household | None"] = relationship()
-    chore_instances: Mapped[list["ChoreInstance"]] = relationship(
+    user: Mapped[User] = relationship(back_populates="chore_templates")
+    household: Mapped[Household | None] = relationship()
+    chore_instances: Mapped[list[ChoreInstance]] = relationship(
         back_populates="chore_template",
         cascade="all, delete-orphan",
         passive_deletes=True,

--- a/backend/app/models/household.py
+++ b/backend/app/models/household.py
@@ -19,7 +19,7 @@ class Household(Base):
     name: Mapped[str] = mapped_column(String(255), nullable=False)
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False, server_default=func.now())
 
-    members: Mapped[list["HouseholdMember"]] = relationship(
+    members: Mapped[list[HouseholdMember]] = relationship(
         back_populates="household",
         cascade="all, delete-orphan",
     )

--- a/backend/app/models/household_member.py
+++ b/backend/app/models/household_member.py
@@ -37,5 +37,5 @@ class HouseholdMember(Base):
     )
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False, server_default=func.now())
 
-    household: Mapped["Household"] = relationship(back_populates="members")
-    user: Mapped["User"] = relationship(back_populates="household_members")
+    household: Mapped[Household] = relationship(back_populates="members")
+    user: Mapped[User] = relationship(back_populates="household_members")

--- a/backend/app/models/integration_client.py
+++ b/backend/app/models/integration_client.py
@@ -24,4 +24,4 @@ class IntegrationClient(Base):
     is_active: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True, server_default=sa.text("true"))
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False, server_default=func.now())
 
-    user: Mapped["User"] = relationship(back_populates="integration_clients")
+    user: Mapped[User] = relationship(back_populates="integration_clients")

--- a/backend/app/models/meal_plan.py
+++ b/backend/app/models/meal_plan.py
@@ -3,7 +3,17 @@ from __future__ import annotations
 from datetime import date, datetime
 from typing import TYPE_CHECKING
 
-from sqlalchemy import CheckConstraint, Date, DateTime, ForeignKey, Index, JSON, String, Text, func
+from sqlalchemy import (
+    JSON,
+    CheckConstraint,
+    Date,
+    DateTime,
+    ForeignKey,
+    Index,
+    String,
+    Text,
+    func,
+)
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from app.db.base import Base
@@ -23,8 +33,8 @@ class MealPlan(Base):
     notes: Mapped[str | None] = mapped_column(Text, nullable=True)
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False, server_default=func.now())
 
-    user: Mapped["User"] = relationship(back_populates="meal_plans")
-    slots: Mapped[list["MealSlot"]] = relationship(
+    user: Mapped[User] = relationship(back_populates="meal_plans")
+    slots: Mapped[list[MealSlot]] = relationship(
         back_populates="meal_plan",
         cascade="all, delete-orphan",
         order_by="MealSlot.slot_date, MealSlot.slot_type",
@@ -49,4 +59,4 @@ class MealSlot(Base):
         ForeignKey("planned_items.id", ondelete="SET NULL"), nullable=True, index=True
     )
 
-    meal_plan: Mapped["MealPlan"] = relationship(back_populates="slots")
+    meal_plan: Mapped[MealPlan] = relationship(back_populates="slots")

--- a/backend/app/models/medication_dose_instance.py
+++ b/backend/app/models/medication_dose_instance.py
@@ -3,7 +3,16 @@ from __future__ import annotations
 from datetime import date, datetime
 from typing import TYPE_CHECKING
 
-from sqlalchemy import Date, DateTime, Enum, ForeignKey, String, Text, UniqueConstraint, func
+from sqlalchemy import (
+    Date,
+    DateTime,
+    Enum,
+    ForeignKey,
+    String,
+    Text,
+    UniqueConstraint,
+    func,
+)
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from app.core.enums import MedicationDoseStatus
@@ -38,5 +47,5 @@ class MedicationDoseInstance(Base):
     missed_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False, server_default=func.now())
 
-    user: Mapped["User"] = relationship(back_populates="medication_dose_instances")
-    medication_plan: Mapped["MedicationPlan"] = relationship(back_populates="dose_instances")
+    user: Mapped[User] = relationship(back_populates="medication_dose_instances")
+    medication_plan: Mapped[MedicationPlan] = relationship(back_populates="dose_instances")

--- a/backend/app/models/medication_plan.py
+++ b/backend/app/models/medication_plan.py
@@ -4,7 +4,18 @@ from datetime import date, datetime, time
 from typing import TYPE_CHECKING
 
 import sqlalchemy as sa
-from sqlalchemy import Boolean, Date, DateTime, ForeignKey, Integer, String, Text, Time, UniqueConstraint, func
+from sqlalchemy import (
+    Boolean,
+    Date,
+    DateTime,
+    ForeignKey,
+    Integer,
+    String,
+    Text,
+    Time,
+    UniqueConstraint,
+    func,
+)
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from app.db.base import Base
@@ -28,8 +39,8 @@ class MedicationPlan(Base):
     is_active: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True, server_default=sa.text("true"))
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False, server_default=func.now())
 
-    user: Mapped["User"] = relationship(back_populates="medication_plans")
-    dose_instances: Mapped[list["MedicationDoseInstance"]] = relationship(
+    user: Mapped[User] = relationship(back_populates="medication_plans")
+    dose_instances: Mapped[list[MedicationDoseInstance]] = relationship(
         back_populates="medication_plan",
         cascade="all, delete-orphan",
     )

--- a/backend/app/models/planned_item.py
+++ b/backend/app/models/planned_item.py
@@ -5,7 +5,17 @@ from typing import TYPE_CHECKING
 from uuid import UUID
 
 import sqlalchemy as sa
-from sqlalchemy import Boolean, Date, DateTime, ForeignKey, JSON, String, Text, UniqueConstraint, func
+from sqlalchemy import (
+    JSON,
+    Boolean,
+    Date,
+    DateTime,
+    ForeignKey,
+    String,
+    Text,
+    UniqueConstraint,
+    func,
+)
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from app.core.enums import Priority
@@ -50,5 +60,5 @@ class PlannedItem(Base):
     completed_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False, server_default=func.now())
 
-    user: Mapped["User"] = relationship(back_populates="planned_items")
-    recurrence_series: Mapped["RecurrenceSeries | None"] = relationship(back_populates="planned_items")
+    user: Mapped[User] = relationship(back_populates="planned_items")
+    recurrence_series: Mapped[RecurrenceSeries | None] = relationship(back_populates="planned_items")

--- a/backend/app/models/push_subscription.py
+++ b/backend/app/models/push_subscription.py
@@ -26,4 +26,4 @@ class PushSubscription(Base):
     is_active: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True, server_default=sa.text("true"))
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False, server_default=func.now())
 
-    user: Mapped["User"] = relationship(back_populates="push_subscriptions")
+    user: Mapped[User] = relationship(back_populates="push_subscriptions")

--- a/backend/app/models/recurrence_series.py
+++ b/backend/app/models/recurrence_series.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING
 from uuid import UUID, uuid4
 
 import sqlalchemy as sa
-from sqlalchemy import Date, DateTime, ForeignKey, JSON, String, Text, func
+from sqlalchemy import JSON, Date, DateTime, ForeignKey, String, Text, func
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from app.core.enums import Priority
@@ -47,6 +47,6 @@ class RecurrenceSeries(Base):
     materialized_through: Mapped[date | None] = mapped_column(Date, nullable=True)
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False, server_default=func.now())
 
-    user: Mapped["User"] = relationship(back_populates="recurrence_series")
-    planned_items: Mapped[list["PlannedItem"]] = relationship(back_populates="recurrence_series")
-    auto_add_to_list: Mapped["ShoppingList | None"] = relationship()
+    user: Mapped[User] = relationship(back_populates="recurrence_series")
+    planned_items: Mapped[list[PlannedItem]] = relationship(back_populates="recurrence_series")
+    auto_add_to_list: Mapped[ShoppingList | None] = relationship()

--- a/backend/app/models/refresh_token.py
+++ b/backend/app/models/refresh_token.py
@@ -23,4 +23,4 @@ class RefreshToken(Base):
     revoked_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False, server_default=func.now())
 
-    user: Mapped["User"] = relationship(back_populates="refresh_tokens")
+    user: Mapped[User] = relationship(back_populates="refresh_tokens")

--- a/backend/app/models/routine_template.py
+++ b/backend/app/models/routine_template.py
@@ -4,7 +4,18 @@ from datetime import date, datetime, time
 from typing import TYPE_CHECKING
 
 import sqlalchemy as sa
-from sqlalchemy import Boolean, CheckConstraint, Date, DateTime, ForeignKey, Integer, String, Text, Time, func
+from sqlalchemy import (
+    Boolean,
+    CheckConstraint,
+    Date,
+    DateTime,
+    ForeignKey,
+    Integer,
+    String,
+    Text,
+    Time,
+    func,
+)
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from app.db.base import Base
@@ -32,8 +43,8 @@ class RoutineTemplate(Base):
     is_active: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True, server_default=sa.text("true"))
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False, server_default=func.now())
 
-    user: Mapped["User"] = relationship(back_populates="routine_templates")
-    task_instances: Mapped[list["TaskInstance"]] = relationship(
+    user: Mapped[User] = relationship(back_populates="routine_templates")
+    task_instances: Mapped[list[TaskInstance]] = relationship(
         back_populates="routine_template",
         cascade="all, delete-orphan",
         passive_deletes=True,

--- a/backend/app/models/shopping_list.py
+++ b/backend/app/models/shopping_list.py
@@ -30,4 +30,4 @@ class ShoppingList(Base):
         DateTime(timezone=True), nullable=False, server_default=func.now()
     )
 
-    user: Mapped["User"] = relationship(back_populates="shopping_lists")
+    user: Mapped[User] = relationship(back_populates="shopping_lists")

--- a/backend/app/models/task_instance.py
+++ b/backend/app/models/task_instance.py
@@ -37,5 +37,5 @@ class TaskInstance(Base):
     completed_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False, server_default=func.now())
 
-    user: Mapped["User"] = relationship(back_populates="task_instances")
-    routine_template: Mapped["RoutineTemplate"] = relationship(back_populates="task_instances")
+    user: Mapped[User] = relationship(back_populates="task_instances")
+    routine_template: Mapped[RoutineTemplate] = relationship(back_populates="task_instances")

--- a/backend/app/models/user.py
+++ b/backend/app/models/user.py
@@ -14,9 +14,9 @@ if TYPE_CHECKING:
     from app.models.chore_template import ChoreTemplate
     from app.models.household_member import HouseholdMember
     from app.models.integration_client import IntegrationClient
+    from app.models.meal_plan import MealPlan
     from app.models.medication_dose_instance import MedicationDoseInstance
     from app.models.medication_plan import MedicationPlan
-    from app.models.meal_plan import MealPlan
     from app.models.planned_item import PlannedItem
     from app.models.push_subscription import PushSubscription
     from app.models.recurrence_series import RecurrenceSeries
@@ -62,36 +62,36 @@ class User(Base):
     calendar_feed_token: Mapped[str | None] = mapped_column(String(64), nullable=True, unique=True, index=True)
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False, server_default=func.now())
 
-    routine_templates: Mapped[list["RoutineTemplate"]] = relationship(back_populates="user", cascade="all, delete-orphan")
-    task_instances: Mapped[list["TaskInstance"]] = relationship(back_populates="user", cascade="all, delete-orphan")
-    chore_templates: Mapped[list["ChoreTemplate"]] = relationship(back_populates="user", cascade="all, delete-orphan")
-    chore_instances: Mapped[list["ChoreInstance"]] = relationship(
+    routine_templates: Mapped[list[RoutineTemplate]] = relationship(back_populates="user", cascade="all, delete-orphan")
+    task_instances: Mapped[list[TaskInstance]] = relationship(back_populates="user", cascade="all, delete-orphan")
+    chore_templates: Mapped[list[ChoreTemplate]] = relationship(back_populates="user", cascade="all, delete-orphan")
+    chore_instances: Mapped[list[ChoreInstance]] = relationship(
         back_populates="user",
         cascade="all, delete-orphan",
         foreign_keys="[ChoreInstance.user_id]",
     )
-    medication_plans: Mapped[list["MedicationPlan"]] = relationship(back_populates="user", cascade="all, delete-orphan")
-    meal_plans: Mapped[list["MealPlan"]] = relationship(back_populates="user", cascade="all, delete-orphan")
-    medication_dose_instances: Mapped[list["MedicationDoseInstance"]] = relationship(
+    medication_plans: Mapped[list[MedicationPlan]] = relationship(back_populates="user", cascade="all, delete-orphan")
+    meal_plans: Mapped[list[MealPlan]] = relationship(back_populates="user", cascade="all, delete-orphan")
+    medication_dose_instances: Mapped[list[MedicationDoseInstance]] = relationship(
         back_populates="user",
         cascade="all, delete-orphan",
     )
-    planned_items: Mapped[list["PlannedItem"]] = relationship(back_populates="user", cascade="all, delete-orphan")
-    shopping_lists: Mapped[list["ShoppingList"]] = relationship(back_populates="user", cascade="all, delete-orphan")
-    recurrence_series: Mapped[list["RecurrenceSeries"]] = relationship(back_populates="user", cascade="all, delete-orphan")
-    integration_clients: Mapped[list["IntegrationClient"]] = relationship(
+    planned_items: Mapped[list[PlannedItem]] = relationship(back_populates="user", cascade="all, delete-orphan")
+    shopping_lists: Mapped[list[ShoppingList]] = relationship(back_populates="user", cascade="all, delete-orphan")
+    recurrence_series: Mapped[list[RecurrenceSeries]] = relationship(back_populates="user", cascade="all, delete-orphan")
+    integration_clients: Mapped[list[IntegrationClient]] = relationship(
         back_populates="user",
         cascade="all, delete-orphan",
     )
-    refresh_tokens: Mapped[list["RefreshToken"]] = relationship(
+    refresh_tokens: Mapped[list[RefreshToken]] = relationship(
         back_populates="user",
         cascade="all, delete-orphan",
     )
-    push_subscriptions: Mapped[list["PushSubscription"]] = relationship(
+    push_subscriptions: Mapped[list[PushSubscription]] = relationship(
         back_populates="user",
         cascade="all, delete-orphan",
     )
-    household_members: Mapped[list["HouseholdMember"]] = relationship(
+    household_members: Mapped[list[HouseholdMember]] = relationship(
         back_populates="user",
         cascade="all, delete-orphan",
     )

--- a/backend/app/repositories/analytics_repository.py
+++ b/backend/app/repositories/analytics_repository.py
@@ -1,6 +1,6 @@
 from collections import defaultdict
 from dataclasses import dataclass
-from datetime import date, datetime, timedelta
+from datetime import UTC, date, datetime, timedelta
 
 from sqlalchemy import case, func, select
 from sqlalchemy.orm import Session, joinedload
@@ -19,9 +19,9 @@ from app.schemas.analytics import (
     DailyCount,
     MedicationStats,
     PlannedItemStats,
-    SchedulingSuggestion,
     RoutineStats,
     RoutineStreak,
+    SchedulingSuggestion,
     SkippedChore,
 )
 
@@ -406,7 +406,7 @@ def get_scheduling_suggestions(db: Session, user_id: int, for_date: date) -> lis
         _, medication_plan_id = weakest_medication
         stats = medication_counts[medication_plan_id]
         current_time = stats.time_label or "09:00"
-        base_time = datetime.strptime(current_time, "%H:%M")
+        base_time = datetime.strptime(current_time, "%H:%M").replace(tzinfo=UTC)
         suggested_time = _shift_time_label(base_time, minutes=-30)
         suggestions.append(
             SchedulingSuggestion(

--- a/backend/app/repositories/refresh_token_repository.py
+++ b/backend/app/repositories/refresh_token_repository.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 
 from sqlalchemy import select, update
 from sqlalchemy.orm import Session
@@ -21,12 +21,12 @@ class RefreshTokenRepository:
         return self.db.scalar(select(RefreshToken).where(RefreshToken.jti == jti))
 
     def revoke(self, token: RefreshToken) -> None:
-        token.revoked_at = datetime.now(timezone.utc)
+        token.revoked_at = datetime.now(UTC)
         self.db.commit()
 
     def consume_if_unrevoked(self, jti: str) -> RefreshToken | None:
         """Atomically revoke token only if currently unrevoked. Returns token on success, None if already revoked or not found."""
-        now = datetime.now(timezone.utc)
+        now = datetime.now(UTC)
         stmt = (
             update(RefreshToken)
             .where(RefreshToken.jti == jti)
@@ -40,7 +40,7 @@ class RefreshTokenRepository:
         return token
 
     def revoke_all_for_user(self, user_id: int) -> None:
-        now = datetime.now(timezone.utc)
+        now = datetime.now(UTC)
         self.db.execute(
             update(RefreshToken)
             .where(RefreshToken.user_id == user_id)

--- a/backend/app/repositories/today_repository.py
+++ b/backend/app/repositories/today_repository.py
@@ -1,6 +1,6 @@
 import logging
 from collections.abc import Mapping, Sequence
-from datetime import date, datetime, time, timedelta, timezone
+from datetime import UTC, date, datetime, time, timedelta
 from uuid import UUID
 from zoneinfo import ZoneInfo
 
@@ -10,9 +10,7 @@ from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.orm import Session, joinedload
 
 from app.core.enums import ChoreStatus, MedicationDoseStatus, Priority, TaskStatus
-from app.models.user import User
 from app.models.chore_instance import ChoreInstance
-from app.models.shopping_list import ShoppingList
 from app.models.chore_template import ChoreTemplate
 from app.models.household_member import HouseholdMember
 from app.models.medication_dose_instance import MedicationDoseInstance
@@ -20,7 +18,9 @@ from app.models.medication_plan import MedicationPlan
 from app.models.planned_item import PlannedItem
 from app.models.recurrence_series import RecurrenceSeries
 from app.models.routine_template import RoutineTemplate
+from app.models.shopping_list import ShoppingList
 from app.models.task_instance import TaskInstance
+from app.models.user import User
 
 logger = logging.getLogger(__name__)
 
@@ -172,7 +172,7 @@ class TodayRepository:
 
             tz = ZoneInfo(user_timezone)
             while cursor <= through_date:
-                scheduled_at = datetime.combine(cursor, template.schedule_time, tzinfo=tz).astimezone(timezone.utc)
+                scheduled_at = datetime.combine(cursor, template.schedule_time, tzinfo=tz).astimezone(UTC)
                 new_instances.append(
                     MedicationDoseInstance(
                         user_id=user_id,
@@ -287,7 +287,7 @@ class TodayRepository:
                     rrule_generated = True
                     for dt in occurrences:
                         cursor = dt.date()
-                        due_at = datetime.combine(cursor, template.due_time, tzinfo=timezone.utc) if template.due_time else None
+                        due_at = datetime.combine(cursor, template.due_time, tzinfo=UTC) if template.due_time else None
                         rows.append({
                             "user_id": user_id,
                             "routine_template_id": template.id,
@@ -301,7 +301,7 @@ class TodayRepository:
                 step = max(template.every_n_days, 1)
                 cursor = template.start_date if last is None else date.fromordinal(last.toordinal() + step)
                 while cursor <= through_date:
-                    due_at = datetime.combine(cursor, template.due_time, tzinfo=timezone.utc) if template.due_time else None
+                    due_at = datetime.combine(cursor, template.due_time, tzinfo=UTC) if template.due_time else None
                     rows.append({
                         "user_id": user_id,
                         "routine_template_id": template.id,
@@ -912,4 +912,4 @@ class TodayRepository:
         self.db.commit()
 
     def utcnow(self) -> datetime:
-        return datetime.now(timezone.utc)
+        return datetime.now(UTC)

--- a/backend/app/services/export_import_service.py
+++ b/backend/app/services/export_import_service.py
@@ -5,9 +5,9 @@ import enum
 import json
 import logging
 from collections.abc import Iterable, Mapping
-from datetime import date, datetime, time, timezone
+from datetime import UTC, date, datetime, time
 from io import StringIO
-from typing import Any, NoReturn, TypeVar
+from typing import Any, NoReturn
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 from fastapi import HTTPException, status
@@ -26,8 +26,6 @@ from app.models.task_instance import TaskInstance
 from app.models.user import User
 
 logger = logging.getLogger(__name__)
-
-_E = TypeVar("_E", bound=enum.Enum)
 
 EXPORT_VERSION = 1
 
@@ -127,7 +125,7 @@ _PLANNED_ITEM_FIELDS = (
 def build_user_export(db: Session, user: User) -> dict[str, Any]:
     return {
         "version": EXPORT_VERSION,
-        "exported_at": datetime.now(timezone.utc).isoformat(),
+        "exported_at": datetime.now(UTC).isoformat(),
         "user_settings": _fields_to_dict(user, _USER_SETTING_FIELDS),
         "routine_templates": _export_rows(
             db.query(RoutineTemplate).filter(RoutineTemplate.user_id == user.id).order_by(RoutineTemplate.id).all(),
@@ -468,7 +466,7 @@ def _bool(value: Any, field: str) -> bool:
     return value
 
 
-def _enum(cls: type[_E], value: Any, field: str) -> _E:
+def _enum[E: enum.Enum](cls: type[E], value: Any, field: str) -> E:
     s = _str(value, field)
     try:
         return cls(s)  # type: ignore[call-arg]

--- a/backend/app/services/push_service.py
+++ b/backend/app/services/push_service.py
@@ -1,6 +1,6 @@
 import json
 import logging
-from datetime import datetime, time, timedelta, timezone
+from datetime import UTC, datetime, time, timedelta
 from typing import Any
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
@@ -43,7 +43,7 @@ def _user_can_receive_push(now: datetime, user: User) -> bool:
     try:
         tz = ZoneInfo(user.timezone)
     except ZoneInfoNotFoundError:
-        tz = timezone.utc
+        tz = UTC
     local_time = now.astimezone(tz).time()
     return not _is_quiet_time(local_time, user.quiet_hours_start, user.quiet_hours_end)
 
@@ -162,7 +162,7 @@ def _notification_sent_exists(user_id_column, notification_type: str, item_id_co
 
 
 def pending_push_user_ids(db: Session, *, now: datetime | None = None) -> list[int]:
-    now = now or datetime.now(timezone.utc)
+    now = now or datetime.now(UTC)
     pending_user_ids: set[int] = set()
 
     pending_user_ids.update(
@@ -209,7 +209,7 @@ def pending_push_user_ids(db: Session, *, now: datetime | None = None) -> list[i
 
 
 def dispatch_overdue_chores(db: Session, user_id: int, *, now: datetime | None = None) -> int:
-    now = now or datetime.now(timezone.utc)
+    now = now or datetime.now(UTC)
     user = db.scalar(select(User).where(User.id == user_id).where(User.is_active.is_(True)))
     if user is None or not user.push_overdue_chores_enabled or not _user_can_receive_push(now, user):
         return 0
@@ -239,7 +239,7 @@ def dispatch_overdue_chores(db: Session, user_id: int, *, now: datetime | None =
 
 
 def dispatch_medication_reminders(db: Session, user_id: int, *, now: datetime | None = None) -> int:
-    now = now or datetime.now(timezone.utc)
+    now = now or datetime.now(UTC)
     user = db.scalar(select(User).where(User.id == user_id).where(User.is_active.is_(True)))
     if user is None or not user.push_medication_reminders_enabled or not _user_can_receive_push(now, user):
         return 0
@@ -271,7 +271,7 @@ def dispatch_medication_reminders(db: Session, user_id: int, *, now: datetime | 
 
 
 def dispatch_missed_medications(db: Session, user_id: int, *, now: datetime | None = None) -> int:
-    now = now or datetime.now(timezone.utc)
+    now = now or datetime.now(UTC)
     user = db.scalar(select(User).where(User.id == user_id).where(User.is_active.is_(True)))
     if user is None or not user.push_missed_medications_enabled or not _user_can_receive_push(now, user):
         return 0

--- a/backend/app/services/today_service.py
+++ b/backend/app/services/today_service.py
@@ -2,7 +2,7 @@ import logging
 from calendar import monthrange
 from collections import defaultdict
 from dataclasses import dataclass
-from datetime import date, datetime, time, timedelta, timezone
+from datetime import UTC, date, datetime, time, timedelta
 from typing import Literal, cast
 from uuid import UUID
 from zoneinfo import ZoneInfo
@@ -418,7 +418,7 @@ class TodayService:
         items.sort(
             key=lambda value: (
                 value.scheduled_at is None,
-                value.scheduled_at or datetime.min.replace(tzinfo=timezone.utc),
+                value.scheduled_at or datetime.min.replace(tzinfo=UTC),
                 _PRIORITY_RANK.get(value.priority, 2),
                 value.item_type,
                 value.item_id,
@@ -1292,7 +1292,7 @@ class TodayService:
                 raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail="Medication dose can only be taken from scheduled or missed")
             if taken_at is not None:
                 # Ensure timezone-aware for comparison
-                ta = taken_at if taken_at.tzinfo is not None else taken_at.replace(tzinfo=timezone.utc)
+                ta = taken_at if taken_at.tzinfo is not None else taken_at.replace(tzinfo=UTC)
                 if ta > now:
                     raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_CONTENT, detail="taken_at must not be in the future")
                 resolved_taken_at = ta

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -18,7 +18,7 @@ async def _skip_lifespan(app):
 
 
 @pytest.fixture()
-def db_session() -> Generator[Session, None, None]:
+def db_session() -> Generator[Session]:
     engine = create_engine(
         "sqlite+pysqlite:///:memory:",
         connect_args={"check_same_thread": False},
@@ -37,8 +37,8 @@ def db_session() -> Generator[Session, None, None]:
 
 
 @pytest.fixture()
-def client(db_session: Session) -> Generator[TestClient, None, None]:
-    def override_get_db() -> Generator[Session, None, None]:
+def client(db_session: Session) -> Generator[TestClient]:
+    def override_get_db() -> Generator[Session]:
         yield db_session
 
     app.dependency_overrides[get_db] = override_get_db

--- a/backend/tests/test_analytics_api.py
+++ b/backend/tests/test_analytics_api.py
@@ -1,4 +1,4 @@
-from datetime import date, datetime, time, timedelta, timezone
+from datetime import UTC, date, datetime, time, timedelta
 
 from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
@@ -49,8 +49,8 @@ def _add_chore(
             title=template.name,
             scheduled_date=scheduled_date,
             status=status,
-            completed_at=datetime.now(timezone.utc) if status == ChoreStatus.completed else None,
-            skipped_at=datetime.now(timezone.utc) if status == ChoreStatus.skipped else None,
+            completed_at=datetime.now(UTC) if status == ChoreStatus.completed else None,
+            skipped_at=datetime.now(UTC) if status == ChoreStatus.skipped else None,
         )
     )
 
@@ -62,7 +62,7 @@ def _add_medication_dose(
     scheduled_date: date,
     status: MedicationDoseStatus,
 ) -> None:
-    scheduled_at = datetime.combine(scheduled_date, plan.schedule_time, tzinfo=timezone.utc)
+    scheduled_at = datetime.combine(scheduled_date, plan.schedule_time, tzinfo=UTC)
     db_session.add(
         MedicationDoseInstance(
             user_id=user.id,
@@ -72,9 +72,9 @@ def _add_medication_dose(
             scheduled_date=scheduled_date,
             scheduled_at=scheduled_at,
             status=status,
-            taken_at=datetime.now(timezone.utc) if status == MedicationDoseStatus.taken else None,
-            skipped_at=datetime.now(timezone.utc) if status == MedicationDoseStatus.skipped else None,
-            missed_at=datetime.now(timezone.utc) if status == MedicationDoseStatus.missed else None,
+            taken_at=datetime.now(UTC) if status == MedicationDoseStatus.taken else None,
+            skipped_at=datetime.now(UTC) if status == MedicationDoseStatus.skipped else None,
+            missed_at=datetime.now(UTC) if status == MedicationDoseStatus.missed else None,
         )
     )
 
@@ -98,7 +98,7 @@ def test_analytics_summary_rejects_unknown_period(client: TestClient, db_session
 def test_analytics_summary_aggregates_user_history(client: TestClient, db_session: Session) -> None:
     user = _create_user(db_session, email="analytics@example.com")
     other_user = _create_user(db_session, email="analytics-other@example.com")
-    today = date.today()
+    today = datetime.now(UTC).date()
 
     chore_template = ChoreTemplate(
         user_id=user.id,
@@ -202,7 +202,7 @@ def test_analytics_summary_aggregates_user_history(client: TestClient, db_sessio
 
 def test_analytics_streaks_use_bounded_recent_history(client: TestClient, db_session: Session) -> None:
     user = _create_user(db_session, email="analytics-streak-window@example.com")
-    today = date.today()
+    today = datetime.now(UTC).date()
 
     chore_template = ChoreTemplate(
         user_id=user.id,
@@ -249,14 +249,14 @@ def _add_task(
             title=template.name,
             scheduled_date=scheduled_date,
             status=status,
-            completed_at=datetime.now(timezone.utc) if status == TaskStatus.completed else None,
+            completed_at=datetime.now(UTC) if status == TaskStatus.completed else None,
         )
     )
 
 
 def test_analytics_includes_routine_streaks(client: TestClient, db_session: Session) -> None:
     user = _create_user(db_session, email="analytics-routine-streaks@example.com")
-    today = date.today()
+    today = datetime.now(UTC).date()
 
     routine = RoutineTemplate(
         user_id=user.id,
@@ -297,7 +297,7 @@ def test_analytics_includes_routine_streaks(client: TestClient, db_session: Sess
 def test_analytics_routine_streaks_do_not_leak_across_users(client: TestClient, db_session: Session) -> None:
     owner = _create_user(db_session, email="analytics-routine-owner@example.com")
     other = _create_user(db_session, email="analytics-routine-other@example.com")
-    today = date.today()
+    today = datetime.now(UTC).date()
 
     routine = RoutineTemplate(
         user_id=owner.id,
@@ -341,7 +341,7 @@ def test_analytics_summary_response_includes_routines_key(client: TestClient, db
 
 def test_analytics_suggestions_include_chore_medication_and_load_balancing(client: TestClient, db_session: Session) -> None:
     user = _create_user(db_session, email="analytics-suggestions@example.com")
-    today = date.today()
+    today = datetime.now(UTC).date()
 
     chore_template = ChoreTemplate(
         user_id=user.id,
@@ -402,7 +402,7 @@ def test_analytics_suggestions_include_chore_medication_and_load_balancing(clien
 
 def test_load_balancing_suggestions_ignore_completed_items(client: TestClient, db_session: Session) -> None:
     user = _create_user(db_session, email="analytics-load-completed@example.com")
-    today = date.today()
+    today = datetime.now(UTC).date()
     chore_templates = [
         ChoreTemplate(
             user_id=user.id,
@@ -436,7 +436,7 @@ def test_load_balancing_suggestions_ignore_completed_items(client: TestClient, d
 
 def test_load_balancing_suggestions_consider_empty_target_days(client: TestClient, db_session: Session) -> None:
     user = _create_user(db_session, email="analytics-load-empty-days@example.com")
-    today = date.today()
+    today = datetime.now(UTC).date()
     overloaded_day = today + timedelta(days=1)
     db_session.add_all(
         [
@@ -462,7 +462,7 @@ def test_load_balancing_suggestions_consider_empty_target_days(client: TestClien
 
 def test_load_balancing_move_count_does_not_overload_target(client: TestClient, db_session: Session) -> None:
     user = _create_user(db_session, email="analytics-load-move-count@example.com")
-    today = date.today()
+    today = datetime.now(UTC).date()
     overloaded_day = today
     db_session.add_all(
         [
@@ -498,7 +498,7 @@ def test_load_balancing_move_count_does_not_overload_target(client: TestClient, 
 
 def test_medication_suggestion_uses_plan_schedule_time(client: TestClient, db_session: Session) -> None:
     user = _create_user(db_session, email="analytics-medication-local-time@example.com")
-    today = date.today()
+    today = datetime.now(UTC).date()
     medication_plan = MedicationPlan(
         user_id=user.id,
         name="Vitamin B",
@@ -528,7 +528,7 @@ def test_medication_suggestion_uses_plan_schedule_time(client: TestClient, db_se
                 name=medication_plan.name,
                 instructions=medication_plan.instructions,
                 scheduled_date=scheduled_date,
-                scheduled_at=datetime.combine(scheduled_date, time(7, 0), tzinfo=timezone.utc),
+                scheduled_at=datetime.combine(scheduled_date, time(7, 0), tzinfo=UTC),
                 status=status,
             )
         )

--- a/backend/tests/test_auth_routes.py
+++ b/backend/tests/test_auth_routes.py
@@ -11,13 +11,15 @@ from fastapi import HTTPException, Request
 from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
 
-from app.api.dependencies.auth import get_current_user, get_current_user_from_query_token
+from app.api.dependencies.auth import (
+    get_current_user,
+    get_current_user_from_query_token,
+)
 from app.api.routes import auth as auth_routes
 from app.core.config import settings
 from app.core.oidc import get_or_create_local_user
 from app.main import app
 from app.models.user import User
-
 
 # ---------------------------------------------------------------------------
 # Helpers

--- a/backend/tests/test_export_import.py
+++ b/backend/tests/test_export_import.py
@@ -1,4 +1,4 @@
-from datetime import date, datetime, time, timezone
+from datetime import UTC, date, datetime, time
 
 from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
@@ -87,9 +87,9 @@ def _seed_export_data(db_session: Session, user: User) -> None:
                 routine_template_id=routine.id,
                 title=routine.name,
                 scheduled_date=date(2026, 5, 4),
-                due_at=datetime(2026, 5, 4, 8, 0, tzinfo=timezone.utc),
+                due_at=datetime(2026, 5, 4, 8, 0, tzinfo=UTC),
                 status=TaskStatus.completed,
-                completed_at=datetime(2026, 5, 4, 8, 10, tzinfo=timezone.utc),
+                completed_at=datetime(2026, 5, 4, 8, 10, tzinfo=UTC),
             ),
             ChoreInstance(
                 user_id=user.id,
@@ -97,7 +97,7 @@ def _seed_export_data(db_session: Session, user: User) -> None:
                 title=chore.name,
                 scheduled_date=date(2026, 5, 2),
                 status=ChoreStatus.skipped,
-                skipped_at=datetime(2026, 5, 2, 11, 0, tzinfo=timezone.utc),
+                skipped_at=datetime(2026, 5, 2, 11, 0, tzinfo=UTC),
             ),
             MedicationDoseInstance(
                 user_id=user.id,
@@ -105,9 +105,9 @@ def _seed_export_data(db_session: Session, user: User) -> None:
                 name=medication.name,
                 instructions=medication.instructions,
                 scheduled_date=date(2026, 5, 1),
-                scheduled_at=datetime(2026, 5, 1, 9, 30, tzinfo=timezone.utc),
+                scheduled_at=datetime(2026, 5, 1, 9, 30, tzinfo=UTC),
                 status=MedicationDoseStatus.taken,
-                taken_at=datetime(2026, 5, 1, 9, 35, tzinfo=timezone.utc),
+                taken_at=datetime(2026, 5, 1, 9, 35, tzinfo=UTC),
             ),
             PlannedItem(
                 user_id=user.id,
@@ -121,7 +121,7 @@ def _seed_export_data(db_session: Session, user: User) -> None:
                 priority=Priority.urgent,
                 tags=["food"],
                 is_done=True,
-                completed_at=datetime(2026, 5, 3, 16, 0, tzinfo=timezone.utc),
+                completed_at=datetime(2026, 5, 3, 16, 0, tzinfo=UTC),
             ),
         ]
     )

--- a/backend/tests/test_households.py
+++ b/backend/tests/test_households.py
@@ -1,16 +1,16 @@
 """Tests for household/shared mode API endpoints."""
 
-from datetime import date
+from datetime import UTC, datetime
 
 import pytest
 from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
 
 from app.api.dependencies.auth import get_current_user
+from app.core.enums import HouseholdMemberRole
 from app.main import app
 from app.models.chore_instance import ChoreInstance
 from app.models.user import User
-from app.core.enums import HouseholdMemberRole
 
 
 def _create_user(db_session: Session, email: str) -> User:
@@ -242,7 +242,7 @@ def test_create_household_chore_template(client: TestClient, db_session: Session
         "/api/templates/chores",
         json={
             "name": "Vacuum Living Room",
-            "start_date": str(date.today()),
+            "start_date": str(datetime.now(UTC).date()),
             "every_n_days": 7,
             "household_id": household_id,
         },
@@ -265,7 +265,7 @@ def test_create_household_chore_template_non_member_forbidden(client: TestClient
         "/api/templates/chores",
         json={
             "name": "Vacuum",
-            "start_date": str(date.today()),
+            "start_date": str(datetime.now(UTC).date()),
             "every_n_days": 7,
             "household_id": household_id,
         },
@@ -287,7 +287,7 @@ def test_member_can_see_household_chore_templates(client: TestClient, db_session
         "/api/templates/chores",
         json={
             "name": "Shared Chore",
-            "start_date": str(date.today()),
+            "start_date": str(datetime.now(UTC).date()),
             "every_n_days": 1,
             "household_id": household_id,
         },
@@ -313,7 +313,7 @@ def test_member_cannot_update_household_chore_template(client: TestClient, db_se
         "/api/templates/chores",
         json={
             "name": "Shared Chore",
-            "start_date": str(date.today()),
+            "start_date": str(datetime.now(UTC).date()),
             "every_n_days": 1,
             "household_id": household_id,
         },
@@ -324,7 +324,7 @@ def test_member_cannot_update_household_chore_template(client: TestClient, db_se
         f"/api/templates/chores/{created_template['id']}",
         json={
             "name": "Renamed Chore",
-            "start_date": str(date.today()),
+            "start_date": str(datetime.now(UTC).date()),
             "every_n_days": 1,
             "household_id": household_id,
         },
@@ -345,7 +345,7 @@ def test_member_cannot_delete_household_chore_template(client: TestClient, db_se
         "/api/templates/chores",
         json={
             "name": "Shared Chore",
-            "start_date": str(date.today()),
+            "start_date": str(datetime.now(UTC).date()),
             "every_n_days": 1,
             "household_id": household_id,
         },
@@ -374,7 +374,7 @@ def test_assign_chore(client: TestClient, db_session: Session) -> None:
         "/api/templates/chores",
         json={
             "name": "Wash Dishes",
-            "start_date": str(date.today()),
+            "start_date": str(datetime.now(UTC).date()),
             "every_n_days": 1,
             "household_id": household_id,
         },
@@ -411,7 +411,7 @@ def test_assign_household_chore_rejects_non_member(client: TestClient, db_sessio
         "/api/templates/chores",
         json={
             "name": "Wash Dishes",
-            "start_date": str(date.today()),
+            "start_date": str(datetime.now(UTC).date()),
             "every_n_days": 1,
             "household_id": household_id,
         },
@@ -436,7 +436,7 @@ def test_assign_personal_chore_rejects_other_user(client: TestClient, db_session
         "/api/templates/chores",
         json={
             "name": "Personal Chore",
-            "start_date": str(date.today()),
+            "start_date": str(datetime.now(UTC).date()),
             "every_n_days": 1,
         },
     )
@@ -464,7 +464,7 @@ def test_complete_chore_sets_completed_by(client: TestClient, db_session: Sessio
         "/api/templates/chores",
         json={
             "name": "Clean Kitchen",
-            "start_date": str(date.today()),
+            "start_date": str(datetime.now(UTC).date()),
             "every_n_days": 1,
             "household_id": household_id,
         },

--- a/backend/tests/test_integration_adapters.py
+++ b/backend/tests/test_integration_adapters.py
@@ -1,4 +1,4 @@
-from datetime import date, time, timedelta
+from datetime import UTC, date, datetime, time, timedelta
 
 from fastapi.testclient import TestClient
 from pytest import MonkeyPatch
@@ -6,20 +6,19 @@ from sqlalchemy.orm import Session
 
 from app.api.dependencies.auth import get_current_user
 from app.api.dependencies.integration_auth import hash_integration_key
+from app.core.enums import ChoreStatus
 from app.main import app
+from app.models.chore_instance import ChoreInstance
+from app.models.chore_template import ChoreTemplate
+from app.models.integration_client import IntegrationClient
+from app.models.medication_plan import MedicationPlan
+from app.models.user import User
 from app.schemas.integration_contracts import (
     HOME_ASSISTANT_ADAPTER,
     HOME_ASSISTANT_CONTRACT_VERSION,
     INTEGRATION_CONTRACT_HEADER,
     integration_contract_header,
 )
-from app.core.enums import ChoreStatus
-from app.models.chore_instance import ChoreInstance
-from app.models.chore_template import ChoreTemplate
-from app.models.integration_client import IntegrationClient
-from app.models.medication_plan import MedicationPlan
-from app.models.user import User
-
 
 HOME_ASSISTANT_ENDPOINTS = ("summary", "entities", "dashboard")
 FIXED_TODAY = date(2026, 1, 15)
@@ -35,14 +34,14 @@ def _clear_auth() -> None:
     app.dependency_overrides.pop(get_current_user, None)
 
 
-class FrozenDate(date):
+class FrozenDatetime(datetime):
     @classmethod
-    def today(cls) -> date:
-        return FIXED_TODAY
+    def now(cls, tz=None) -> datetime:
+        return datetime.combine(FIXED_TODAY, time(0, 0), tzinfo=tz)
 
 
 def _freeze_route_today(monkeypatch: MonkeyPatch, route_module: str) -> None:
-    monkeypatch.setattr(f"{route_module}.date", FrozenDate)
+    monkeypatch.setattr(f"{route_module}.datetime", FrozenDatetime)
 
 
 def _create_user(db_session: Session, email: str) -> User:
@@ -309,7 +308,7 @@ def test_home_assistant_mark_medication_taken(
     db_session: Session,
     monkeypatch: MonkeyPatch,
 ) -> None:
-    from datetime import datetime, timezone
+    from datetime import datetime
 
     from app.core.enums import MedicationDoseStatus
     from app.models.medication_dose_instance import MedicationDoseInstance
@@ -325,7 +324,7 @@ def test_home_assistant_mark_medication_taken(
     assert plan is not None
 
     # Create a dose instance in scheduled status directly (avoids missed-marking by dashboard)
-    future_scheduled_at = datetime(2026, 1, 15, 12, 0, tzinfo=timezone.utc)
+    future_scheduled_at = datetime(2026, 1, 15, 12, 0, tzinfo=UTC)
     dose = MedicationDoseInstance(
         user_id=user.id,
         medication_plan_id=plan.id,

--- a/backend/tests/test_integration_contracts.py
+++ b/backend/tests/test_integration_contracts.py
@@ -1,20 +1,20 @@
-from datetime import date
+from datetime import UTC, datetime
 
 from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
 
 from app.api.dependencies.integration_auth import hash_integration_key
+from app.core.enums import ChoreStatus
+from app.models.chore_instance import ChoreInstance
+from app.models.chore_template import ChoreTemplate
+from app.models.integration_client import IntegrationClient
+from app.models.user import User
 from app.schemas.integration_contracts import (
     HOME_ASSISTANT_ADAPTER,
     HOME_ASSISTANT_CONTRACT_VERSION,
     INTEGRATION_CONTRACT_HEADER,
     integration_contract_header,
 )
-from app.core.enums import ChoreStatus
-from app.models.chore_instance import ChoreInstance
-from app.models.chore_template import ChoreTemplate
-from app.models.integration_client import IntegrationClient
-from app.models.user import User
 
 
 def _create_user(db_session: Session, email: str) -> User:
@@ -43,7 +43,7 @@ def _setup_contract_chore(db_session: Session, user: User, name: str) -> None:
         user_id=user.id,
         name=name,
         description=None,
-        start_date=date.today(),
+        start_date=datetime.now(UTC).date(),
         every_n_days=1,
         is_active=True,
     )
@@ -56,7 +56,7 @@ def _setup_contract_chore(db_session: Session, user: User, name: str) -> None:
             user_id=user.id,
             chore_template_id=template.id,
             title=name,
-            scheduled_date=date.today(),
+            scheduled_date=datetime.now(UTC).date(),
             status=ChoreStatus.pending,
         )
     )
@@ -141,7 +141,7 @@ def test_home_assistant_contract_calendar_shape(client: TestClient, db_session: 
     _setup_contract_chore(db_session, user, "Calendar Contract Chore")
 
     key = _create_integration_key(db_session, user.id)
-    today = date.today()
+    today = datetime.now(UTC).date()
     response = client.get(
         "/api/integrations/home-assistant/calendar",
         params={"start": today.isoformat(), "end": today.isoformat()},

--- a/backend/tests/test_mcp_server.py
+++ b/backend/tests/test_mcp_server.py
@@ -1,11 +1,10 @@
 import asyncio
+from datetime import UTC, datetime, time, timedelta
 from hashlib import sha256
-from datetime import datetime, time, timedelta, timezone
 
 import pytest
 from fastapi.testclient import TestClient
 from fastmcp.server.auth import AccessToken
-
 from sqlalchemy.orm import Session, sessionmaker
 
 from app.api.dependencies.integration_auth import hash_integration_key
@@ -100,7 +99,7 @@ async def test_mcp_capability_tool_names_match_registered_tools(db_session: Sess
 
 
 def test_mcp_backend_resolves_single_active_user_and_returns_today(db_session: Session) -> None:
-    utc_today = datetime.now(timezone.utc).date()
+    utc_today = datetime.now(UTC).date()
     user = _create_user(db_session, "mcp@example.com")
     db_session.add(
         RoutineTemplate(
@@ -189,7 +188,7 @@ def test_mcp_backend_can_create_and_update_planned_items(db_session: Session) ->
 
 
 def test_mcp_backend_can_list_medications(db_session: Session) -> None:
-    utc_today = datetime.now(timezone.utc).date()
+    utc_today = datetime.now(UTC).date()
     user = _create_user(db_session, "med-list@example.com")
     db_session.add(
         MedicationPlan(
@@ -213,7 +212,7 @@ def test_mcp_backend_can_list_medications(db_session: Session) -> None:
 
 
 def test_mcp_backend_can_get_medication_history(db_session: Session) -> None:
-    utc_today = datetime.now(timezone.utc).date()
+    utc_today = datetime.now(UTC).date()
     user = _create_user(db_session, "med-history@example.com")
     plan = MedicationPlan(
         user_id=user.id,
@@ -233,7 +232,7 @@ def test_mcp_backend_can_get_medication_history(db_session: Session) -> None:
         name=plan.name,
         instructions=plan.instructions,
         scheduled_date=utc_today - timedelta(days=1),
-        scheduled_at=datetime(2026, 1, 1, 8, 0, tzinfo=timezone.utc),
+        scheduled_at=datetime(2026, 1, 1, 8, 0, tzinfo=UTC),
         status=MedicationDoseStatus.taken,
     )
     db_session.add(dose)
@@ -248,7 +247,7 @@ def test_mcp_backend_can_get_medication_history(db_session: Session) -> None:
 
 
 def test_mcp_backend_can_get_scheduling_suggestions(db_session: Session) -> None:
-    utc_today = datetime.now(timezone.utc).date()
+    utc_today = datetime.now(UTC).date()
     user = _create_user(db_session, "mcp-suggestions@example.com")
     chore_template = ChoreTemplate(
         user_id=user.id,
@@ -309,7 +308,7 @@ def test_mcp_backend_can_create_medication(db_session: Session) -> None:
 
 
 def test_mcp_backend_can_update_medication(db_session: Session) -> None:
-    utc_today = datetime.now(timezone.utc).date()
+    utc_today = datetime.now(UTC).date()
     user = _create_user(db_session, "med-update@example.com")
     backend = DaynestMcpBackend(_session_factory(db_session), user_email=user.email)
 
@@ -491,7 +490,7 @@ def test_mcp_backend_rejects_authenticated_token_without_client_id(db_session: S
 
 
 def test_mcp_backend_can_list_routines(db_session: Session) -> None:
-    utc_today = datetime.now(timezone.utc).date()
+    utc_today = datetime.now(UTC).date()
     user = _create_user(db_session, "routine-list@example.com")
     db_session.add(
         RoutineTemplate(
@@ -536,7 +535,7 @@ def test_mcp_backend_can_create_routine(db_session: Session) -> None:
 
 
 def test_mcp_backend_can_update_routine(db_session: Session) -> None:
-    utc_today = datetime.now(timezone.utc).date()
+    utc_today = datetime.now(UTC).date()
     user = _create_user(db_session, "routine-update@example.com")
     backend = DaynestMcpBackend(_session_factory(db_session), user_email=user.email)
 
@@ -589,7 +588,7 @@ def test_mcp_backend_delete_routine_raises_for_missing_template(db_session: Sess
 
 
 def test_mcp_backend_can_list_chore_templates(db_session: Session) -> None:
-    utc_today = datetime.now(timezone.utc).date()
+    utc_today = datetime.now(UTC).date()
     user = _create_user(db_session, "chore-list@example.com")
     db_session.add(
         ChoreTemplate(
@@ -631,7 +630,7 @@ def test_mcp_backend_can_create_chore_template(db_session: Session) -> None:
 
 
 def test_mcp_backend_can_update_chore_template(db_session: Session) -> None:
-    utc_today = datetime.now(timezone.utc).date()
+    utc_today = datetime.now(UTC).date()
     user = _create_user(db_session, "chore-update@example.com")
     backend = DaynestMcpBackend(_session_factory(db_session), user_email=user.email)
 
@@ -785,7 +784,7 @@ def test_mcp_backend_defer_planned_item(db_session: Session) -> None:
     )
     result = backend.defer_planned_item(created["id"], days=7)
 
-    expected = (datetime.now(timezone.utc).date() + timedelta(days=7)).isoformat()
+    expected = (datetime.now(UTC).date() + timedelta(days=7)).isoformat()
     assert result["planned_for"] == expected
     assert result["title"] == "Defer me"
     assert result["notes"] == "preserve me"
@@ -795,7 +794,7 @@ def test_mcp_backend_defer_planned_item(db_session: Session) -> None:
 
 
 def test_mcp_backend_take_medication_dose_with_custom_taken_at(db_session: Session) -> None:
-    utc_today = datetime.now(timezone.utc).date()
+    utc_today = datetime.now(UTC).date()
     user = _create_user(db_session, "med-take-takenat@example.com")
     plan = MedicationPlan(
         user_id=user.id,
@@ -810,14 +809,14 @@ def test_mcp_backend_take_medication_dose_with_custom_taken_at(db_session: Sessi
     db_session.commit()
     db_session.refresh(plan)
 
-    past_time = datetime.now(timezone.utc) - timedelta(hours=2)
+    past_time = datetime.now(UTC) - timedelta(hours=2)
     dose = MedicationDoseInstance(
         user_id=user.id,
         medication_plan_id=plan.id,
         name=plan.name,
         instructions=plan.instructions,
         scheduled_date=utc_today,
-        scheduled_at=datetime(utc_today.year, utc_today.month, utc_today.day, 8, 0, tzinfo=timezone.utc),
+        scheduled_at=datetime(utc_today.year, utc_today.month, utc_today.day, 8, 0, tzinfo=UTC),
         status=MedicationDoseStatus.missed,
     )
     db_session.add(dose)
@@ -834,7 +833,7 @@ def test_mcp_backend_take_medication_dose_with_custom_taken_at(db_session: Sessi
 def test_mcp_backend_take_medication_dose_rejects_future_taken_at(db_session: Session) -> None:
     from fastapi import HTTPException
 
-    utc_today = datetime.now(timezone.utc).date()
+    utc_today = datetime.now(UTC).date()
     user = _create_user(db_session, "med-take-future@example.com")
     plan = MedicationPlan(
         user_id=user.id,
@@ -855,14 +854,14 @@ def test_mcp_backend_take_medication_dose_rejects_future_taken_at(db_session: Se
         name=plan.name,
         instructions=plan.instructions,
         scheduled_date=utc_today,
-        scheduled_at=datetime(utc_today.year, utc_today.month, utc_today.day, 9, 0, tzinfo=timezone.utc),
+        scheduled_at=datetime(utc_today.year, utc_today.month, utc_today.day, 9, 0, tzinfo=UTC),
         status=MedicationDoseStatus.scheduled,
     )
     db_session.add(dose)
     db_session.commit()
     db_session.refresh(dose)
 
-    future_time = (datetime.now(timezone.utc) + timedelta(hours=2)).isoformat()
+    future_time = (datetime.now(UTC) + timedelta(hours=2)).isoformat()
     backend = DaynestMcpBackend(_session_factory(db_session), user_email=user.email)
 
     with pytest.raises(HTTPException) as exc_info:
@@ -871,7 +870,7 @@ def test_mcp_backend_take_medication_dose_rejects_future_taken_at(db_session: Se
 
 
 def test_mcp_backend_skip_missed_medication_doses(db_session: Session) -> None:
-    utc_today = datetime.now(timezone.utc).date()
+    utc_today = datetime.now(UTC).date()
     user = _create_user(db_session, "med-skip-missed@example.com")
     plan = MedicationPlan(
         user_id=user.id,
@@ -895,7 +894,7 @@ def test_mcp_backend_skip_missed_medication_doses(db_session: Session) -> None:
             name=plan.name,
             instructions=plan.instructions,
             scheduled_date=d,
-            scheduled_at=datetime(d.year, d.month, d.day, 8, 0, tzinfo=timezone.utc),
+            scheduled_at=datetime(d.year, d.month, d.day, 8, 0, tzinfo=UTC),
             status=MedicationDoseStatus.missed,
         ))
     # One scheduled dose for today — should not be touched
@@ -905,7 +904,7 @@ def test_mcp_backend_skip_missed_medication_doses(db_session: Session) -> None:
         name=plan.name,
         instructions=plan.instructions,
         scheduled_date=utc_today,
-        scheduled_at=datetime(utc_today.year, utc_today.month, utc_today.day, 8, 0, tzinfo=timezone.utc),
+        scheduled_at=datetime(utc_today.year, utc_today.month, utc_today.day, 8, 0, tzinfo=UTC),
         status=MedicationDoseStatus.scheduled,
     ))
     db_session.commit()
@@ -918,7 +917,7 @@ def test_mcp_backend_skip_missed_medication_doses(db_session: Session) -> None:
 
 
 def test_mcp_backend_skip_missed_doses_does_not_touch_today(db_session: Session) -> None:
-    utc_today = datetime.now(timezone.utc).date()
+    utc_today = datetime.now(UTC).date()
     user = _create_user(db_session, "med-skip-today-safe@example.com")
     plan = MedicationPlan(
         user_id=user.id,
@@ -940,7 +939,7 @@ def test_mcp_backend_skip_missed_doses_does_not_touch_today(db_session: Session)
         name=plan.name,
         instructions=plan.instructions,
         scheduled_date=utc_today,
-        scheduled_at=datetime(utc_today.year, utc_today.month, utc_today.day, 22, 0, tzinfo=timezone.utc),
+        scheduled_at=datetime(utc_today.year, utc_today.month, utc_today.day, 22, 0, tzinfo=UTC),
         status=MedicationDoseStatus.missed,
     ))
     db_session.commit()

--- a/backend/tests/test_meal_plans.py
+++ b/backend/tests/test_meal_plans.py
@@ -10,9 +10,9 @@ from sqlalchemy.orm import Session
 from app.api.dependencies.auth import get_current_user
 from app.main import app
 from app.models.planned_item import PlannedItem
-from app.schemas.meal_plan import MealPlanCreate
 from app.models.user import User
 from app.repositories.meal_plan_repository import MealPlanRepository
+from app.schemas.meal_plan import MealPlanCreate
 from app.services.meal_plan_service import MealPlanService
 
 

--- a/backend/tests/test_observability.py
+++ b/backend/tests/test_observability.py
@@ -5,8 +5,8 @@ import logging
 import time
 import uuid
 
-from fastapi.testclient import TestClient
 import pytest
+from fastapi.testclient import TestClient
 
 
 def test_liveness_and_health_endpoints(client: TestClient) -> None:

--- a/backend/tests/test_push.py
+++ b/backend/tests/test_push.py
@@ -1,4 +1,4 @@
-from datetime import date, datetime, time, timedelta, timezone
+from datetime import UTC, date, datetime, time, timedelta
 
 from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
@@ -12,8 +12,12 @@ from app.models.medication_plan import MedicationPlan
 from app.models.notification_sent import NotificationSent
 from app.models.push_subscription import PushSubscription
 from app.models.user import User
-from app.services.push_service import dispatch_medication_reminders, dispatch_overdue_chores, pending_push_user_ids
-from app.services.push_service import send_notification
+from app.services.push_service import (
+    dispatch_medication_reminders,
+    dispatch_overdue_chores,
+    pending_push_user_ids,
+    send_notification,
+)
 
 
 def _create_user(db_session: Session, email: str) -> User:
@@ -172,7 +176,7 @@ def test_dispatch_functions_and_quiet_hours(client: TestClient, db_session: Sess
         name="Vitamin D",
         instructions="Take with water",
         scheduled_date=date(2026, 5, 21),
-        scheduled_at=datetime(2026, 5, 21, 10, 10, tzinfo=timezone.utc),
+        scheduled_at=datetime(2026, 5, 21, 10, 10, tzinfo=UTC),
         status="scheduled",
     )
     db_session.add_all([subscription, overdue, reminder])
@@ -186,7 +190,7 @@ def test_dispatch_functions_and_quiet_hours(client: TestClient, db_session: Sess
 
     monkeypatch.setattr("app.services.push_service.send_notification", _fake_send)
 
-    now = datetime(2026, 5, 21, 10, 0, tzinfo=timezone.utc)
+    now = datetime(2026, 5, 21, 10, 0, tzinfo=UTC)
     assert dispatch_overdue_chores(db_session, user.id, now=now) == 1
     assert dispatch_medication_reminders(db_session, user.id, now=now) == 1
     assert len(sent) == 2
@@ -236,7 +240,7 @@ def test_dispatch_overdue_chores_respects_user_preference(db_session: Session, m
     assert dispatch_overdue_chores(
         db_session,
         user.id,
-        now=datetime(2026, 5, 21, 10, 0, tzinfo=timezone.utc),
+        now=datetime(2026, 5, 21, 10, 0, tzinfo=UTC),
     ) == 0
     assert sent == []
 
@@ -294,5 +298,5 @@ def test_pending_push_user_ids_only_returns_users_with_unnotified_candidates(db_
 
     assert pending_push_user_ids(
         db_session,
-        now=datetime(2026, 5, 21, 10, 0, tzinfo=timezone.utc),
+        now=datetime(2026, 5, 21, 10, 0, tzinfo=UTC),
     ) == [candidate.id]

--- a/backend/tests/test_recurring_planned_items.py
+++ b/backend/tests/test_recurring_planned_items.py
@@ -1,4 +1,4 @@
-from datetime import date
+from datetime import UTC, date, datetime
 
 from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
@@ -235,7 +235,7 @@ def test_create_planned_item_with_rrule_not_matching_planned_for_returns_422(cli
 def test_delete_planned_item_scope_future_deletes_series_from_today(client: TestClient, db_session: Session) -> None:
     user = _create_user(db_session, "planned-delete-future@example.com")
     _auth_as(user)
-    start = date.today().isoformat()
+    start = datetime.now(UTC).date().isoformat()
     try:
         create = client.post(
             "/api/planned-items",
@@ -270,7 +270,7 @@ def test_delete_planned_item_scope_future_deletes_series_from_today(client: Test
 def test_delete_planned_item_scope_future_from_middle_truncates_series_rule(client: TestClient, db_session: Session) -> None:
     user = _create_user(db_session, "planned-delete-future-middle@example.com")
     _auth_as(user)
-    start = date.today()
+    start = datetime.now(UTC).date()
     end = start + (date.resolution * 6)
     try:
         create = client.post(
@@ -315,7 +315,7 @@ def test_update_planned_item_scope_future_updates_template_and_clears_materializ
 ) -> None:
     user = _create_user(db_session, "planned-update-future@example.com")
     _auth_as(user)
-    start = date.today()
+    start = datetime.now(UTC).date()
     end = start + (date.resolution * 3)
     try:
         create = client.post(
@@ -366,7 +366,7 @@ def test_update_planned_item_scope_all_updates_template_and_clears_materialized_
 ) -> None:
     user = _create_user(db_session, "planned-update-all@example.com")
     _auth_as(user)
-    start = date.today()
+    start = datetime.now(UTC).date()
     end = start + (date.resolution * 3)
     try:
         create = client.post(
@@ -417,7 +417,7 @@ def test_update_planned_item_scope_all_from_later_instance_preserves_series_star
 ) -> None:
     user = _create_user(db_session, "planned-update-all-later@example.com")
     _auth_as(user)
-    start = date.today()
+    start = datetime.now(UTC).date()
     edit_date = start + date.resolution
     end = start + (date.resolution * 3)
     try:
@@ -474,7 +474,7 @@ def test_update_planned_item_scope_all_shifts_series_start_when_date_changes(
 ) -> None:
     user = _create_user(db_session, "planned-update-all-shift-anchor@example.com")
     _auth_as(user)
-    start = date.today()
+    start = datetime.now(UTC).date()
     end = start + (date.resolution * 4)
     try:
         create = client.post(

--- a/backend/tests/test_shopping_lists.py
+++ b/backend/tests/test_shopping_lists.py
@@ -1,6 +1,6 @@
 """Tests for shopping-list backend APIs and service behavior."""
 
-from datetime import date, timedelta
+from datetime import UTC, datetime, timedelta
 
 import pytest
 from fastapi.testclient import TestClient
@@ -102,7 +102,7 @@ def test_delete_shopping_list_deletes_linked_planned_items(db_session: Session) 
         title="Screws",
         module_key="shopping_list",
         linked_ref=str(shopping_list.id),
-        planned_for=date.today(),
+        planned_for=datetime.now(UTC).date(),
         is_done=False,
     )
     db_session.add(linked)
@@ -191,7 +191,7 @@ def test_import_recurring_groceries_route_links_upcoming_items(
         "/api/shopping-lists", json={"name": "Groceries"}
     ).json()["id"]
 
-    today = date.today()
+    today = datetime.now(UTC).date()
     next_week = today + timedelta(weeks=1)
     db_session.add(
         RecurrenceSeries(

--- a/backend/tests/test_sse.py
+++ b/backend/tests/test_sse.py
@@ -1,6 +1,6 @@
 import asyncio
 from collections.abc import Coroutine
-from datetime import date, datetime, timezone
+from datetime import UTC, datetime
 from typing import Any
 from unittest.mock import MagicMock
 
@@ -78,7 +78,7 @@ async def test_today_rollover_publishes_today_updated_for_subscribed_user(db_ses
         db_session,
         event_bus,
         local_dates,
-        now=datetime(2026, 5, 21, 21, 59, tzinfo=timezone.utc),
+        now=datetime(2026, 5, 21, 21, 59, tzinfo=UTC),
     )
     assert queue.empty()
 
@@ -86,7 +86,7 @@ async def test_today_rollover_publishes_today_updated_for_subscribed_user(db_ses
         db_session,
         event_bus,
         local_dates,
-        now=datetime(2026, 5, 21, 22, 1, tzinfo=timezone.utc),
+        now=datetime(2026, 5, 21, 22, 1, tzinfo=UTC),
     )
     event = await asyncio.wait_for(queue.get(), timeout=1)
     assert event == {"type": "today_updated"}
@@ -135,7 +135,7 @@ def test_today_mutation_publishes_today_updated(client: TestClient, db_session: 
     app.dependency_overrides[get_current_user] = _auth_dep
     app.dependency_overrides[get_event_bus] = lambda: mock_bus
     try:
-        payload = {"title": "Test item", "planned_for": str(date.today()), "priority": "normal"}
+        payload = {"title": "Test item", "planned_for": str(datetime.now(UTC).date()), "priority": "normal"}
         response = client.post("/api/planned-items", json=payload)
         assert response.status_code == 200
         mock_bus.publish.assert_called_once_with(user.id, {"type": "today_updated"})

--- a/backend/tests/test_today_route_integration.py
+++ b/backend/tests/test_today_route_integration.py
@@ -1,4 +1,4 @@
-from datetime import date, datetime, time, timedelta, timezone
+from datetime import UTC, date, datetime, time, timedelta
 from unittest.mock import MagicMock
 
 from fastapi.testclient import TestClient
@@ -55,7 +55,7 @@ def test_get_today_includes_generated_chore_sections(client: TestClient, db_sess
         user_id=user.id,
         name="Morning reset",
         description="Kitchen and windows",
-        start_date=date.today(),
+        start_date=datetime.now(UTC).date(),
         every_n_days=1,
         due_time=time(8, 0),
         is_active=True,
@@ -64,7 +64,7 @@ def test_get_today_includes_generated_chore_sections(client: TestClient, db_sess
         user_id=user.id,
         name="Take out trash",
         description=None,
-        start_date=date.today(),
+        start_date=datetime.now(UTC).date(),
         every_n_days=1,
         is_active=True,
     )
@@ -72,7 +72,7 @@ def test_get_today_includes_generated_chore_sections(client: TestClient, db_sess
         user_id=user.id,
         name="Vitamin D",
         instructions="Take with breakfast and water",
-        start_date=date.today(),
+        start_date=datetime.now(UTC).date(),
         schedule_time=time(9, 0),
         every_n_days=1,
         is_active=True,
@@ -183,10 +183,11 @@ def test_routine_generation_falls_back_for_invalid_rrule(db_session: Session) ->
         .all()
     )
     assert [item.scheduled_date for item in generated] == [date(2026, 4, 20), date(2026, 4, 22), date(2026, 4, 24)]
+    # SQLite round-trips DateTime(timezone=True) columns as naive UTC values.
     assert [item.due_at for item in generated] == [
-        datetime(2026, 4, 20, 7, 30),
-        datetime(2026, 4, 22, 7, 30),
-        datetime(2026, 4, 24, 7, 30),
+        datetime(2026, 4, 20, 7, 30),  # noqa: DTZ001
+        datetime(2026, 4, 22, 7, 30),  # noqa: DTZ001
+        datetime(2026, 4, 24, 7, 30),  # noqa: DTZ001
     ]
 
 
@@ -217,7 +218,7 @@ def test_routine_generation_does_not_fallback_for_exhausted_rrule(db_session: Se
         .all()
     )
     assert [item.scheduled_date for item in generated] == [date(2026, 4, 20)]
-    assert generated[0].due_at == datetime(2026, 4, 20, 8, 0)
+    assert generated[0].due_at == datetime(2026, 4, 20, 8, 0)  # noqa: DTZ001 -- SQLite round-trips as naive UTC
 
 
 def test_get_today_allows_today_service_dependency_override(client: TestClient, db_session: Session) -> None:
@@ -230,7 +231,7 @@ def test_get_today_allows_today_service_dependency_override(client: TestClient, 
 
         def get_today(self, *, user_id: int, for_date: date) -> TodayResponse:
             assert user_id == user.id
-            assert for_date == date.today()
+            assert for_date == datetime.now(UTC).date()
             return TodayResponse(
                 medication=[],
                 medication_history=[],
@@ -351,7 +352,7 @@ def test_medication_endpoints_create_list_history_and_mutate_status(client: Test
             name=plan.name,
             instructions=plan.instructions,
             scheduled_date=date(2026, 4, 22),
-            scheduled_at=datetime(2026, 4, 22, 20, 0, tzinfo=timezone.utc),
+            scheduled_at=datetime(2026, 4, 22, 20, 0, tzinfo=UTC),
             status=MedicationDoseStatus.scheduled,
         )
         db_session.add(dose)
@@ -488,7 +489,7 @@ def test_ical_export_window_uses_user_timezone(
     class FixedDatetime(datetime):
         @classmethod
         def now(cls, tz=None):
-            value = datetime(2026, 1, 1, 10, 0, tzinfo=timezone.utc)
+            value = datetime(2026, 1, 1, 10, 0, tzinfo=UTC)
             return value.astimezone(tz) if tz else value.replace(tzinfo=None)
 
     app.dependency_overrides[get_today_service] = lambda: StubCalendarService()
@@ -738,7 +739,7 @@ def test_routine_task_generation_and_mutation_endpoints(client: TestClient, db_s
         user_id=user.id,
         name="Morning check",
         description="Review day plan",
-        start_date=date.today(),
+        start_date=datetime.now(UTC).date(),
         every_n_days=1,
         due_time=time(7, 30),
         is_active=True,
@@ -764,11 +765,11 @@ def test_routine_task_generation_and_mutation_endpoints(client: TestClient, db_s
             user_id=user.id,
             routine_template_id=routine_template.id,
             title=routine_template.name,
-            scheduled_date=date.fromordinal(date.today().toordinal() + 1),
+            scheduled_date=date.fromordinal(datetime.now(UTC).date().toordinal() + 1),
             due_at=datetime.combine(
-                date.fromordinal(date.today().toordinal() + 1),
+                date.fromordinal(datetime.now(UTC).date().toordinal() + 1),
                 time(7, 30),
-                tzinfo=timezone.utc,
+                tzinfo=UTC,
             ),
             status=TaskStatus.pending,
         )
@@ -823,7 +824,7 @@ def test_calendar_feed_ics_serializes_planned_items(client: TestClient, db_sessi
     user = _create_user(db_session, email="calendar-feed-ics@example.com")
     user.calendar_feed_token = "feed-token"
     user.timezone = "UTC"
-    today = date.today()
+    today = datetime.now(UTC).date()
     included = PlannedItem(
         user_id=user.id,
         title="Plan menu, shop",

--- a/backend/tests/test_today_service.py
+++ b/backend/tests/test_today_service.py
@@ -1,4 +1,4 @@
-from datetime import date, datetime, time, timedelta, timezone
+from datetime import UTC, date, datetime, time, timedelta
 from types import SimpleNamespace
 from typing import Any, cast
 
@@ -9,7 +9,7 @@ from app.core.config import AppSettings
 from app.core.enums import ChoreStatus, MedicationDoseStatus, TaskStatus
 from app.services.today_service import TodayService
 
-_FIXED_NOW = datetime(2026, 4, 23, 10, 0, tzinfo=timezone.utc)
+_FIXED_NOW = datetime(2026, 4, 23, 10, 0, tzinfo=UTC)
 
 
 class StubTodayRepository:
@@ -47,7 +47,6 @@ class StubTodayRepository:
 
     def mark_due_medications_missed(self, user_id: int, now, grace_minutes: int = 30):
         self.grace_minutes = grace_minutes
-        return None
 
     def utcnow(self):
         return _FIXED_NOW
@@ -126,7 +125,7 @@ def test_get_today_shapes_chore_sections() -> None:
             medication_plan_id=8,
             name="Vitamin D",
             instructions="Take with breakfast",
-            scheduled_at=datetime(2026, 4, 23, 9, 0, tzinfo=timezone.utc),
+            scheduled_at=datetime(2026, 4, 23, 9, 0, tzinfo=UTC),
             scheduled_date=for_date,
             status=MedicationDoseStatus.scheduled,
         )
@@ -321,7 +320,7 @@ def _make_dose(status: MedicationDoseStatus) -> SimpleNamespace:
         name="Vitamin D",
         instructions="Take with breakfast",
         scheduled_date=date(2026, 4, 23),
-        scheduled_at=datetime(2026, 4, 23, 9, 0, tzinfo=timezone.utc),
+        scheduled_at=datetime(2026, 4, 23, 9, 0, tzinfo=UTC),
         status=status,
         taken_at=None,
         skipped_at=None,
@@ -410,7 +409,7 @@ def test_mutate_medication_miss_from_missed_raises_conflict() -> None:
 
 def test_mutate_medication_not_found_raises_404() -> None:
     """Missing dose raises 404."""
-    repo, service = _make_service(dose=None)
+    _repo, service = _make_service(dose=None)
 
     with pytest.raises(HTTPException) as exc_info:
         service.mutate_medication_status(user_id=7, medication_dose_instance_id=99, action="take")

--- a/backend/tests/test_users.py
+++ b/backend/tests/test_users.py
@@ -1,6 +1,6 @@
 """Tests for user account settings and deletion endpoints."""
 
-from datetime import date, time
+from datetime import UTC, datetime, time
 
 import pytest
 from fastapi.testclient import TestClient
@@ -42,7 +42,7 @@ def clear_auth_override():
 
 def test_delete_current_user_removes_personal_data(client: TestClient, db_session: Session) -> None:
     user = _create_user(db_session, "delete-me@example.com")
-    plan = MedicationPlan(user_id=user.id, name="Vitamin D", instructions="Take daily", start_date=date.today(), schedule_time=time(8, 0))
+    plan = MedicationPlan(user_id=user.id, name="Vitamin D", instructions="Take daily", start_date=datetime.now(UTC).date(), schedule_time=time(8, 0))
     db_session.add(plan)
     db_session.commit()
     _auth_as(user)
@@ -69,7 +69,7 @@ def test_delete_current_user_blocks_household_shared_chores(client: TestClient, 
             user_id=owner.id,
             household_id=household.id,
             name="Shared dishes",
-            start_date=date.today(),
+            start_date=datetime.now(UTC).date(),
             every_n_days=1,
         )
     )


### PR DESCRIPTION
## Summary

- The `backend-ci` workflow was failing on the `python-quality` Dependabot bump (ruff 0.15.22 → 0.16.0, PR #688) because ruff 0.16.0 expanded its default lint rule set from 59 to 413 rules, surfacing 217 new findings across `backend/app` and `backend/tests`.
- Applied ruff's safe auto-fixes (import sorting, `timezone.utc` → `UTC` alias, redundant `return`/quoted-annotation cleanups, etc.) and manually resolved the remaining findings:
  - Replaced naive `date.today()` / `datetime.now()` calls with the codebase's existing `datetime.now(UTC).date()` idiom in both `app/` routes/services and test fixtures.
  - Added `.replace(tzinfo=UTC)` where a naive `datetime.strptime(...)` result is used purely for time-of-day arithmetic (`app/mcp_server.py`, `app/repositories/analytics_repository.py`).
  - Converted `app/services/export_import_service.py`'s `_enum` helper to PEP 695 generic syntax, removing the now-unused `TypeVar`.
  - Prefixed an unused unpacked test variable with `_`.
  - Updated `tests/test_integration_adapters.py`'s "frozen today" test helper to patch `datetime.now` instead of `date.today`, matching the Home Assistant route's new `datetime.now(UTC).date()` call.
- Verified `ruff check`, `ty check`, and the full `pytest` suite (269 tests) all pass locally.

## Test plan

- [x] `uv run ruff check app tests`
- [x] `uv run ty check app`
- [x] `PYTHONPATH=. uv run pytest -q`

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dyzrm28W3UhgNf8DXLpvyz)_