### PR TITLE
ci(frontend): bump frontend-ci Node.js to 22

### DIFF
--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: '20'
+          node-version: '22'
           cache: pnpm
           cache-dependency-path: frontend/pnpm-lock.yaml
 


### PR DESCRIPTION
## Summary
- The `frontend-ci` workflow ([job](https://github.com/tjorim/daynest/actions/runs/30654929933/job/91236885419?pr=717)) is failing on dependabot PR #717 (jsdom 29.1.1 → 30.0.0) with `TypeError: webidl.util.markAsUncloneable is not a function` when vitest starts its jsdom worker.
- jsdom 30 raised its minimum Node.js requirement to `^22.22.2 || ^24.15.0 || >=26.0.0`, but `frontend-ci.yml` still pins Node 20, which is now unsupported.
- Bumps the `Set up Node.js` step in `.github/workflows/frontend-ci.yml` from `'20'` to `'22'`, matching the Node version already used by `pebble.yml`, `e2e.yml`, and `release.yml`.

## Test plan
- [ ] `frontend-ci` workflow runs green on this branch
- [ ] Once merged, dependabot PR #717 should pass CI on rebase

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MDw5x58uQ2HrK4LZyJy2ry

---
_Generated by [Claude Code](https://claude.ai/code/session_01MDw5x58uQ2HrK4LZyJy2ry)_