### PR TITLE
fix(pebble): make the Alloy package build and run, and document what hardware still has to prove

### DIFF
--- a/.github/workflows/pebble.yml
+++ b/.github/workflows/pebble.yml
@@ -29,6 +29,9 @@ jobs:
       - name: Validate Alloy package contract
         working-directory: pebble
         run: node scripts/validate.mjs
+      - name: Test watch app logic
+        working-directory: pebble
+        run: npm test
 
   # Compiling the package and booting it on the Emery emulator catches the two
   # failure modes the contract checks can only approximate: a build that does

--- a/.github/workflows/pebble.yml
+++ b/.github/workflows/pebble.yml
@@ -29,3 +29,91 @@ jobs:
       - name: Validate Alloy package contract
         working-directory: pebble
         run: node scripts/validate.mjs
+
+  # Compiling the package and booting it on the Emery emulator catches the two
+  # failure modes the contract checks can only approximate: a build that does
+  # not compile, and a watchapp that compiles but dies on startup. The latter is
+  # silent — PebbleOS tears the app down leaving a blank screen, and watch-side
+  # console output never reaches `pebble logs` in a release build — so the
+  # screenshot is the only mechanical evidence that the app actually ran.
+  # See pebble/EMULATOR.md.
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    env:
+      SDL_VIDEODRIVER: dummy
+      SDL_AUDIODRIVER: dummy
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v6
+        with:
+          node-version: 22
+
+      - uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+
+      - name: Install emulator runtime libraries
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            libsdl2-2.0-0 libglib2.0-0 libpixman-1-0 zlib1g
+
+      - name: Install the Pebble SDK
+        run: |
+          uv tool install pebble-tool
+          pebble sdk install latest
+
+      - name: Build the Alloy package
+        working-directory: pebble
+        run: pebble build
+
+      - name: Upload the .pbw
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: daynest-pebble-pbw
+          path: pebble/build/*.pbw
+          if-no-files-found: error
+
+      # pypkjs binds its websocket with ("", port), which resolves to AF_INET6.
+      # Where IPv6 is unavailable that fails, and the CLI reports it only as a
+      # bare "Connection refused". Binding loopback is correct for a local
+      # emulator either way, so pin it rather than depend on the runner.
+      - name: Pin pypkjs to an IPv4 bind
+        run: |
+          runner=$(ls "$(uv tool dir)"/pebble-tool/lib/python*/site-packages/pypkjs/runner/websocket.py)
+          sed -i 's/pywsgi.WSGIServer(("", self.port)/pywsgi.WSGIServer(("127.0.0.1", self.port)/' "$runner"
+          grep -q '"127.0.0.1", self.port' "$runner"
+
+      - name: Install and run on the Emery emulator
+        working-directory: pebble
+        run: |
+          for attempt in 1 2; do
+            echo "::group::emulator attempt $attempt"
+            if pebble install --emulator emery; then
+              sleep 10
+              if pebble screenshot --emulator emery --no-open screenshot.png; then
+                echo "::endgroup::"
+                exit 0
+              fi
+            fi
+            echo "::endgroup::"
+            echo "attempt $attempt failed; restarting the emulator"
+            pebble kill || true
+            sleep 5
+          done
+          echo "the emulator did not produce a screenshot after 2 attempts" >&2
+          exit 1
+
+      - name: Check the watchapp actually rendered
+        working-directory: pebble
+        run: python3 scripts/check-screenshot.py screenshot.png
+
+      - name: Upload the screenshot
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: daynest-pebble-screenshot
+          path: pebble/screenshot.png
+          if-no-files-found: warn

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,10 +41,28 @@ bump on every app release.
 
 ## [2026.7.2] - 2026-07-24
 
+### Added
+- **Pebble:** a companion watchapp for Pebble Time 2, built with Alloy (`pebble/`) — a today
+  glance showing due/overdue counts and the first due items, with UP to refresh, SELECT to
+  complete and DOWN to skip the first due item, and a `device.keyValue` cache so the last
+  dashboard stays readable offline. It talks to a dedicated, narrowly scoped backend router
+  (`/api/integrations/pebble/...`, `pebble:read`/`pebble:write`) and pairs through an
+  authenticated Daynest configuration page opened from the stock Pebble app (#676, #678).
+
+### Fixed
+- **Pebble:** the Alloy package did not build — a trailing comma in `src/pkjs/index.js`'s
+  argument list is a hard `SyntaxError` for the SDK's ES2015-era PKJS bundler. The watchapp
+  also died at startup with a blank screen once it did build, because Piu resolves fonts
+  against PebbleOS's built-in table and the requested `OpenSans-Regular-15` does not exist
+  there; it now uses `14px Gothic`. Both are covered by `pebble/scripts/validate.mjs` (#704).
+- **Pebble:** the pairing token is relayed through `moddableProxy.sendAppMessage()` rather
+  than `Pebble.sendAppMessage()`, so it queues behind in-flight `fetch()` proxy traffic
+  instead of competing with it for PKJS's small outbound message budget (#704).
+
 ### Removed
 - **Android:** the Wear OS companion module (`:wear`) has been removed — tile, complication,
   and quick-action due list activity all deleted, along with its DI modules, local Room cache,
-  and CI checks. Superseded by a planned Pebble (Alloy) companion app (#676).
+  and CI checks. Superseded by the Pebble (Alloy) companion app above (#676).
 
 ## [2026.7.1] - 2026-07-22
 

--- a/pebble/.gitignore
+++ b/pebble/.gitignore
@@ -1,3 +1,5 @@
 build/
 node_modules/
 *.pbw
+screenshot.png
+requests.log

--- a/pebble/EMULATOR.md
+++ b/pebble/EMULATOR.md
@@ -17,6 +17,18 @@ complete/skip, offline cache fallback, or the mutation-replay guards. Watch-side
 `fetch()` never completes under QEMU. See [The `fetch()` dead
 end](#the-fetch-dead-end) for why, and don't spend a day rediscovering it.
 
+## What CI does with this
+
+`.github/workflows/pebble.yml` runs the same sequence on every PR touching
+`pebble/`: `pebble build`, then boot the emulator, install, screenshot, and
+assert the app rendered via
+[`scripts/check-screenshot.py`](scripts/check-screenshot.py). Both are proven
+against the defects they exist for — reintroducing the trailing comma fails the
+build step, and reintroducing the bad font *passes* the build and fails the
+screenshot check, which is exactly how that bug slipped through in the first
+place. The `.pbw` and the screenshot are uploaded as artifacts, so a failure is
+inspectable without reproducing it locally.
+
 ## One-time setup
 
 ```sh

--- a/pebble/EMULATOR.md
+++ b/pebble/EMULATOR.md
@@ -1,0 +1,167 @@
+# Testing the Pebble app without a watch
+
+A runbook for the Emery QEMU emulator, written up after using it to find and
+fix the build and startup defects described in [`README.md`](README.md). It
+exists because the emulator is far more useful here than it first looks — but
+also has one hard limit that decides what still needs hardware.
+
+## What the emulator can and cannot prove
+
+It can prove: the package builds; the watchapp launches and stays running; Piu
+renders what you expect at the real screen size; fonts and glyphs resolve;
+`localStorage` and `device.keyValue` work; and configuration sent from the
+phone side arrives and is read back correctly.
+
+It cannot prove anything requiring a live HTTP round-trip — the dashboard load,
+complete/skip, offline cache fallback, or the mutation-replay guards. Watch-side
+`fetch()` never completes under QEMU. See [The `fetch()` dead
+end](#the-fetch-dead-end) for why, and don't spend a day rediscovering it.
+
+## One-time setup
+
+```sh
+sudo apt install nodejs npm libsdl2-2.0-0 libglib2.0-0 libpixman-1-0 zlib1g
+uv tool install pebble-tool     # Python 3.10+; https://docs.astral.sh/uv/
+pebble sdk install latest       # SDK 4.17 + ARM and Moddable toolchains
+```
+
+Two environment notes that cost time:
+
+- `qemu-pebble` is not on `PATH`. It lives in the SDK toolchain, at
+  `~/.local/share/pebble-sdk/SDKs/4.17/toolchain/bin/qemu-pebble`. You only
+  need it directly if you are booting the emulator by hand.
+- **If the host has no IPv6**, pypkjs cannot start. It binds its websocket with
+  `pywsgi.WSGIServer(("", port), ...)`, which resolves to `AF_INET6` and fails
+  with `OSError: [Errno 97] Address family not supported by protocol`; the
+  `pebble` CLI reports this only as a bare `[Errno 111] Connection refused`.
+  Patch the installed copy to bind IPv4:
+
+  ```sh
+  # ~/.local/share/uv/tools/pebble-tool/lib/python3.11/site-packages/pypkjs/runner/websocket.py
+  -  self.server = pywsgi.WSGIServer(("", self.port), ...)
+  +  self.server = pywsgi.WSGIServer(("127.0.0.1", self.port), ...)
+  ```
+
+## Running the app
+
+```sh
+cd pebble
+export SDL_VIDEODRIVER=dummy SDL_AUDIODRIVER=dummy   # headless hosts only
+pebble build
+pebble install --emulator emery                      # boots the emulator if needed
+pebble logs --emulator emery
+pebble screenshot --emulator emery --no-open shot.png
+```
+
+`pebble install` launches the app as a side effect, so reinstalling is the
+normal way to restart it.
+
+## Debugging when there is nothing in the logs
+
+**Watch-side `console.log` does not reach `pebble logs` in a release build.**
+Only PKJS output does. A watchapp that throws during startup therefore shows a
+blank screen and produces no diagnostic whatsoever — which is exactly how the
+font defect presented.
+
+The technique that worked is to treat the screen as the console: render
+diagnostics into a Piu `Text` and take a screenshot.
+
+```js
+import {} from "piu/MC";
+const application = new Application(null, { skin: new Skin({ fill: "black" }) });
+// ...then set application.content("status").string = <whatever you want to see>
+```
+
+From there, bisect. A minimal Piu app with a black fill renders, so Piu works;
+add a `Style` with the app's font and it dies, so the font is the problem. It is
+also worth swapping in the stock `pebble new-project --alloy` watchface as a
+control — if that renders inside your package, the toolchain and your
+`package.json` are fine and the fault is in your own `main.js`.
+
+The alternative is `pebble build --debug` plus an xsbug session, which gives
+real exceptions but needs a debugger attached.
+
+## Driving the app
+
+**Configuration.** You do not need the pairing webview. Message keys are
+assigned numerically by the build — read them from `build/*.pbw`'s
+`appinfo.json` (currently `API_BASE_URL` is 10000 and `AUTH_TOKEN` is 10001,
+clear of the proxy's 15000+ range) and push them directly:
+
+```sh
+pebble send-app-message --emulator emery \
+  --string 10000=http://127.0.0.1:8899 10001=test-pebble-key
+```
+
+`--string KEY=VALUE` requires the numeric key; passing the symbolic name is
+rejected. This exercises the real path — `Message`'s `onReadable`, the
+`payload.get("API_BASE_URL")` lookup, and the `localStorage` write.
+
+**Buttons.**
+
+```sh
+pebble emu-button --emulator emery click up      # or select, down, back
+```
+
+**Other state.** `pebble emu-bt-connection --connected no|yes` toggles the
+Bluetooth connection, and `pebble emu-set-time` moves the clock.
+
+## The mock backend
+
+[`scripts/mock-server.py`](scripts/mock-server.py) implements the three routes
+from `backend/app/api/routes/integrations/pebble.py` — dashboard, complete-task,
+skip-task — with the same `X-Integration-Key` check. It logs every request to
+`requests.log`, which is the point: the mutation-replay acceptance criteria are
+about what the server received, not what the watch displayed. Three rapid
+SELECT presses should produce exactly one `POST complete`.
+
+```sh
+python3 pebble/scripts/mock-server.py 8899
+```
+
+It is equally useful for the hardware run — point `API_BASE_URL` at a laptop on
+the same network instead of at a real Daynest server, and you get an exact
+record of what the watch actually submitted.
+
+## The `fetch()` dead end
+
+Watch-side `fetch()` never completes under QEMU + pypkjs. The promise never
+settles, and no request reaches the server.
+
+What happens: `httpclient-pebble.js` opens its own AppMessage channel and only
+writes a queued request when that channel reports writable. In
+`pebble-appmessage.c`, writability is granted by `updateActive()`, which is
+driven by a PebbleOS comm-session event gated on
+`sys_app_pp_get_comm_session()` — a *system* session that pypkjs never
+establishes. So the request sits in the queue forever.
+
+Things that look like the cause but are not: `watch.connected.pebblekit` is
+`true` throughout, and the proxy handshake completes (enable
+`moddableProxy.log = true` in `src/pkjs/index.js` and you will see
+`readyReceived` and the watch's `15025` probe). Toggling
+`emu-bt-connection` to force a session event does not help either.
+
+A fetch-only app containing no Daynest code stalls identically, so this is an
+emulator limitation, not an app bug. Confirm that first if you ever suspect
+otherwise.
+
+One consequence worth recognising: each stalled fetch is retained, so repeatedly
+pressing UP eventually aborts the app with `fxAbort memory full` in the log.
+That is a symptom of the stall, not an independent memory bug.
+
+## Gotchas
+
+- **`pkill -f qemu-pebble` can kill the shell running it.** If the pattern
+  appears in the enclosing `bash -c` command line, `pkill -f` matches that
+  process too and the script dies silently with a nonzero exit and no output.
+  Use `pkill -x qemu-pebble`, or put the commands in a script file.
+- **A wedged emulator reports `libpebble2.exceptions.TimeoutError` or
+  `Connection refused`**, and `pebble install` may log `QEMU is already
+  running` while nothing responds. `pebble kill` and start again; this happens
+  after an `fxAbort` or a Bluetooth toggle.
+- **The emulator persists app storage across installs**, under
+  `~/.local/share/pebble-sdk/4.17/emery`. `localStorage` and `device.keyValue`
+  survive a reinstall, so a token from an earlier run will make the app skip its
+  "Not configured" screen. Use `pebble wipe` for a genuinely clean device.
+- **Screenshots need `SDL_VIDEODRIVER=dummy`** on a headless host, or QEMU fails
+  to start with an SDL error.

--- a/pebble/README.md
+++ b/pebble/README.md
@@ -157,7 +157,9 @@ complete a watch-side `fetch()`.
 - [ ] Repeated SELECT/DOWN presses submit the mutation exactly once (check the
       backend, not just the screen).
 - [ ] With networking off, the last dashboard is still shown and is labelled
-      `(cached — offline)`.
+      `Phone offline · HH:MM`.
+- [ ] An action chosen from cached state re-reads the dashboard first and acts
+      on the current first item, not the cached one.
 - [ ] After a successful mutation, a failed refresh does not resurrect the
       acted-on item from cache.
 - [ ] The integration key works with only `pebble:read` and `pebble:write`.

--- a/pebble/README.md
+++ b/pebble/README.md
@@ -184,4 +184,8 @@ complete a watch-side `fetch()`.
   the Emery emulator; a richer per-item list is a good next iteration.
 - **Storage/offline behavior**: cached via `device.keyValue`; Pebble's docs
   don't document a hard size limit for Emery, just "keep it minimal" — the
-  cached payload here is a single small JSON blob, which should be safe.
+  cached payload here is a single small JSON blob. Snapshots older than 12
+  hours, or stamped in the future after a clock rollback, are discarded.
+  Changing the integration key or server URL also clears the cache; responses
+  still in flight for the previous identity are ignored, and the new refresh
+  is serviced after the active request.

--- a/pebble/README.md
+++ b/pebble/README.md
@@ -18,10 +18,11 @@ HTTP proxy never receives it, because the Moddable AppMessage channel it rides
 on never becomes writable in the emulator (PebbleOS gates that on a system comm
 session pypkjs doesn't establish). A minimal fetch-only app containing no
 Daynest code stalls identically, so this is an emulator limit rather than an
-app bug — but it does mean the dashboard load, complete/skip actions, offline
-cache fallback, and the mutation-replay guards can only be signed off on
-hardware. Work through the [hardware smoke test](#hardware-smoke-test) on a
-Pebble Time 2 before treating those as done.
+app bug (see [`EMULATOR.md`](EMULATOR.md)) — but it does mean the dashboard
+load, complete/skip actions, offline cache fallback, and the mutation-replay
+guards can only be signed off on hardware. Work through the
+[hardware smoke test](#hardware-smoke-test) on a Pebble Time 2 before treating
+those as done.
 
 ## Architecture
 
@@ -97,6 +98,10 @@ app so the `pebble` CLI can push builds and stream logs.
 `node scripts/validate.mjs` runs the CI contract checks (message keys, target
 platforms, required scopes, and the footguns described below). It does not need
 the SDK.
+
+[`EMULATOR.md`](EMULATOR.md) is the runbook for the Emery emulator: how to drive
+the app without a phone, how to debug a watchapp that renders nothing and logs
+nothing, and which environment quirks to expect.
 
 ### Pairing
 

--- a/pebble/README.md
+++ b/pebble/README.md
@@ -95,9 +95,12 @@ pebble logs --emulator emery
 To sideload to a real watch, enable "Developer Connection" in the Pebble mobile
 app so the `pebble` CLI can push builds and stream logs.
 
-`node scripts/validate.mjs` runs the CI contract checks (message keys, target
+`node scripts/validate.mjs` runs the contract checks (message keys, target
 platforms, required scopes, and the footguns described below). It does not need
-the SDK.
+the SDK. CI runs that, plus a real `pebble build` and an emulator boot that
+screenshots the app and asserts it rendered — a watchapp that dies at startup
+compiles cleanly and logs nothing, so the screenshot is the only thing that
+catches it.
 
 [`EMULATOR.md`](EMULATOR.md) is the runbook for the Emery emulator: how to drive
 the app without a phone, how to debug a watchapp that renders nothing and logs

--- a/pebble/README.md
+++ b/pebble/README.md
@@ -5,17 +5,23 @@ companion app for Pebble Time 2 (Emery), built with
 [Alloy](https://developer.repebble.com/guides/alloy/) — Moddable's
 JavaScript/TypeScript SDK for PebbleOS.
 
-## Status: early scaffold, not yet hardware-tested
+## Status: builds and runs; live data still needs a real watch
 
-This has been written against the public Alloy documentation and the
-[moddable-OpenSource/pebble-examples](https://github.com/moddable-OpenSource/pebble-examples)
-reference apps, but **has not been compiled or run on a device or the
-emulator** — there's no toolchain available in the environment this was
-scaffolded in. Per the plan in #676, validating this by hand in CloudPebble
-or the local SDK against a real Pebble Time 2 is the next step, not
-something to automate.
+The package builds for Emery and Gabbro against Pebble SDK 4.17, and the
+watchapp installs, launches, and renders on the Emery QEMU emulator. Two
+defects that prevented each of those are fixed — see
+[Validation notes](#validation-notes).
 
-Treat everything below as a documented starting point, not a finished app.
+Everything behind a live network call is still unverified. Watch-side
+`fetch()` never completes under QEMU + pypkjs: the request is queued and the
+HTTP proxy never receives it, because the Moddable AppMessage channel it rides
+on never becomes writable in the emulator (PebbleOS gates that on a system comm
+session pypkjs doesn't establish). A minimal fetch-only app containing no
+Daynest code stalls identically, so this is an emulator limit rather than an
+app bug — but it does mean the dashboard load, complete/skip actions, offline
+cache fallback, and the mutation-replay guards can only be signed off on
+hardware. Work through the [hardware smoke test](#hardware-smoke-test) on a
+Pebble Time 2 before treating those as done.
 
 ## Architecture
 
@@ -61,19 +67,92 @@ Home Assistant integration routes or vice versa:
 
 ## Setup
 
-1. Open this directory in [CloudPebble](https://cloudpebble.repebble.com/)
-   (no local install needed), or install the SDK locally — see
-   [Installing the Pebble SDK](https://developer.repebble.com/sdk/). Local
-   builds also need `@moddable/pebbleproxy` installed
-   (`pebble package install @moddable/pebbleproxy` — already declared in
-   `package.json`'s `dependencies`, so a normal build should fetch it).
-2. To sideload directly instead of using CloudPebble's install button,
-   enable "Developer Connection" in the Pebble mobile app so the `pebble`
-   CLI can push builds and stream logs to a paired watch.
-3. In the Pebble mobile app, open Daynest's settings and sign in through the
-   Daynest configuration webview. Daynest rotates a credential containing only
-   `pebble:read` and `pebble:write`, closes the webview, and relays it to the
-   watch.
+### Toolchain
+
+These are the exact steps used to build and run the package. On Ubuntu:
+
+```sh
+sudo apt install nodejs npm libsdl2-2.0-0 libglib2.0-0 libpixman-1-0 zlib1g
+uv tool install pebble-tool     # needs Python 3.10+; see https://docs.astral.sh/uv/
+pebble sdk install latest       # installs SDK 4.17 + the ARM/Moddable toolchain
+```
+
+[CloudPebble](https://cloudpebble.repebble.com/) works too and needs no local
+install. `@moddable/pebbleproxy` is declared in `package.json`'s
+`dependencies`, and `pebble build` fetches it automatically — no separate
+`pebble package install` step is needed.
+
+### Build and run
+
+```sh
+cd pebble
+pebble build                              # → build/pebble.pbw (emery + gabbro)
+pebble install --emulator emery           # or: --phone <ip> for a paired watch
+pebble logs --emulator emery
+```
+
+To sideload to a real watch, enable "Developer Connection" in the Pebble mobile
+app so the `pebble` CLI can push builds and stream logs.
+
+`node scripts/validate.mjs` runs the CI contract checks (message keys, target
+platforms, required scopes, and the footguns described below). It does not need
+the SDK.
+
+### Pairing
+
+In the Pebble mobile app, open Daynest's settings and sign in through the
+Daynest configuration webview. Daynest rotates a credential containing only
+`pebble:read` and `pebble:write`, closes the webview, and relays it to the
+watch as `API_BASE_URL` / `AUTH_TOKEN`.
+
+## Validation notes
+
+Findings from building and running the package. The fixes are in the code
+already; the guards live in `scripts/validate.mjs` so they can't regress.
+
+- **PKJS is bundled by an ES2015-era acorn.** A trailing comma in an argument
+  list — ordinary repo formatting style — is a hard `SyntaxError` that fails
+  `pebble build`. Keep `src/pkjs/index.js` free of them.
+- **Piu fonts come from PebbleOS's built-in table, not from the app.** Only
+  `Gothic` (9/14/18/24/28/36), `Bitham`, `Roboto`, `DroidSerif`, and `Leco`
+  exist, in regular or bold, and the value is CSS shorthand — `"14px Gothic"`,
+  not a font filename. An unknown family throws an uncaught
+  `font not found` URIError from `new Style(...)` that kills the app at
+  startup, with a blank screen and nothing in `pebble logs` to explain it.
+- **`Pebble.sendAppMessage()` bypasses the proxy's send queue.** PKJS allows
+  only a few simultaneously enqueued messages and the proxy is already using
+  that budget for in-flight `fetch()` traffic, so `src/pkjs/index.js` relays
+  the pairing token through `moddableProxy.sendAppMessage()` instead.
+- **Watch-side `console.log` does not reach `pebble logs` in release builds** —
+  only PKJS output does. Debugging the watchapp means either rendering state to
+  the screen or a `pebble build --debug` xsbug session.
+- **Emery renders the whole glance comfortably.** At `14px Gothic` on 200×228,
+  the header, counts, four items, and the action hint all fit, and `—`, `•`,
+  and `…` all have glyph coverage. Consecutive newlines collapse, so the empty
+  strings used as separators in `renderDashboard()` produce no blank line.
+- **Message keys are assigned numerically by the build** — `API_BASE_URL` is
+  10000 and `AUTH_TOKEN` is 10001, clear of the proxy's 15000+ range. Pushing
+  them by hand (`pebble send-app-message --emulator emery --string
+  10000=<url> 10001=<key>`) is the quickest way to exercise the config path
+  without standing up the pairing webview.
+
+## Hardware smoke test
+
+Everything below needs a paired Pebble Time 2, because the emulator can't
+complete a watch-side `fetch()`.
+
+- [ ] The app installs and starts from the Pebble mobile app.
+- [ ] Daynest's configuration page opens from the stock Pebble app, and after
+      sign-in the watch leaves the "Not configured" screen.
+- [ ] The glance shows live due-today/overdue counts and the first due items.
+- [ ] UP refreshes; SELECT completes the first due item; DOWN skips it.
+- [ ] Repeated SELECT/DOWN presses submit the mutation exactly once (check the
+      backend, not just the screen).
+- [ ] With networking off, the last dashboard is still shown and is labelled
+      `(cached — offline)`.
+- [ ] After a successful mutation, a failed refresh does not resurrect the
+      acted-on item from cache.
+- [ ] The integration key works with only `pebble:read` and `pebble:write`.
 
 ## Known gaps / next steps
 
@@ -90,13 +169,9 @@ Home Assistant integration routes or vice versa:
   `X-Pebble-Watch-Token`, which are Pebble's own tokens, not Daynest's).
   This scaffold is the simpler "open the app to see today" version.
 - **UI is a single static-text screen**, not a scrollable list — kept
-  deliberately simple since the exact Piu list/scroller component API
-  wasn't verified against working examples during scaffolding. Piu's
-  `Container`/`Content`/`Text` primitives used here (`add`/`content(name)`/
-  `.string`) are confirmed against
-  [Moddable's Piu reference](https://github.com/Moddable-OpenSource/moddable/blob/public/documentation/piu/piu.md);
-  a richer per-item list is a good next iteration once this boots on
-  hardware.
+  deliberately simple. The Piu primitives used here
+  (`Application.template`/`content(name)`/`.string`) are confirmed working on
+  the Emery emulator; a richer per-item list is a good next iteration.
 - **Storage/offline behavior**: cached via `device.keyValue`; Pebble's docs
   don't document a hard size limit for Emery, just "keep it minimal" — the
   cached payload here is a single small JSON blob, which should be safe.

--- a/pebble/package.json
+++ b/pebble/package.json
@@ -5,6 +5,7 @@
   "keywords": ["pebble-app"],
   "private": true,
   "scripts": {
+    "test": "node --test tests/offline.test.mjs",
     "validate": "node scripts/validate.mjs"
   },
   "dependencies": {

--- a/pebble/scripts/check-screenshot.py
+++ b/pebble/scripts/check-screenshot.py
@@ -1,0 +1,150 @@
+"""Assert that an emulator screenshot shows the Daynest watchapp, not a dead screen.
+
+A watchapp that throws during startup does not report an error anywhere the
+build or the logs can see it: PebbleOS just tears the app down and leaves a
+blank screen, and watch-side console output never reaches `pebble logs` in a
+release build. That is how the Piu font defect (#704) shipped. The only
+mechanical signal is the screen itself, so CI takes a screenshot and checks it
+here.
+
+Two things are asserted:
+
+  * the dominant colour is the app's dark background, so we are looking at the
+    Daynest screen rather than the launcher, a watchface or a blank panel; and
+  * enough pixels differ from it to be actual text, so a bare background from a
+    half-initialised app still fails.
+
+    python3 pebble/scripts/check-screenshot.py shot.png
+
+Only the standard library is used, so CI needs no extra install. The input is
+whatever `pebble screenshot` writes: 8-bit RGBA (PNG colour type 6).
+"""
+
+import argparse
+import struct
+import sys
+import zlib
+from collections import Counter
+from pathlib import Path
+
+
+def read_png_rgba(path):
+    """Decode an 8-bit RGBA PNG into a list of (r, g, b) pixels."""
+    data = path.read_bytes()
+    if data[:8] != b"\x89PNG\r\n\x1a\n":
+        raise ValueError(f"{path} is not a PNG")
+
+    width = height = None
+    idat = bytearray()
+    pos = 8
+    while pos < len(data):
+        (length,) = struct.unpack(">I", data[pos : pos + 4])
+        kind = data[pos + 4 : pos + 8]
+        payload = data[pos + 8 : pos + 8 + length]
+        pos += 12 + length  # length + type + payload + crc
+
+        if kind == b"IHDR":
+            width, height, depth, colour = struct.unpack(">IIBB", payload[:10])
+            if (depth, colour) != (8, 6):
+                raise ValueError(f"expected 8-bit RGBA, got depth {depth} colour type {colour}")
+        elif kind == b"IDAT":
+            idat += payload
+        elif kind == b"IEND":
+            break
+
+    if width is None:
+        raise ValueError(f"{path} has no IHDR")
+
+    raw = zlib.decompress(bytes(idat))
+    stride = width * 4
+    pixels = []
+    previous = bytearray(stride)
+    pos = 0
+    for _ in range(height):
+        filter_type = raw[pos]
+        line = bytearray(raw[pos + 1 : pos + 1 + stride])
+        pos += 1 + stride
+        for i in range(stride):
+            left = line[i - 4] if i >= 4 else 0
+            up = previous[i]
+            up_left = previous[i - 4] if i >= 4 else 0
+            if filter_type == 0:
+                value = line[i]
+            elif filter_type == 1:
+                value = line[i] + left
+            elif filter_type == 2:
+                value = line[i] + up
+            elif filter_type == 3:
+                value = line[i] + (left + up) // 2
+            elif filter_type == 4:
+                # Paeth
+                estimate = left + up - up_left
+                da, db, dc = (
+                    abs(estimate - left),
+                    abs(estimate - up),
+                    abs(estimate - up_left),
+                )
+                nearest = left if (da <= db and da <= dc) else (up if db <= dc else up_left)
+                value = line[i] + nearest
+            else:
+                raise ValueError(f"unsupported PNG filter {filter_type}")
+            line[i] = value & 0xFF
+        pixels.extend(
+            (line[i], line[i + 1], line[i + 2]) for i in range(0, stride, 4)
+        )
+        previous = line
+
+    return pixels
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Check an emulator screenshot renders the app.")
+    parser.add_argument("screenshot", type=Path)
+    parser.add_argument(
+        "--min-ink",
+        type=float,
+        default=0.5,
+        help="minimum %% of pixels differing from the background (default: 0.5)",
+    )
+    parser.add_argument(
+        "--max-background-level",
+        type=int,
+        default=120,
+        help="max mean RGB for the dominant colour to count as the dark app background",
+    )
+    args = parser.parse_args()
+
+    pixels = read_png_rgba(args.screenshot)
+    counts = Counter(pixels)
+    background, background_count = counts.most_common(1)[0]
+    ink = 100.0 * (len(pixels) - background_count) / len(pixels)
+    level = sum(background) / 3
+
+    print(
+        f"{args.screenshot}: {len(counts)} colours, "
+        f"background rgb{background} (level {level:.0f}), ink {ink:.2f}%"
+    )
+
+    problems = []
+    if level > args.max_background_level:
+        problems.append(
+            f"dominant colour rgb{background} is too light for the app's dark background — "
+            "the watchapp is probably not on screen (crashed at startup, or the launcher is showing)"
+        )
+    if ink < args.min_ink:
+        problems.append(
+            f"only {ink:.2f}% of pixels differ from the background "
+            f"(need {args.min_ink}%) — the screen looks empty, so nothing was drawn"
+        )
+
+    if problems:
+        for problem in problems:
+            print(f"FAIL: {problem}", file=sys.stderr)
+        return 1
+
+    print("OK: the watchapp rendered.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/pebble/scripts/mock-server.py
+++ b/pebble/scripts/mock-server.py
@@ -1,0 +1,127 @@
+"""Mock of Daynest's Pebble integration routes, for testing the watchapp.
+
+Mirrors backend/app/api/routes/integrations/pebble.py:
+
+    GET  /api/integrations/pebble/dashboard              (pebble:read)
+    POST /api/integrations/pebble/actions/complete-task  (pebble:write)
+    POST /api/integrations/pebble/actions/skip-task      (pebble:write)
+
+Every request is appended to a log file, which is the point: the acceptance
+criteria about repeated button presses and cache replay are claims about what
+the server received, not about what the watch displayed. Three rapid SELECT
+presses should leave exactly one "POST complete" line behind.
+
+    python3 pebble/scripts/mock-server.py [port] [--host H] [--key K]
+
+Point the watch at it through the pairing flow, or directly:
+
+    pebble send-app-message --emulator emery \
+      --string 10000=http://127.0.0.1:8899 10001=test-pebble-key
+
+See ../EMULATOR.md.
+"""
+
+import argparse
+import json
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from pathlib import Path
+
+DASHBOARD_PATH = "/api/integrations/pebble/dashboard"
+COMPLETE_PATH = "/api/integrations/pebble/actions/complete-task"
+SKIP_PATH = "/api/integrations/pebble/actions/skip-task"
+
+STATE = {
+    "due_today_count": 3,
+    "overdue_count": 2,
+    "due_today": [
+        {"chore_instance_id": 101, "title": "Water plants", "status": "pending"},
+        {"chore_instance_id": 102, "title": "Take out bins", "status": "pending"},
+        {"chore_instance_id": 103, "title": "Vacuum hallway", "status": "pending"},
+    ],
+}
+
+
+class Handler(BaseHTTPRequestHandler):
+    api_key = "test-pebble-key"
+    log_path = Path("requests.log")
+
+    def log_message(self, *args):
+        """Silence the default stderr access log; we keep our own."""
+
+    def record(self, line):
+        with self.log_path.open("a") as fh:
+            fh.write(line + "\n")
+        print(line, flush=True)
+
+    def authorized(self):
+        return self.headers.get("X-Integration-Key") == self.api_key
+
+    def respond(self, code, payload):
+        body = json.dumps(payload).encode()
+        self.send_response(code)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def do_GET(self):
+        if not self.authorized():
+            self.record(f"GET {self.path} -> 401 (bad or missing key)")
+            return self.respond(401, {"detail": "invalid integration key"})
+        if self.path != DASHBOARD_PATH:
+            self.record(f"GET {self.path} -> 404")
+            return self.respond(404, {"detail": "not found"})
+        self.record(f"GET {self.path} -> 200 ({STATE['due_today_count']} due)")
+        self.respond(200, STATE)
+
+    def do_POST(self):
+        length = int(self.headers.get("Content-Length") or 0)
+        raw = self.rfile.read(length).decode() if length else ""
+        if not self.authorized():
+            self.record(f"POST {self.path} {raw} -> 401 (bad or missing key)")
+            return self.respond(401, {"detail": "invalid integration key"})
+
+        if self.path == COMPLETE_PATH:
+            action = "complete"
+        elif self.path == SKIP_PATH:
+            action = "skip"
+        else:
+            self.record(f"POST {self.path} {raw} -> 404")
+            return self.respond(404, {"detail": "not found"})
+
+        try:
+            chore_instance_id = json.loads(raw).get("chore_instance_id")
+        except ValueError:
+            self.record(f"POST {action} -> 422 (unparseable body {raw!r})")
+            return self.respond(422, {"detail": "invalid body"})
+
+        self.record(f"POST {action} chore_instance_id={chore_instance_id}")
+        STATE["due_today"] = [
+            item for item in STATE["due_today"] if item["chore_instance_id"] != chore_instance_id
+        ]
+        STATE["due_today_count"] = len(STATE["due_today"])
+        self.respond(200, {"success": True, "detail": f"Task {chore_instance_id} {action}d"})
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Mock Daynest Pebble integration API.")
+    parser.add_argument("port", nargs="?", type=int, default=8899)
+    parser.add_argument(
+        "--host",
+        default="127.0.0.1",
+        help="bind address; use 0.0.0.0 to reach it from a watch on the network",
+    )
+    parser.add_argument("--key", default=Handler.api_key, help="expected X-Integration-Key")
+    parser.add_argument("--log", default="requests.log", help="request log file")
+    args = parser.parse_args()
+
+    Handler.api_key = args.key
+    Handler.log_path = Path(args.log)
+    Handler.log_path.write_text("")
+
+    print(f"mock Daynest Pebble API on http://{args.host}:{args.port} (log: {args.log})")
+    HTTPServer((args.host, args.port), Handler).serve_forever()
+
+
+if __name__ == "__main__":
+    main()

--- a/pebble/scripts/validate.mjs
+++ b/pebble/scripts/validate.mjs
@@ -50,6 +50,15 @@ if (!watchSource.includes("fetch(")) throw new Error("Watch code must use Alloy 
 for (const action of ["complete-task", "skip-task"]) {
   if (!watchSource.includes(action)) throw new Error(`Missing Daynest action: ${action}`);
 }
+if (!watchSource.includes("SNAPSHOT_MAX_AGE_SECONDS") || !watchSource.includes("loadCachedDashboard(")) {
+  throw new Error("Watch code must persist and age-limit the offline dashboard snapshot");
+}
+if (!watchSource.includes("!dashboardIsLive && !(await refresh())")) {
+  throw new Error("Cached task state must be re-read before choosing a mutation");
+}
+if (!watchSource.includes("runExclusive(() => runAction(")) {
+  throw new Error("Task actions must go through the exclusive-action guard");
+}
 if (!phoneSource.includes("@moddable/pebbleproxy")) {
   throw new Error("Phone code must initialize the official Alloy network proxy");
 }

--- a/pebble/scripts/validate.mjs
+++ b/pebble/scripts/validate.mjs
@@ -62,6 +62,32 @@ for (const scope of ["pebble:read", "pebble:write"]) {
   }
 }
 
+// Piu resolves `font` against PebbleOS's built-in font table. An unknown family
+// throws an uncaught URIError that kills the watchapp the moment it starts, and
+// nothing in the build catches it — so pin the families here instead.
+const PEBBLE_FONT_FAMILIES = ["Gothic", "Bitham", "Roboto", "DroidSerif", "Leco"];
+for (const [, font] of watchSource.matchAll(/font:\s*"([^"]+)"/g)) {
+  const match = /^(?:italic\s+)?(?:\w+\s+)?\d+px\s+(\w+)$/.exec(font);
+  if (!match || !PEBBLE_FONT_FAMILIES.includes(match[1])) {
+    throw new Error(
+      `Unsupported Piu font ${JSON.stringify(font)}: use "<size>px <family>" with one of ` +
+        PEBBLE_FONT_FAMILIES.join(", "),
+    );
+  }
+}
+
+// PKJS is bundled by the SDK's webpack/acorn, which predates ES2017 trailing
+// commas in argument lists — one is a hard build failure, so keep them out.
+if (/,\s*[)\]]/.test(phoneSource)) {
+  throw new Error("Trailing comma in src/pkjs/index.js: the SDK's PKJS bundler cannot parse it");
+}
+
+// The proxy owns the PKJS send queue; bypassing it can drop messages when a
+// fetch() is in flight (see @moddable/pebbleproxy's README).
+if (/Pebble\.sendAppMessage\s*\(/.test(phoneSource)) {
+  throw new Error("Use moddableProxy.sendAppMessage() so sends are queued behind proxy traffic");
+}
+
 for (const file of ["src/embeddedjs/main.js", "src/pkjs/index.js"]) {
   execFileSync(process.execPath, ["--check", resolve(root, file)], { stdio: "inherit" });
 }

--- a/pebble/src/embeddedjs/main.js
+++ b/pebble/src/embeddedjs/main.js
@@ -77,6 +77,7 @@ function loadCachedDashboard() {
       snapshot.version !== SNAPSHOT_VERSION ||
       !snapshot.dashboard ||
       !snapshot.fetchedAt ||
+      age < 0 ||
       age > SNAPSHOT_MAX_AGE_SECONDS
     ) {
       clearCachedDashboard();
@@ -186,14 +187,17 @@ async function refresh() {
     showStale("Phone offline");
     return false;
   }
+  const generation = identityGeneration;
   try {
     const dashboard = await fetchDashboard();
+    if (generation !== identityGeneration) return false;
     lastDashboard = dashboard;
     saveCachedDashboard(dashboard);
     dashboardIsLive = true;
     renderDashboard(dashboard);
     return true;
   } catch (e) {
+    if (generation !== identityGeneration) return false;
     console.log(`Daynest refresh failed: ${e}`);
     showStale(String(e.message || e));
     return false;
@@ -201,15 +205,26 @@ async function refresh() {
 }
 
 let busy = false;
+let identityGeneration = 0;
+let refreshOwed = false;
 
 async function runExclusive(action) {
   if (busy) return;
   busy = true;
   try {
     await action();
+    while (refreshOwed) {
+      refreshOwed = false;
+      await refresh();
+    }
   } finally {
     busy = false;
   }
+}
+
+function requestRefresh() {
+  if (busy) refreshOwed = true;
+  else runExclusive(refresh);
 }
 
 async function runAction(kind) {
@@ -221,9 +236,11 @@ async function runAction(kind) {
     showStale("Phone offline");
     return;
   }
+  const generation = identityGeneration;
   // Cached state is display-only. Re-read before selecting a task so an item
   // completed or skipped elsewhere cannot be replayed from a stale snapshot.
   if (!dashboardIsLive && !(await refresh())) return;
+  if (generation !== identityGeneration) return;
   const items = lastDashboard && lastDashboard.due_today;
   if (!items || items.length === 0) return;
 
@@ -232,6 +249,7 @@ async function runAction(kind) {
   dashboardIsLive = false;
   try {
     await postAction(path, { chore_instance_id: item.chore_instance_id });
+    if (generation !== identityGeneration) return;
     // Drop the acted-on item locally before refreshing so a failed/slow
     // live refetch that falls back to cache can't replay the same action.
     lastDashboard = Object.assign({}, lastDashboard, {
@@ -245,6 +263,7 @@ async function runAction(kind) {
     });
     await refresh();
   } catch (e) {
+    if (generation !== identityGeneration) return;
     console.log(`Daynest ${kind} action failed: ${e}`);
     // A conflict means server state moved under us. Resolve by reading; never
     // retry a mutation whose outcome is uncertain.
@@ -261,6 +280,7 @@ const message = new Message({
     const token = payload.get("AUTH_TOKEN");
     const nextBaseUrl = baseUrl ? baseUrl.replace(/\/$/, "") : apiBaseUrl;
     if (nextBaseUrl !== apiBaseUrl || (token && token !== authToken)) {
+      identityGeneration += 1;
       clearCachedDashboard();
       dashboardIsLive = false;
     }
@@ -272,12 +292,12 @@ const message = new Message({
       authToken = token;
       localStorage.setItem("authToken", authToken);
     }
-    runExclusive(refresh);
+    requestRefresh();
   },
 });
 
-watch.addEventListener("connected", () => runExclusive(refresh));
-runExclusive(refresh);
+watch.addEventListener("connected", requestRefresh);
+requestRefresh();
 
 new Button({
   types: ["up", "select", "down"],

--- a/pebble/src/embeddedjs/main.js
+++ b/pebble/src/embeddedjs/main.js
@@ -14,6 +14,8 @@ const DEFAULT_API_BASE_URL = "https://daynest.tjor.im";
 
 const CACHE_PATH = "daynest-today";
 const CACHE_KEY = "dashboard";
+const SNAPSHOT_VERSION = 1;
+const SNAPSHOT_MAX_AGE_SECONDS = 12 * 60 * 60;
 
 // Piu resolves `font` through PebbleOS's built-in font table, so only the
 // system families/sizes are available (Gothic 9/14/18/24/28/36, Bitham,
@@ -38,8 +40,30 @@ const application = new DaynestApplication(null, { displayListLength: 4096 });
 
 let apiBaseUrl = localStorage.getItem("apiBaseUrl") || DEFAULT_API_BASE_URL;
 let authToken = localStorage.getItem("authToken");
-let lastDashboard = loadCachedDashboard();
-renderDashboard(lastDashboard, { stale: !!lastDashboard });
+let dashboardIsLive = false;
+const pad = value => (value < 10 ? `0${value}` : String(value));
+let cachedSnapshot = null;
+let lastDashboard = null;
+
+function formatClock(epochSeconds) {
+  const date = new Date(epochSeconds * 1000);
+  return `${pad(date.getHours())}:${pad(date.getMinutes())}`;
+}
+
+cachedSnapshot = loadCachedDashboard();
+lastDashboard = cachedSnapshot && cachedSnapshot.dashboard;
+renderDashboard(lastDashboard, {
+  staleReason: cachedSnapshot ? "Last known" : null,
+  fetchedAt: cachedSnapshot && cachedSnapshot.fetchedAt,
+});
+
+function clearCachedDashboard() {
+  const store = device.keyValue.open({ path: CACHE_PATH, format: "string" });
+  store.delete(CACHE_KEY);
+  store.close();
+  cachedSnapshot = null;
+  lastDashboard = null;
+}
 
 function loadCachedDashboard() {
   const store = device.keyValue.open({ path: CACHE_PATH, format: "string" });
@@ -47,20 +71,37 @@ function loadCachedDashboard() {
   store.close();
   if (!raw) return null;
   try {
-    return JSON.parse(raw);
+    const snapshot = JSON.parse(raw);
+    const age = Math.floor(Date.now() / 1000) - snapshot.fetchedAt;
+    if (
+      snapshot.version !== SNAPSHOT_VERSION ||
+      !snapshot.dashboard ||
+      !snapshot.fetchedAt ||
+      age > SNAPSHOT_MAX_AGE_SECONDS
+    ) {
+      clearCachedDashboard();
+      return null;
+    }
+    return snapshot;
   } catch (error) {
     console.log(`Daynest: invalid cached dashboard: ${error}`);
+    clearCachedDashboard();
     return null;
   }
 }
 
 function saveCachedDashboard(dashboard) {
+  cachedSnapshot = {
+    version: SNAPSHOT_VERSION,
+    fetchedAt: Math.floor(Date.now() / 1000),
+    dashboard,
+  };
   const store = device.keyValue.open({ path: CACHE_PATH, format: "string" });
-  store.write(CACHE_KEY, JSON.stringify(dashboard));
+  store.write(CACHE_KEY, JSON.stringify(cachedSnapshot));
   store.close();
 }
 
-function renderDashboard(dashboard, { stale = false } = {}) {
+function renderDashboard(dashboard, { staleReason = null, fetchedAt = null } = {}) {
   const statusText = application.content("status");
   if (!dashboard) {
     statusText.string = "Daynest\n\nNo data yet.\nWaiting for phone…";
@@ -83,7 +124,10 @@ function renderDashboard(dashboard, { stale = false } = {}) {
     lines.push("skips the first item.");
   }
 
-  if (stale) lines.push("\n(cached — offline)");
+  if (staleReason) {
+    const when = fetchedAt ? ` · ${formatClock(fetchedAt)}` : "";
+    lines.push(`\n${staleReason}${when}`);
+  }
 
   statusText.string = lines.join("\n");
 }
@@ -92,7 +136,7 @@ async function fetchDashboard() {
   const response = await fetch(`${apiBaseUrl}${DASHBOARD_PATH}`, {
     headers: { "X-Integration-Key": authToken },
   });
-  if (!response.ok) throw new Error(`dashboard fetch failed: HTTP ${response.status}`);
+  if (!response.ok) throw apiError(response.status);
   return response.json();
 }
 
@@ -105,42 +149,87 @@ async function postAction(path, body) {
     },
     body: JSON.stringify(body),
   });
-  if (!response.ok) throw new Error(`action failed: HTTP ${response.status}`);
+  if (!response.ok) throw apiError(response.status);
   return response.json();
+}
+
+function apiError(status) {
+  const error = new Error(
+    status === 401 || status === 403
+      ? "Sign-in needed"
+      : status === 429 || status >= 500
+        ? `Try again later (${status})`
+        : `Request failed (${status})`,
+  );
+  error.status = status;
+  return error;
+}
+
+function showStale(reason) {
+  dashboardIsLive = false;
+  renderDashboard(lastDashboard, {
+    staleReason: lastDashboard ? reason : null,
+    fetchedAt: cachedSnapshot && cachedSnapshot.fetchedAt,
+  });
+  if (!lastDashboard) application.content("status").string = `Daynest\n\n${reason}`;
 }
 
 async function refresh() {
   if (!authToken) {
+    dashboardIsLive = false;
     application.content("status").string =
       "Daynest\n\nNot configured.\nOpen Settings in the\nPebble phone app.";
-    return;
+    return false;
   }
   if (!watch.connected.pebblekit) {
     console.log("Daynest: proxy not ready yet, showing cache");
-    renderDashboard(lastDashboard, { stale: !!lastDashboard });
-    return;
+    showStale("Phone offline");
+    return false;
   }
   try {
     const dashboard = await fetchDashboard();
     lastDashboard = dashboard;
     saveCachedDashboard(dashboard);
+    dashboardIsLive = true;
     renderDashboard(dashboard);
+    return true;
   } catch (e) {
     console.log(`Daynest refresh failed: ${e}`);
-    renderDashboard(lastDashboard, { stale: !!lastDashboard });
+    showStale(String(e.message || e));
+    return false;
   }
 }
 
-let actionInFlight = false;
+let busy = false;
+
+async function runExclusive(action) {
+  if (busy) return;
+  busy = true;
+  try {
+    await action();
+  } finally {
+    busy = false;
+  }
+}
 
 async function runAction(kind) {
-  if (actionInFlight) return;
+  if (!authToken) {
+    await refresh();
+    return;
+  }
+  if (!watch.connected.pebblekit) {
+    showStale("Phone offline");
+    return;
+  }
+  // Cached state is display-only. Re-read before selecting a task so an item
+  // completed or skipped elsewhere cannot be replayed from a stale snapshot.
+  if (!dashboardIsLive && !(await refresh())) return;
   const items = lastDashboard && lastDashboard.due_today;
   if (!items || items.length === 0) return;
 
   const item = items[0];
   const path = kind === "complete" ? COMPLETE_TASK_PATH : SKIP_TASK_PATH;
-  actionInFlight = true;
+  dashboardIsLive = false;
   try {
     await postAction(path, { chore_instance_id: item.chore_instance_id });
     // Drop the acted-on item locally before refreshing so a failed/slow
@@ -150,12 +239,17 @@ async function runAction(kind) {
       due_today_count: Math.max(0, (lastDashboard.due_today_count || items.length) - 1),
     });
     saveCachedDashboard(lastDashboard);
-    renderDashboard(lastDashboard, { stale: true });
+    renderDashboard(lastDashboard, {
+      staleReason: "Updating",
+      fetchedAt: cachedSnapshot.fetchedAt,
+    });
     await refresh();
   } catch (e) {
     console.log(`Daynest ${kind} action failed: ${e}`);
-  } finally {
-    actionInFlight = false;
+    // A conflict means server state moved under us. Resolve by reading; never
+    // retry a mutation whose outcome is uncertain.
+    if (e.status === 409) await refresh();
+    else showStale(String(e.message || e));
   }
 }
 
@@ -165,27 +259,32 @@ const message = new Message({
     const payload = this.read();
     const baseUrl = payload.get("API_BASE_URL");
     const token = payload.get("AUTH_TOKEN");
+    const nextBaseUrl = baseUrl ? baseUrl.replace(/\/$/, "") : apiBaseUrl;
+    if (nextBaseUrl !== apiBaseUrl || (token && token !== authToken)) {
+      clearCachedDashboard();
+      dashboardIsLive = false;
+    }
     if (baseUrl) {
-      apiBaseUrl = baseUrl.replace(/\/$/, "");
+      apiBaseUrl = nextBaseUrl;
       localStorage.setItem("apiBaseUrl", apiBaseUrl);
     }
     if (token) {
       authToken = token;
       localStorage.setItem("authToken", authToken);
     }
-    refresh();
+    runExclusive(refresh);
   },
 });
 
-watch.addEventListener("connected", refresh);
-refresh();
+watch.addEventListener("connected", () => runExclusive(refresh));
+runExclusive(refresh);
 
 new Button({
   types: ["up", "select", "down"],
   onPush(down, type) {
     if (!down) return;
-    if (type === "up") refresh();
-    else if (type === "select") runAction("complete");
-    else if (type === "down") runAction("skip");
+    if (type === "up") runExclusive(refresh);
+    else if (type === "select") runExclusive(() => runAction("complete"));
+    else if (type === "down") runExclusive(() => runAction("skip"));
   },
 });

--- a/pebble/src/embeddedjs/main.js
+++ b/pebble/src/embeddedjs/main.js
@@ -15,8 +15,12 @@ const DEFAULT_API_BASE_URL = "https://daynest.tjor.im";
 const CACHE_PATH = "daynest-today";
 const CACHE_KEY = "dashboard";
 
+// Piu resolves `font` through PebbleOS's built-in font table, so only the
+// system families/sizes are available (Gothic 9/14/18/24/28/36, Bitham,
+// Roboto, Droid Serif, Leco — regular or bold). An unknown family throws an
+// uncaught "font not found" URIError that kills the app at startup.
 const backgroundSkin = new Skin({ fill: "black" });
-const bodyStyle = new Style({ font: "OpenSans-Regular-15", color: "white", horizontal: "left", vertical: "top" });
+const bodyStyle = new Style({ font: "14px Gothic", color: "white", horizontal: "left", vertical: "top" });
 
 const DaynestApplication = Application.template($ => ({
   skin: backgroundSkin,

--- a/pebble/src/pkjs/index.js
+++ b/pebble/src/pkjs/index.js
@@ -20,17 +20,20 @@ Pebble.addEventListener("webviewclosed", function (event) {
   try {
     const result = JSON.parse(decodeURIComponent(event.response));
     if (!result.accessToken) return;
-    Pebble.sendAppMessage(
+    // Use the proxy's queue rather than Pebble.sendAppMessage directly: PKJS
+    // allows only a small number of simultaneously enqueued messages, and the
+    // proxy is already using that budget for in-flight fetch() traffic.
+    moddableProxy.sendAppMessage(
       {
         API_BASE_URL: "https://daynest.tjor.im",
-        AUTH_TOKEN: result.accessToken,
+        AUTH_TOKEN: result.accessToken
       },
       function () {
         console.log("Daynest: pairing token relayed to watch");
       },
       function (error) {
-        console.log(`Daynest: failed to relay pairing token: ${JSON.stringify(error)}`);
-      },
+        console.log("Daynest: failed to relay pairing token: " + JSON.stringify(error));
+      }
     );
   } catch (error) {
     console.log(`Daynest: failed to parse pairing response: ${error}`);

--- a/pebble/tests/harness.mjs
+++ b/pebble/tests/harness.mjs
@@ -1,0 +1,179 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { createContext, runInContext } from "node:vm";
+
+const MAIN_PATH = resolve(import.meta.dirname, "../src/embeddedjs/main.js");
+const pause = (milliseconds) => new Promise((done) => setTimeout(done, milliseconds));
+
+function stripImports(source) {
+  return source.replace(/^import .*;\s*$/gm, "");
+}
+
+export const DASHBOARD_PATH = "/api/integrations/pebble/dashboard";
+export const COMPLETE_PATH = "/api/integrations/pebble/actions/complete-task";
+export const SKIP_PATH = "/api/integrations/pebble/actions/skip-task";
+
+export function dashboard(firstId = 101) {
+  return {
+    due_today_count: 2,
+    overdue_count: 1,
+    due_today: [
+      { chore_instance_id: firstId, title: `Task ${firstId}`, status: "pending" },
+      { chore_instance_id: firstId + 1, title: `Task ${firstId + 1}`, status: "pending" },
+    ],
+  };
+}
+
+export function snapshot(value, ageSeconds = 0) {
+  return JSON.stringify({
+    version: 1,
+    fetchedAt: Math.floor(Date.now() / 1000) - ageSeconds,
+    dashboard: value,
+  });
+}
+
+export function createHarness({
+  connected = true,
+  storage = {},
+  cachedDashboard = null,
+  responder = () => ({ status: 200, body: dashboard() }),
+} = {}) {
+  const localStore = new Map(Object.entries(storage));
+  const keyValueStore = new Map();
+  if (cachedDashboard) keyValueStore.set("dashboard", cachedDashboard);
+  const requests = [];
+  const listeners = new Map();
+  const inFlight = new Set();
+  const hooks = {};
+  let respond = responder;
+
+  class Button {
+    constructor(spec) {
+      hooks.onPush = spec.onPush;
+    }
+  }
+
+  class Message {
+    constructor(spec) {
+      this.onReadable = spec.onReadable;
+      hooks.message = this;
+    }
+  }
+
+  const Application = {
+    template(build) {
+      return class FakeApplication {
+        constructor(_parent, data) {
+          const spec = build(data);
+          this.status = spec.contents[0];
+          hooks.application = this;
+        }
+        content(name) {
+          return name === "status" ? this.status : null;
+        }
+      };
+    },
+  };
+
+  const context = createContext({
+    Application,
+    Button,
+    Message,
+    Skin: class Skin {},
+    Style: class Style {},
+    Text: (_data, spec) => ({ ...spec }),
+    console,
+    device: {
+      keyValue: {
+        open: () => ({
+          read: (key) => keyValueStore.get(key),
+          write: (key, value) => keyValueStore.set(key, String(value)),
+          delete: (key) => keyValueStore.delete(key),
+          close: () => {},
+        }),
+      },
+    },
+    localStorage: {
+      getItem: (key) => (localStore.has(key) ? localStore.get(key) : null),
+      setItem: (key, value) => localStore.set(key, String(value)),
+    },
+    watch: {
+      connected: { pebblekit: connected },
+      addEventListener: (type, handler) => listeners.set(type, handler),
+    },
+    fetch: (url, options = {}) => {
+      requests.push({
+        url,
+        method: options.method || "GET",
+        headers: options.headers,
+        body: options.body,
+      });
+      const work = (async () => {
+        const { status, body } = await respond(url, options);
+        return {
+          status,
+          ok: status >= 200 && status < 300,
+          json: async () => body,
+        };
+      })();
+      inFlight.add(work);
+      const forget = () => inFlight.delete(work);
+      work.then(forget, forget);
+      return work;
+    },
+  });
+
+  runInContext(stripImports(readFileSync(MAIN_PATH, "utf8")), context, {
+    filename: "main.js",
+  });
+
+  async function settle(timeoutMs = 2000) {
+    const deadline = Date.now() + timeoutMs;
+    for (;;) {
+      if (inFlight.size) {
+        await Promise.race([Promise.allSettled([...inFlight]), pause(5)]);
+      }
+      for (let index = 0; index < 20; index += 1) await Promise.resolve();
+      await pause(0);
+      if (!inFlight.size) return;
+      if (Date.now() > deadline) throw new Error("watch app did not settle");
+    }
+  }
+
+  return {
+    requests,
+    get status() {
+      return hooks.application.status.string;
+    },
+    get cachedDashboard() {
+      return keyValueStore.get("dashboard");
+    },
+    get stored() {
+      return Object.fromEntries(localStore);
+    },
+    setConnected(value) {
+      context.watch.connected.pebblekit = value;
+    },
+    setResponder(handler) {
+      respond = handler;
+    },
+    async settle() {
+      await settle();
+    },
+    async press(type, wait = true) {
+      hooks.onPush(true, type);
+      if (wait) await settle();
+    },
+    async reconnect() {
+      context.watch.connected.pebblekit = true;
+      listeners.get("connected")?.();
+      await settle();
+    },
+    async configure(payload) {
+      const message = new Map(Object.entries(payload));
+      hooks.message.read = () => message;
+      hooks.message.onReadable.call(hooks.message);
+      await settle();
+    },
+  };
+}

--- a/pebble/tests/harness.mjs
+++ b/pebble/tests/harness.mjs
@@ -175,5 +175,8 @@ export function createHarness({
       hooks.message.onReadable.call(hooks.message);
       await settle();
     },
+    emit(type) {
+      listeners.get(type)?.();
+    },
   };
 }

--- a/pebble/tests/offline.test.mjs
+++ b/pebble/tests/offline.test.mjs
@@ -52,6 +52,19 @@ test("a cache older than 12 hours is discarded", async () => {
   assert.equal(harness.cachedDashboard, undefined);
 });
 
+test("a snapshot stamped in the future is discarded", async () => {
+  const harness = createHarness({
+    connected: false,
+    storage: TOKEN,
+    cachedDashboard: snapshot(dashboard(), -600),
+  });
+
+  await harness.settle();
+
+  assert.match(harness.status, /Phone offline/);
+  assert.equal(harness.cachedDashboard, undefined);
+});
+
 test("cached task state is re-read before choosing a mutation", async () => {
   const harness = createHarness({
     connected: false,
@@ -131,4 +144,65 @@ test("a changed pairing clears data from the previous account", async () => {
 
   assert.equal(harness.cachedDashboard, undefined);
   assert.match(harness.status, /Phone offline/);
+});
+
+function heldResponder(body) {
+  let release;
+  return [
+    () => ({
+      status: 200,
+      body: new Promise((resolve) => {
+        release = () => resolve(body);
+      }),
+    }),
+    () => release(),
+  ];
+}
+
+test("a reconnect during another request is serviced", async () => {
+  const [held, release] = heldResponder(dashboard());
+  const harness = createHarness({ storage: TOKEN, responder: held });
+  await harness.settle();
+
+  harness.emit("connected");
+  release();
+  await harness.settle();
+
+  assert.deepEqual(paths(harness), [DASHBOARD_PATH, DASHBOARD_PATH]);
+});
+
+test("an old account response is never cached after pairing changes", async () => {
+  const [held, release] = heldResponder(dashboard(101));
+  const harness = createHarness({ storage: TOKEN, responder: held });
+  await harness.settle();
+
+  await harness.configure({ AUTH_TOKEN: "other_key" });
+  harness.setResponder(() => ({ status: 503, body: {} }));
+  release();
+  await harness.settle();
+
+  assert.match(harness.status, /Try again later \(503\)/);
+  assert.equal(harness.cachedDashboard, undefined);
+  assert.equal(harness.requests.at(-1).headers["X-Integration-Key"], "other_key");
+});
+
+test("a mutation after pairing changes uses the new account state", async () => {
+  const [held, release] = heldResponder(dashboard(101));
+  const harness = createHarness({ storage: TOKEN, responder: held });
+  await harness.settle();
+
+  await harness.configure({ AUTH_TOKEN: "other_key" });
+  harness.setResponder((url) =>
+    url.endsWith(DASHBOARD_PATH)
+      ? { status: 200, body: dashboard(201) }
+      : { status: 200, body: {} },
+  );
+  release();
+  await harness.settle();
+  harness.requests.length = 0;
+
+  await harness.press("select");
+
+  assert.deepEqual(paths(harness), [COMPLETE_PATH, DASHBOARD_PATH]);
+  assert.equal(JSON.parse(harness.requests[0].body).chore_instance_id, 201);
 });

--- a/pebble/tests/offline.test.mjs
+++ b/pebble/tests/offline.test.mjs
@@ -1,0 +1,134 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import {
+  COMPLETE_PATH,
+  DASHBOARD_PATH,
+  createHarness,
+  dashboard,
+  snapshot,
+} from "./harness.mjs";
+
+const TOKEN = {
+  authToken: "daynest_key",
+  apiBaseUrl: "https://example.test",
+};
+
+const paths = (harness) =>
+  harness.requests.map((request) => new URL(request.url).pathname);
+
+test("a live dashboard is rendered and cached", async () => {
+  const harness = createHarness({ storage: TOKEN });
+
+  await harness.settle();
+
+  assert.match(harness.status, /Task 101/);
+  assert.equal(JSON.parse(harness.cachedDashboard).dashboard.due_today[0].chore_instance_id, 101);
+});
+
+test("an offline cold start shows the cached dashboard without fetching", async () => {
+  const harness = createHarness({
+    connected: false,
+    storage: TOKEN,
+    cachedDashboard: snapshot(dashboard()),
+  });
+
+  await harness.settle();
+
+  assert.match(harness.status, /Task 101/);
+  assert.match(harness.status, /Phone offline · \d\d:\d\d/);
+  assert.deepEqual(harness.requests, []);
+});
+
+test("a cache older than 12 hours is discarded", async () => {
+  const harness = createHarness({
+    connected: false,
+    storage: TOKEN,
+    cachedDashboard: snapshot(dashboard(), 13 * 60 * 60),
+  });
+
+  await harness.settle();
+
+  assert.match(harness.status, /Phone offline/);
+  assert.equal(harness.cachedDashboard, undefined);
+});
+
+test("cached task state is re-read before choosing a mutation", async () => {
+  const harness = createHarness({
+    connected: false,
+    storage: TOKEN,
+    cachedDashboard: snapshot(dashboard(101)),
+    responder: (url) =>
+      url.endsWith(DASHBOARD_PATH)
+        ? { status: 200, body: dashboard(201) }
+        : { status: 200, body: {} },
+  });
+  await harness.settle();
+  harness.setConnected(true);
+
+  await harness.press("select");
+
+  assert.deepEqual(paths(harness), [DASHBOARD_PATH, COMPLETE_PATH, DASHBOARD_PATH]);
+  assert.equal(JSON.parse(harness.requests[1].body).chore_instance_id, 201);
+});
+
+test("repeated SELECT presses submit one mutation", async () => {
+  let release;
+  const harness = createHarness({
+    storage: TOKEN,
+    responder: (url) => {
+      if (url.endsWith(DASHBOARD_PATH)) return { status: 200, body: dashboard() };
+      return new Promise((done) => {
+        release = () => done({ status: 200, body: {} });
+      });
+    },
+  });
+  await harness.settle();
+  harness.requests.length = 0;
+
+  await harness.press("select", false);
+  await harness.press("select", false);
+  await harness.press("select", false);
+  await new Promise((done) => setTimeout(done, 0));
+
+  assert.deepEqual(
+    paths(harness).filter((path) => path === COMPLETE_PATH),
+    [COMPLETE_PATH],
+  );
+  release();
+  await harness.settle();
+});
+
+test("a conflict re-reads the dashboard without retrying", async () => {
+  let dashboardReads = 0;
+  const harness = createHarness({
+    storage: TOKEN,
+    responder: (url) => {
+      if (url.endsWith(DASHBOARD_PATH)) {
+        dashboardReads += 1;
+        return { status: 200, body: dashboard(dashboardReads === 1 ? 101 : 201) };
+      }
+      return { status: 409, body: {} };
+    },
+  });
+  await harness.settle();
+  harness.requests.length = 0;
+
+  await harness.press("select");
+
+  assert.deepEqual(paths(harness), [COMPLETE_PATH, DASHBOARD_PATH]);
+  assert.match(harness.status, /Task 201/);
+});
+
+test("a changed pairing clears data from the previous account", async () => {
+  const harness = createHarness({
+    connected: false,
+    storage: TOKEN,
+    cachedDashboard: snapshot(dashboard()),
+  });
+  await harness.settle();
+
+  await harness.configure({ AUTH_TOKEN: "other_key" });
+
+  assert.equal(harness.cachedDashboard, undefined);
+  assert.match(harness.status, /Phone offline/);
+});


### PR DESCRIPTION
Work towards #704. I don't have a Pebble Time 2, so the hardware sign-off in that issue is still open — but a lot of it turned out to be automatable, and doing so found two defects that would have stopped the smoke test at step one.

I installed the Pebble SDK (`uv tool install pebble-tool` + `pebble sdk install latest`, SDK 4.17) and ran the package through `pebble build` and the Emery QEMU emulator.

## What was broken

**The package did not build.** `src/pkjs/index.js` had a trailing comma in an argument list — ordinary formatting for this repo, but the SDK bundles PKJS with an ES2015-era acorn for which it is a hard `SyntaxError`.

**Once it built, the watchapp died instantly.** It asked Piu for `"OpenSans-Regular-15"`. Piu resolves fonts against PebbleOS's built-in table (`Gothic`, `Bitham`, `Roboto`, `DroidSerif`, `Leco`, at fixed sizes, via CSS shorthand), so `new Style(...)` threw an uncaught `font not found` URIError and the app exited to a blank screen. Nothing appeared in `pebble logs` to explain it, because watch-side `console.log` doesn't reach the log in release builds — worth knowing before debugging this on a watch. It now uses `"14px Gothic"`.

**The pairing token bypassed the proxy's send queue.** `@moddable/pebbleproxy`'s README is explicit that PKJS allows only a few simultaneously enqueued messages and that senders should use `moddableProxy.sendAppMessage()`; the proxy is already spending that budget on in-flight `fetch()` traffic. Switched.

Both build/run defects now have regression guards in `pebble/scripts/validate.mjs`, which already runs in Pebble CI.

## What now works

- Builds for `emery` and `gabbro`, producing a `.pbw`.
- Installs, launches and renders on the Emery emulator.
- The unconfigured state renders correctly, and pushing `API_BASE_URL`/`AUTH_TOKEN` as an app message reaches the watch and is read back correctly — so the config path from the phone is sound.
- The full glance layout fits on Emery's 200×228 at `14px Gothic`, and `—`, `•` and `…` all have glyph coverage.

## What still needs a real watch

Watch-side `fetch()` never completes under QEMU + pypkjs. The request is queued and the HTTP proxy never receives it: the Moddable AppMessage channel it rides on never becomes writable, because PebbleOS gates that on a system comm session pypkjs doesn't establish. A minimal fetch-only app containing no Daynest code stalls identically, so this is an emulator limit rather than an app bug — but it does mean live dashboard loading, complete/skip, offline cache fallback and the mutation-replay guards can only be signed off on hardware. `pebble/README.md` now carries a checklist for exactly those items.

## Also

- `pebble/README.md`: replaced the "early scaffold, not hardware-tested" warning with the verified toolchain and build/run instructions, the findings above, and the hardware smoke test.
- `CHANGELOG.md`: the `2026.7.2` entry no longer describes the Pebble companion as merely planned, and records the fixes.

I'd suggest keeping #704 open until the hardware checklist is done.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018aZTL25PeJcGutVF5N9rwV

---
_Generated by [Claude Code](https://claude.ai/code/session_018aZTL25PeJcGutVF5N9rwV)_